### PR TITLE
feat: smart gate script for Ada (#81)

### DIFF
--- a/app/api/gate/route.ts
+++ b/app/api/gate/route.ts
@@ -1,0 +1,157 @@
+import { NextResponse } from "next/server"
+import { db } from "@/lib/db"
+
+interface GateStatus {
+  needsAttention: boolean
+  reason: string | null
+  details: {
+    readyTasks: number
+    pendingInputs: number
+    stuckTasks: number
+    reviewTasks: number
+    pendingDispatch: number
+    unreadEscalations: number
+  }
+  tasks?: {
+    ready: Array<{ id: string; title: string; priority: string }>
+    pendingInput: Array<{ taskId: string; taskTitle: string; author: string; content: string }>
+    stuck: Array<{ id: string; title: string; assignee: string; hours: number }>
+    review: Array<{ id: string; title: string; assignee: string }>
+    pendingDispatch: Array<{ id: string; title: string; assignee: string }>
+  }
+  escalations?: Array<{ id: string; severity: string; message: string; agent: string }>
+  timestamp: number
+}
+
+// GET /api/gate — Check if coordinator should wake
+export async function GET() {
+  const now = Date.now()
+  const twoHoursAgo = now - (2 * 60 * 60 * 1000)
+  
+  // Get counts for all conditions
+  const counts = db.prepare(`
+    SELECT 
+      (SELECT COUNT(*) FROM tasks WHERE status = 'ready' AND assignee IS NULL) as ready_tasks,
+      (SELECT COUNT(*) FROM comments WHERE type = 'request_input' AND responded_at IS NULL) as pending_inputs,
+      (SELECT COUNT(*) FROM tasks WHERE status = 'in_progress' AND updated_at < ?) as stuck_tasks,
+      (SELECT COUNT(*) FROM tasks WHERE status = 'review') as review_tasks,
+      (SELECT COUNT(*) FROM tasks WHERE dispatch_status = 'pending') as pending_dispatch,
+      (SELECT COUNT(*) FROM notifications WHERE type = 'escalation' AND read = 0) as unread_escalations
+  `).get(twoHoursAgo) as {
+    ready_tasks: number
+    pending_inputs: number
+    stuck_tasks: number
+    review_tasks: number
+    pending_dispatch: number
+    unread_escalations: number
+  }
+  
+  // Build detailed response
+  const status: GateStatus = {
+    needsAttention: false,
+    reason: null,
+    details: {
+      readyTasks: counts.ready_tasks,
+      pendingInputs: counts.pending_inputs,
+      stuckTasks: counts.stuck_tasks,
+      reviewTasks: counts.review_tasks,
+      pendingDispatch: counts.pending_dispatch,
+      unreadEscalations: counts.unread_escalations,
+    },
+    timestamp: now,
+  }
+  
+  // Build reasons list (priority order)
+  const reasons: string[] = []
+  
+  if (counts.unread_escalations > 0) {
+    reasons.push(`${counts.unread_escalations} unread escalation(s)`)
+  }
+  if (counts.pending_inputs > 0) {
+    reasons.push(`${counts.pending_inputs} pending input request(s)`)
+  }
+  if (counts.pending_dispatch > 0) {
+    reasons.push(`${counts.pending_dispatch} task(s) pending dispatch`)
+  }
+  if (counts.ready_tasks > 0) {
+    reasons.push(`${counts.ready_tasks} task(s) ready for assignment`)
+  }
+  if (counts.stuck_tasks > 0) {
+    reasons.push(`${counts.stuck_tasks} task(s) stuck > 2 hours`)
+  }
+  if (counts.review_tasks > 0) {
+    reasons.push(`${counts.review_tasks} task(s) ready for review`)
+  }
+  
+  if (reasons.length > 0) {
+    status.needsAttention = true
+    status.reason = reasons.join("; ")
+    
+    // Fetch task details
+    const tasks: NonNullable<GateStatus["tasks"]> = {
+      ready: db.prepare(`
+        SELECT id, title, priority FROM tasks 
+        WHERE status = 'ready' AND assignee IS NULL
+        ORDER BY 
+          CASE priority WHEN 'urgent' THEN 1 WHEN 'high' THEN 2 WHEN 'medium' THEN 3 ELSE 4 END
+        LIMIT 10
+      `).all() as Array<{ id: string; title: string; priority: string }>,
+      
+      pendingInput: db.prepare(`
+        SELECT c.task_id as taskId, t.title as taskTitle, c.author, c.content
+        FROM comments c
+        JOIN tasks t ON c.task_id = t.id
+        WHERE c.type = 'request_input' AND c.responded_at IS NULL
+        ORDER BY c.created_at
+        LIMIT 10
+      `).all() as Array<{ taskId: string; taskTitle: string; author: string; content: string }>,
+      
+      stuck: db.prepare(`
+        SELECT id, title, assignee, 
+          CAST((? - updated_at) / 3600000.0 AS INT) as hours
+        FROM tasks 
+        WHERE status = 'in_progress' AND updated_at < ?
+        ORDER BY updated_at
+        LIMIT 10
+      `).all(now, twoHoursAgo) as Array<{ id: string; title: string; assignee: string; hours: number }>,
+      
+      review: db.prepare(`
+        SELECT id, title, assignee FROM tasks 
+        WHERE status = 'review'
+        ORDER BY updated_at DESC
+        LIMIT 10
+      `).all() as Array<{ id: string; title: string; assignee: string }>,
+      
+      pendingDispatch: db.prepare(`
+        SELECT id, title, assignee FROM tasks 
+        WHERE dispatch_status = 'pending'
+        ORDER BY dispatch_requested_at
+        LIMIT 10
+      `).all() as Array<{ id: string; title: string; assignee: string }>,
+    }
+    
+    status.tasks = tasks
+    
+    // Fetch escalations
+    if (counts.unread_escalations > 0) {
+      status.escalations = db.prepare(`
+        SELECT id, severity, message, agent FROM notifications
+        WHERE type = 'escalation' AND read = 0
+        ORDER BY 
+          CASE severity WHEN 'critical' THEN 1 WHEN 'warning' THEN 2 ELSE 3 END,
+          created_at DESC
+        LIMIT 10
+      `).all() as GateStatus["escalations"]
+    }
+  }
+  
+  // Log check (could be persisted to DB)
+  console.log(
+    `[gate_check] needsAttention=${status.needsAttention} ` +
+    `ready=${counts.ready_tasks} pending=${counts.pending_inputs} ` +
+    `dispatch=${counts.pending_dispatch} stuck=${counts.stuck_tasks} ` +
+    `review=${counts.review_tasks} escalations=${counts.unread_escalations}`
+  )
+  
+  return NextResponse.json(status)
+}

--- a/bin/trap-gate.sh
+++ b/bin/trap-gate.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# trap-gate.sh — Gate script for OpenClaw cron
+#
+# Returns 0 (wake) if coordinator should process work
+# Returns 1 (sleep) if nothing needs attention
+#
+# Usage: TRAP_URL=http://localhost:3002 ./trap-gate.sh
+
+set -e
+
+TRAP_URL="${TRAP_URL:-http://localhost:3002}"
+
+# Fetch gate status
+response=$(curl -s --max-time 5 "$TRAP_URL/api/gate" 2>/dev/null || echo '{"needsAttention":false,"error":"failed to connect"}')
+
+# Check for errors
+if echo "$response" | jq -e '.error' > /dev/null 2>&1; then
+  echo "Error: $(echo "$response" | jq -r '.error')" >&2
+  exit 1
+fi
+
+# Parse response
+needs_attention=$(echo "$response" | jq -r '.needsAttention')
+
+if [ "$needs_attention" = "true" ]; then
+  # Output reason for the cron logs
+  reason=$(echo "$response" | jq -r '.reason // "needs attention"')
+  echo "$reason"
+  exit 0  # Wake up
+else
+  exit 1  # Stay asleep
+fi


### PR DESCRIPTION
## Summary
Smart gate script that only wakes coordinator when there's work to do.

## Changes
- `GET /api/gate` - Returns gate status with counts and details
- `bin/trap-gate.sh` - Exit 0 (wake) or 1 (sleep)

## Wake Conditions (in priority order)
| Condition | Priority |
|-----------|----------|
| Unread escalations | Critical |
| Pending input requests | High |
| Tasks pending dispatch | High |
| Tasks ready (no assignee) | High |
| Tasks stuck > 2 hours | Medium |
| Tasks ready for review | Medium |

## Gate Response
```json
{
  "needsAttention": true,
  "reason": "2 tasks ready; 1 pending input",
  "details": { ...counts... },
  "tasks": { ready: [...], pendingInput: [...], ... },
  "escalations": [...]
}
```

## Usage
```bash
# In cron job or manually
TRAP_URL=http://localhost:3002 ./bin/trap-gate.sh
# Exit 0 = wake, Exit 1 = sleep
```

Closes #81