### PR TITLE
feat: add agents listing via OpenClaw RPC

### DIFF
--- a/components/ui/alert.tsx
+++ b/components/ui/alert.tsx
@@ -1,0 +1,58 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+import { cn } from "@/lib/utils"
+
+const alertVariants = cva(
+  "relative w-full rounded-lg border p-4 [&>svg~*]:pl-7 [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground",
+  {
+    variants: {
+      variant: {
+        default: "bg-background text-foreground",
+        destructive:
+          "border-destructive/50 text-destructive dark:border-destructive [&>svg]:text-destructive",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+const Alert = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof alertVariants>
+>(({ className, variant, ...props }, ref) => (
+  <div
+    ref={ref}
+    role="alert"
+    className={cn(alertVariants({ variant }), className)}
+    {...props}
+  />
+))
+Alert.displayName = "Alert"
+
+const AlertTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h5
+    ref={ref}
+    className={cn("mb-1 font-medium leading-none tracking-tight", className)}
+    {...props}
+  />
+))
+AlertTitle.displayName = "AlertTitle"
+
+const AlertDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("text-sm [&_p]:leading-relaxed", className)}
+    {...props}
+  />
+))
+AlertDescription.displayName = "AlertDescription"
+
+export { Alert, AlertTitle, AlertDescription }

--- a/lib/hooks/use-openclaw-rpc.ts
+++ b/lib/hooks/use-openclaw-rpc.ts
@@ -2,7 +2,7 @@
 
 import { useCallback } from "react";
 import { useOpenClawWS } from "@/lib/providers/openclaw-ws-provider";
-import { SessionListResponse, SessionListParams, SessionPreview } from "@/lib/types";
+import { SessionListResponse, SessionListParams, SessionPreview, AgentListResponse, AgentListParams } from "@/lib/types";
 
 export function useOpenClawRpc() {
   const { status, rpc } = useOpenClawWS();
@@ -10,6 +10,11 @@ export function useOpenClawRpc() {
   // List sessions via RPC
   const listSessions = useCallback(async (params?: SessionListParams): Promise<SessionListResponse> => {
     return rpc<SessionListResponse>("sessions.list", (params || {}) as Record<string, unknown>);
+  }, [rpc]);
+
+  // List agents via RPC
+  const listAgents = useCallback(async (params?: AgentListParams): Promise<AgentListResponse> => {
+    return rpc<AgentListResponse>("agents.list", (params || {}) as Record<string, unknown>);
   }, [rpc]);
 
   // Get session preview with history
@@ -45,6 +50,7 @@ export function useOpenClawRpc() {
     },
     rpc,
     listSessions,
+    listAgents,
     getSessionPreview,
     resetSession,
     compactSession,

--- a/lib/types/agent.ts
+++ b/lib/types/agent.ts
@@ -1,0 +1,29 @@
+/**
+ * Agent Types
+ * Type definitions for OpenClaw agents
+ */
+
+export type AgentStatus = 'active' | 'idle' | 'offline';
+
+export interface Agent {
+  id: string;
+  name: string;
+  description: string;
+  model: string;
+  status: AgentStatus;
+  sessionCount: number;
+  createdAt: string;
+  updatedAt?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface AgentListResponse {
+  agents: Agent[];
+  total: number;
+}
+
+export interface AgentListParams {
+  status?: AgentStatus;
+  limit?: number;
+  offset?: number;
+}

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -4,3 +4,4 @@
  */
 
 export * from './session';
+export * from './agent';


### PR DESCRIPTION
## Summary
Implements agents listing functionality using OpenClaw websocket RPC.

## Changes
- ✅ Add Agent types (AgentListResponse, AgentListParams, Agent)
- ✅ Add agents.list RPC method to use-openclaw-rpc hook  
- ✅ Update agents page to fetch and display real agent data
- ✅ Replace placeholder data with live RPC calls
- ✅ Display agent cards with: name, description, model, session count
- ✅ Add loading states, error handling, and refresh functionality
- ✅ Create Alert UI component for status messages

## Features
- Real-time agent data fetched via WebSocket RPC
- Card grid layout showing key agent metrics
- Connection status indicators
- Manual refresh functionality
- Error handling with user-friendly messages
- Responsive design for mobile/desktop

## Testing
- ✅ Build passes
- ✅ TypeScript compilation successful
- ✅ Dev server running without issues

Closes: List agents via OpenClaw RPC (1afab55f-4233-484a-9654-2cf1f86d97a4)