### PR TITLE
Add memory browser and editor for agents

### DIFF
--- a/components/editors/file-tree.tsx
+++ b/components/editors/file-tree.tsx
@@ -1,0 +1,171 @@
+'use client';
+
+/**
+ * File Tree Component
+ * Display a tree of files with selection capability
+ */
+
+import React from 'react';
+import { FileText, Folder, Plus } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+export interface FileTreeItem {
+  name: string;
+  path: string;
+  isDirectory: boolean;
+}
+
+export interface FileTreeProps {
+  files: FileTreeItem[];
+  selectedFile?: string;
+  onFileSelect: (filePath: string) => void;
+  onCreateFile?: (fileName: string) => void;
+  className?: string;
+  loading?: boolean;
+}
+
+export function FileTree({
+  files,
+  selectedFile,
+  onFileSelect,
+  onCreateFile,
+  className = '',
+  loading = false,
+}: FileTreeProps) {
+  const [newFileName, setNewFileName] = React.useState('');
+  const [isCreating, setIsCreating] = React.useState(false);
+
+  const handleCreateFile = () => {
+    if (newFileName.trim() && onCreateFile) {
+      const fileName = newFileName.trim();
+      // Ensure .md extension
+      const finalName = fileName.endsWith('.md') ? fileName : `${fileName}.md`;
+      // For memory files, prefix with memory/ if it's not MEMORY.md
+      const filePath = finalName === 'MEMORY.md' ? finalName : `memory/${finalName}`;
+      onCreateFile(filePath);
+      setNewFileName('');
+      setIsCreating(false);
+    }
+  };
+
+  const handleCancelCreate = () => {
+    setNewFileName('');
+    setIsCreating(false);
+  };
+
+  if (loading) {
+    return (
+      <div className={`p-4 ${className}`}>
+        <div className="animate-pulse">
+          <div className="h-4 bg-muted rounded w-3/4 mb-2"></div>
+          <div className="h-4 bg-muted rounded w-1/2 mb-2"></div>
+          <div className="h-4 bg-muted rounded w-2/3"></div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={`space-y-1 ${className}`}>
+      {/* File list */}
+      <div className="space-y-1">
+        {files.map((file) => (
+          <button
+            key={file.path}
+            onClick={() => onFileSelect(file.path)}
+            className={`w-full flex items-center gap-2 px-2 py-1.5 text-left text-sm rounded-md transition-colors ${
+              selectedFile === file.path
+                ? 'bg-primary text-primary-foreground'
+                : 'hover:bg-muted'
+            }`}
+          >
+            {file.isDirectory ? (
+              <Folder className="h-4 w-4 text-muted-foreground" />
+            ) : (
+              <FileText className="h-4 w-4 text-muted-foreground" />
+            )}
+            <span className="truncate">{file.name}</span>
+          </button>
+        ))}
+      </div>
+
+      {/* Create new file section */}
+      {onCreateFile && (
+        <div className="border-t pt-2 mt-2">
+          {isCreating ? (
+            <div className="space-y-2">
+              <div className="flex items-center gap-2">
+                <input
+                  type="text"
+                  value={newFileName}
+                  onChange={(e) => setNewFileName(e.target.value)}
+                  placeholder="filename.md"
+                  className="flex-1 px-2 py-1 text-xs border rounded focus:outline-none focus:ring-1 focus:ring-primary"
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') {
+                      e.preventDefault();
+                      handleCreateFile();
+                    } else if (e.key === 'Escape') {
+                      handleCancelCreate();
+                    }
+                  }}
+                  autoFocus
+                />
+              </div>
+              <div className="flex items-center gap-1">
+                <Button
+                  size="sm"
+                  variant="default"
+                  onClick={handleCreateFile}
+                  disabled={!newFileName.trim()}
+                  className="h-6 text-xs"
+                >
+                  Create
+                </Button>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={handleCancelCreate}
+                  className="h-6 text-xs"
+                >
+                  Cancel
+                </Button>
+              </div>
+            </div>
+          ) : (
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={() => setIsCreating(true)}
+              className="w-full justify-start h-7 text-xs text-muted-foreground"
+            >
+              <Plus className="h-3 w-3 mr-1" />
+              New memory file
+            </Button>
+          )}
+        </div>
+      )}
+
+      {/* Empty state */}
+      {files.length === 0 && !isCreating && (
+        <div className="text-center py-8 text-muted-foreground">
+          <FileText className="h-8 w-8 mx-auto mb-2 opacity-50" />
+          <p className="text-sm">No memory files found</p>
+          {onCreateFile && (
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={() => setIsCreating(true)}
+              className="mt-2 text-xs"
+            >
+              <Plus className="h-3 w-3 mr-1" />
+              Create first memory file
+            </Button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default FileTree;

--- a/lib/hooks/use-openclaw-rpc.ts
+++ b/lib/hooks/use-openclaw-rpc.ts
@@ -44,12 +44,27 @@ export function useOpenClawRpc() {
 
   // Get agent's soul file content
   const getAgentSoul = useCallback(async (agentId: string) => {
-    return rpc<{ content: string; exists: boolean }>("agents.getSoul", { id: agentId });
+    return rpc<{ content: string; exists: boolean }>("agent.soul.get", { id: agentId });
   }, [rpc]);
 
   // Update agent's soul file content
   const updateAgentSoul = useCallback(async (agentId: string, content: string) => {
-    return rpc<void>("agents.updateSoul", { id: agentId, content });
+    return rpc<void>("agent.soul.update", { id: agentId, content });
+  }, [rpc]);
+
+  // Get agent's memory files list
+  const getAgentMemoryFiles = useCallback(async (agentId: string) => {
+    return rpc<{ files: Array<{ name: string; path: string; isDirectory: boolean }> }>("agent.memory.list", { id: agentId });
+  }, [rpc]);
+
+  // Get agent's memory file content
+  const getAgentMemoryFile = useCallback(async (agentId: string, filePath: string) => {
+    return rpc<{ content: string; exists: boolean }>("agent.memory.get", { id: agentId, path: filePath });
+  }, [rpc]);
+
+  // Update agent's memory file content
+  const updateAgentMemoryFile = useCallback(async (agentId: string, filePath: string, content: string) => {
+    return rpc<void>("agent.memory.update", { id: agentId, path: filePath, content });
   }, [rpc]);
 
   return {
@@ -73,6 +88,9 @@ export function useOpenClawRpc() {
     cancelSession,
     getAgentSoul,
     updateAgentSoul,
+    getAgentMemoryFiles,
+    getAgentMemoryFile,
+    updateAgentMemoryFile,
   };
 }
 


### PR DESCRIPTION
Implements memory browser and editor functionality for agents as specified in ticket 03e6ddb7-1081-440e-89ec-0365b66aa7ae.

## Features Added

### Backend (OpenClaw RPC Methods)
- `agent.memory.list` - List memory files for an agent
- `agent.memory.get` - Get content of a specific memory file  
- `agent.memory.update` - Update content of a memory file
- `agent.soul.get` - Get agent soul content (fixed method name)
- `agent.soul.update` - Update agent soul content (fixed method name)
- Added proper authorization for new RPC endpoints

### Frontend Components
- **Memory tab** on agent detail page with file tree and editor
- **FileTree component** for browsing memory files with creation support
- **Markdown editor integration** for editing memory files
- **File management** - create new memory files, select files, save changes

### File Support
- `MEMORY.md` - Main agent memory file
- `memory/*.md` - Topic-specific memory files
- Auto-creation of memory directory structure
- Path validation for security

### UI/UX Features
- File count badge on memory tab when files exist
- Loading states for file operations
- Empty states with helpful create buttons
- Error handling with user-friendly toasts
- Read-only mode when not connected to OpenClaw

## Testing
- ✅ TypeScript compilation passes
- ✅ Dev server running on port 3002
- ✅ Hot reload working for file changes

Addresses ticket: 03e6ddb7-1081-440e-89ec-0365b66aa7ae