### PR TITLE
feat: agent registry with types and API (#78)

### DIFF
--- a/app/api/agents/[id]/route.ts
+++ b/app/api/agents/[id]/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from "next/server"
+import { getAgent } from "@/lib/agents/registry"
+
+type RouteContext = {
+  params: Promise<{ id: string }>
+}
+
+// GET /api/agents/:id — Get agent by ID
+export async function GET(
+  _request: NextRequest,
+  context: RouteContext
+) {
+  const { id } = await context.params
+  const agent = getAgent(id)
+  
+  if (!agent) {
+    return NextResponse.json(
+      { error: "Agent not found" },
+      { status: 404 }
+    )
+  }
+
+  return NextResponse.json({ agent })
+}

--- a/app/api/agents/route.ts
+++ b/app/api/agents/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from "next/server"
+import { getAllAgents } from "@/lib/agents/registry"
+
+// GET /api/agents — List all agents
+export async function GET() {
+  const agents = getAllAgents()
+  return NextResponse.json({ agents })
+}

--- a/lib/agents/index.ts
+++ b/lib/agents/index.ts
@@ -1,0 +1,16 @@
+// Re-export everything from registry (which re-exports types)
+export {
+  getAgent,
+  getAllAgents,
+  getAgentsByRole,
+  getAgentsByCapability,
+  getAgentDisplay,
+  getAllAgentDisplays,
+} from "./registry"
+
+export type {
+  Agent,
+  AgentDisplay,
+  AgentRole,
+  AgentCapability,
+} from "./types"

--- a/lib/agents/registry.ts
+++ b/lib/agents/registry.ts
@@ -1,0 +1,104 @@
+import type { Agent, AgentDisplay, AgentRole } from "./types"
+
+/**
+ * Built-in agent definitions
+ * 
+ * These match OpenClaw agent configurations.
+ * In the future, this could move to database for runtime editing.
+ */
+const AGENTS: Agent[] = [
+  {
+    id: "ada",
+    name: "Ada",
+    role: "coordinator",
+    model: "anthropic/claude-opus-4-5",
+    color: "#a855f7", // Purple
+    capabilities: ["coordinate", "review", "escalate", "plan"],
+  },
+  {
+    id: "kimi-coder",
+    name: "Kimi",
+    role: "executor",
+    model: "moonshot/kimi-for-coding",
+    color: "#3b82f6", // Blue
+    capabilities: ["code", "test", "debug", "pr"],
+  },
+  {
+    id: "sonnet-reviewer",
+    name: "Sonnet",
+    role: "evaluator",
+    model: "anthropic/claude-sonnet-4-20250514",
+    color: "#22c55e", // Green
+    capabilities: ["review", "verify", "merge"],
+  },
+  {
+    id: "haiku-triage",
+    name: "Haiku",
+    role: "scanner",
+    model: "anthropic/claude-haiku-4-5",
+    color: "#eab308", // Yellow
+    capabilities: ["triage", "scan", "categorize"],
+  },
+]
+
+/**
+ * Get agent by ID
+ */
+export function getAgent(id: string): Agent | undefined {
+  return AGENTS.find((agent) => agent.id === id)
+}
+
+/**
+ * Get all agents
+ */
+export function getAllAgents(): Agent[] {
+  return [...AGENTS]
+}
+
+/**
+ * Get agents by role
+ */
+export function getAgentsByRole(role: AgentRole): Agent[] {
+  return AGENTS.filter((agent) => agent.role === role)
+}
+
+/**
+ * Get agents with a specific capability
+ */
+export function getAgentsByCapability(capability: string): Agent[] {
+  return AGENTS.filter((agent) => 
+    agent.capabilities.includes(capability as Agent["capabilities"][number])
+  )
+}
+
+/**
+ * Get agent display info for UI components
+ */
+export function getAgentDisplay(id: string): AgentDisplay | undefined {
+  const agent = getAgent(id)
+  if (!agent) return undefined
+  
+  return {
+    id: agent.id,
+    name: agent.name,
+    color: agent.color,
+    avatar: agent.avatar,
+    role: agent.role,
+  }
+}
+
+/**
+ * Get all agent display info
+ */
+export function getAllAgentDisplays(): AgentDisplay[] {
+  return AGENTS.map((agent) => ({
+    id: agent.id,
+    name: agent.name,
+    color: agent.color,
+    avatar: agent.avatar,
+    role: agent.role,
+  }))
+}
+
+// Re-export types for convenience
+export type { Agent, AgentDisplay, AgentRole, AgentCapability } from "./types"

--- a/lib/agents/types.ts
+++ b/lib/agents/types.ts
@@ -1,0 +1,55 @@
+/**
+ * Agent role determines what kind of work an agent handles
+ */
+export type AgentRole = "coordinator" | "executor" | "evaluator" | "scanner"
+
+/**
+ * Agent capabilities define what actions an agent can perform
+ */
+export type AgentCapability =
+  | "coordinate"  // Assign work, manage flow
+  | "review"      // Review PRs, code, output
+  | "escalate"    // Escalate to human
+  | "plan"        // Create plans, break down work
+  | "code"        // Write code
+  | "test"        // Write/run tests
+  | "debug"       // Debug issues
+  | "pr"          // Create pull requests
+  | "verify"      // Verify work is complete
+  | "merge"       // Merge pull requests
+  | "triage"      // Triage issues/tasks
+  | "scan"        // Scan for problems
+  | "categorize"  // Categorize/label items
+
+/**
+ * Agent definition
+ */
+export interface Agent {
+  /** Unique agent identifier (matches OpenClaw agent config) */
+  id: string
+  /** Display name */
+  name: string
+  /** Agent role type */
+  role: AgentRole
+  /** Model identifier (provider/model format) */
+  model: string
+  /** Color for UI badges (hex) */
+  color: string
+  /** Optional avatar URL */
+  avatar?: string
+  /** What this agent can do */
+  capabilities: AgentCapability[]
+  /** Optional system prompt or reference to SOUL file */
+  systemPrompt?: string
+}
+
+/**
+ * Agent display info for UI components
+ */
+export interface AgentDisplay {
+  id: string
+  name: string
+  color: string
+  avatar?: string
+  role: AgentRole
+}


### PR DESCRIPTION
## Summary
Agent registry with 4 initial agents and lookup functions.

## Changes
- Add `lib/agents/types.ts` with Agent, AgentRole, AgentCapability types
- Add `lib/agents/registry.ts` with 4 agents: ada, kimi-coder, sonnet-reviewer, haiku-triage
- Registry functions: getAgent, getAllAgents, getAgentsByRole, getAgentsByCapability, getAgentDisplay
- GET /api/agents - list all agents
- GET /api/agents/:id - get single agent

## Testing
```bash
curl http://192.168.7.200:3002/api/agents  # Returns 4 agents
curl http://192.168.7.200:3002/api/agents/ada  # Returns ada
```

Closes #78