### PR TITLE
feat: add Agents tab to sidebar navigation

### DIFF
--- a/app/agents/page.tsx
+++ b/app/agents/page.tsx
@@ -1,0 +1,175 @@
+'use client';
+
+/**
+ * Agents Page
+ * Manage and monitor AI agents
+ */
+
+import { Bot, Plus, Activity, Zap, Clock } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+
+type AgentStatus = 'active' | 'idle' | 'offline';
+
+interface Agent {
+  id: string;
+  name: string;
+  status: AgentStatus;
+  type: string;
+  uptime: string;
+  tasks: number;
+}
+
+// Placeholder data - will be replaced with real data later
+const PLACEHOLDER_AGENTS: Agent[] = [
+  {
+    id: '1',
+    name: 'Ada',
+    status: 'active',
+    type: 'General Assistant',
+    uptime: '24h 15m',
+    tasks: 142,
+  },
+  {
+    id: '2', 
+    name: 'Kimi',
+    status: 'active',
+    type: 'Coding Agent',
+    uptime: '12h 30m',
+    tasks: 89,
+  },
+  {
+    id: '3',
+    name: 'Researcher Bot',
+    status: 'idle',
+    type: 'Research Assistant',
+    uptime: '2h 45m',
+    tasks: 23,
+  },
+];
+
+function AgentCard({ agent }: { agent: Agent }) {
+  const statusColors = {
+    active: 'bg-green-500',
+    idle: 'bg-yellow-500',
+    offline: 'bg-red-500',
+  };
+
+  const statusVariants = {
+    active: 'default' as const,
+    idle: 'secondary' as const,
+    offline: 'destructive' as const,
+  };
+
+  return (
+    <div className="rounded-lg border bg-card p-6">
+      <div className="flex items-start justify-between mb-4">
+        <div className="flex items-center gap-3">
+          <div className="p-2 rounded-lg bg-muted">
+            <Bot className="h-5 w-5" />
+          </div>
+          <div>
+            <h3 className="font-semibold">{agent.name}</h3>
+            <p className="text-sm text-muted-foreground">{agent.type}</p>
+          </div>
+        </div>
+        <Badge variant={statusVariants[agent.status]}>
+          <span 
+            className={`w-2 h-2 rounded-full ${statusColors[agent.status]} mr-2`}
+          />
+          {agent.status}
+        </Badge>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4 text-sm">
+        <div className="flex items-center gap-2 text-muted-foreground">
+          <Clock className="h-4 w-4" />
+          <span>Uptime: {agent.uptime}</span>
+        </div>
+        <div className="flex items-center gap-2 text-muted-foreground">
+          <Zap className="h-4 w-4" />
+          <span>Tasks: {agent.tasks}</span>
+        </div>
+      </div>
+
+      <div className="mt-4 pt-4 border-t flex gap-2">
+        <Button variant="outline" size="sm" className="flex-1">
+          Configure
+        </Button>
+        <Button variant="outline" size="sm" className="flex-1">
+          View Logs
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export default function AgentsPage() {
+  return (
+    <div className="container mx-auto py-8 px-4">
+      {/* Header */}
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-8">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight flex items-center gap-2">
+            <Bot className="h-8 w-8" />
+            Agents
+          </h1>
+          <p className="text-muted-foreground mt-1">
+            Manage and monitor your AI agents
+          </p>
+        </div>
+        
+        <div className="flex items-center gap-3">
+          <Button>
+            <Plus className="h-4 w-4 mr-2" />
+            Add Agent
+          </Button>
+        </div>
+      </div>
+
+      {/* Stats */}
+      <div className="grid grid-cols-1 sm:grid-cols-4 gap-4 mb-8">
+        <div className="rounded-lg border bg-card p-4">
+          <div className="text-sm font-medium text-muted-foreground">Total Agents</div>
+          <div className="text-2xl font-bold mt-1">{PLACEHOLDER_AGENTS.length}</div>
+        </div>
+        
+        <div className="rounded-lg border bg-card p-4">
+          <div className="text-sm font-medium text-muted-foreground">Active</div>
+          <div className="text-2xl font-bold mt-1 text-green-600">
+            {PLACEHOLDER_AGENTS.filter(a => a.status === 'active').length}
+          </div>
+        </div>
+        
+        <div className="rounded-lg border bg-card p-4">
+          <div className="text-sm font-medium text-muted-foreground">Idle</div>
+          <div className="text-2xl font-bold mt-1 text-yellow-600">
+            {PLACEHOLDER_AGENTS.filter(a => a.status === 'idle').length}
+          </div>
+        </div>
+
+        <div className="rounded-lg border bg-card p-4">
+          <div className="text-sm font-medium text-muted-foreground">Total Tasks</div>
+          <div className="text-2xl font-bold mt-1">
+            {PLACEHOLDER_AGENTS.reduce((acc, agent) => acc + agent.tasks, 0)}
+          </div>
+        </div>
+      </div>
+
+      {/* Agents Grid */}
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        {PLACEHOLDER_AGENTS.map((agent) => (
+          <AgentCard key={agent.id} agent={agent} />
+        ))}
+      </div>
+
+      {/* Footer info */}
+      <div className="mt-8 text-center">
+        <div className="text-sm text-muted-foreground">
+          <Activity className="h-4 w-4 inline mr-1" />
+          Real-time agent monitoring coming soon
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { Providers } from "@/components/providers";
+import { MainLayout } from "@/components/layout/main-layout";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -29,7 +30,9 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         <Providers>
-          {children}
+          <MainLayout>
+            {children}
+          </MainLayout>
         </Providers>
       </body>
     </html>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,8 +1,6 @@
 "use client"
 
 import { useEffect } from "react"
-import Link from "next/link"
-import { Activity } from "lucide-react"
 import { useProjectStore } from "@/lib/stores/project-store"
 import { ProjectCard } from "@/components/projects/project-card"
 import { CreateProjectModal } from "@/components/projects/create-project-modal"
@@ -16,29 +14,21 @@ export default function Home() {
   }, [fetchProjects])
 
   return (
-    <div className="min-h-screen bg-[var(--bg-primary)]">
-      <main className="container mx-auto py-12 px-4 max-w-6xl">
-        {/* Header */}
-        <div className="flex items-center justify-between mb-8">
-          <div>
-            <h1 className="text-3xl font-bold text-[var(--text-primary)]">
-              🦞 The Trap
-            </h1>
-            <p className="text-[var(--text-secondary)] mt-1">
-              AI agent orchestration dashboard
-            </p>
-          </div>
-          <div className="flex items-center gap-3">
-            <Link 
-              href="/sessions"
-              className="flex items-center gap-2 px-3 py-2 text-sm text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors"
-            >
-              <Activity className="h-4 w-4" />
-              Sessions
-            </Link>
-            <CreateProjectModal />
-          </div>
+    <div className="container mx-auto py-12 px-4 max-w-6xl">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-8">
+        <div>
+          <h1 className="text-3xl font-bold text-[var(--text-primary)]">
+            Projects
+          </h1>
+          <p className="text-[var(--text-secondary)] mt-1">
+            Organize and manage your AI agent workflows
+          </p>
         </div>
+        <div className="flex items-center gap-3">
+          <CreateProjectModal />
+        </div>
+      </div>
 
         {/* Error state */}
         {error && (
@@ -77,15 +67,14 @@ export default function Home() {
           </div>
         )}
 
-        {/* Project grid */}
-        {projects.length > 0 && (
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-            {projects.map((project) => (
-              <ProjectCard key={project.id} project={project} />
-            ))}
-          </div>
-        )}
-      </main>
+      {/* Project grid */}
+      {projects.length > 0 && (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {projects.map((project) => (
+            <ProjectCard key={project.id} project={project} />
+          ))}
+        </div>
+      )}
     </div>
   )
 }

--- a/components/layout/main-layout.tsx
+++ b/components/layout/main-layout.tsx
@@ -1,0 +1,26 @@
+"use client"
+
+import { usePathname } from "next/navigation"
+import { Sidebar } from "./sidebar"
+
+interface MainLayoutProps {
+  children: React.ReactNode
+}
+
+export function MainLayout({ children }: MainLayoutProps) {
+  const pathname = usePathname()
+
+  // Don't apply main layout on project pages (they have their own layout)
+  if (pathname.startsWith('/projects/')) {
+    return <>{children}</>
+  }
+
+  return (
+    <div className="min-h-screen bg-[var(--bg-primary)]">
+      <Sidebar />
+      <main className="ml-64">
+        {children}
+      </main>
+    </div>
+  )
+}

--- a/components/layout/sidebar.tsx
+++ b/components/layout/sidebar.tsx
@@ -1,0 +1,77 @@
+"use client"
+
+import Link from "next/link"
+import { usePathname } from "next/navigation"
+import { Home, Activity, Bot, Settings } from "lucide-react"
+import { cn } from "@/lib/utils"
+
+const NAVIGATION_ITEMS = [
+  { id: "home", label: "Home", icon: Home, href: "/" },
+  { id: "sessions", label: "Sessions", icon: Activity, href: "/sessions" },
+  { id: "agents", label: "Agents", icon: Bot, href: "/agents" },
+  { id: "settings", label: "Settings", icon: Settings, href: "/settings" },
+]
+
+export function Sidebar() {
+  const pathname = usePathname()
+
+  // Don't show sidebar on project pages (they have their own navigation)
+  if (pathname.startsWith('/projects/')) {
+    return null
+  }
+
+  const getActiveId = () => {
+    if (pathname === "/") return "home"
+    if (pathname.startsWith("/sessions")) return "sessions"
+    if (pathname.startsWith("/agents")) return "agents"
+    if (pathname.startsWith("/settings")) return "settings"
+    return "home"
+  }
+  const activeId = getActiveId()
+
+  return (
+    <div className="fixed left-0 top-0 z-40 h-screen w-64 bg-[var(--bg-secondary)] border-r border-[var(--border)]">
+      {/* Header */}
+      <div className="p-6 border-b border-[var(--border)]">
+        <Link href="/" className="flex items-center gap-3">
+          <div className="text-2xl">🦞</div>
+          <div>
+            <h1 className="text-lg font-bold text-[var(--text-primary)]">
+              The Trap
+            </h1>
+            <p className="text-xs text-[var(--text-secondary)]">
+              AI Agent Dashboard
+            </p>
+          </div>
+        </Link>
+      </div>
+
+      {/* Navigation */}
+      <nav className="p-4">
+        <ul className="space-y-1">
+          {NAVIGATION_ITEMS.map((item) => {
+            const Icon = item.icon
+            const isActive = activeId === item.id
+            
+            return (
+              <li key={item.id}>
+                <Link
+                  href={item.href}
+                  className={cn(
+                    "flex items-center gap-3 px-3 py-2 text-sm font-medium rounded-lg transition-colors",
+                    isActive
+                      ? "bg-[var(--accent)] text-[var(--accent-foreground)]"
+                      : "text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-tertiary)]"
+                  )}
+                >
+                  <Icon className="h-4 w-4" />
+                  {item.label}
+                </Link>
+              </li>
+            )
+          })}
+        </ul>
+      </nav>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
Add a new 'Agents' tab to the main sidebar navigation, positioned between Sessions and Settings.

## Changes
- **New global sidebar navigation** with Home, Sessions, Agents, Settings
- **Created placeholder /agents page** with mock data showing agent status dashboard
- **Implemented MainLayout wrapper** to handle sidebar on non-project pages (projects keep their existing tab navigation)
- **Updated root layout** to integrate sidebar navigation
- **Agents page features:**
  - Agent status cards (Active, Idle, Offline)
  - Statistics dashboard (Total Agents, Active count, Total Tasks)
  - Placeholder agent management interface
  - Responsive grid layout

## Technical Details
- Uses lucide-react Bot icon for Agents
- Follows existing design patterns and CSS variables
- TypeScript properly typed with Agent interface
- Sidebar excludes itself on project pages to maintain existing UX
- Hot-reload friendly with proper component structure

## Testing
- ✅ Build passes (npm run build)
- ✅ Dev server runs correctly
- ✅ Pages render at localhost:3002/agents and localhost:3002/
- ✅ Sidebar navigation works between pages
- ✅ Project pages maintain their existing tab navigation

Resolves trap ticket: `a601ab47-e1be-4491-b2d4-01246b3740c7`