### PR TITLE
Mobile responsive: Tables and lists

### DIFF
--- a/components/ui/responsive-table.tsx
+++ b/components/ui/responsive-table.tsx
@@ -1,0 +1,133 @@
+'use client';
+
+/**
+ * Responsive Table Component
+ * A wrapper that automatically switches between table and card view based on screen size
+ */
+
+import React from 'react';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { cn } from '@/lib/utils';
+
+interface ResponsiveTableProps<T> {
+  data: T[];
+  columns: {
+    key: string;
+    header: string;
+    cell: (item: T) => React.ReactNode;
+    sortable?: boolean;
+    mobileVisible?: boolean; // Whether this column should be visible in mobile card view
+  }[];
+  onRowClick?: (item: T) => void;
+  className?: string;
+  cardClassName?: string;
+  tableClassName?: string;
+  renderMobileCard?: (item: T, onRowClick?: (item: T) => void) => React.ReactNode;
+}
+
+export function ResponsiveTable<T extends { id: string }>({
+  data,
+  columns,
+  onRowClick,
+  className,
+  cardClassName,
+  tableClassName,
+  renderMobileCard,
+}: ResponsiveTableProps<T>) {
+  // Default mobile card renderer
+  const defaultMobileCard = (item: T) => {
+    const primaryColumns = columns.filter(col => col.mobileVisible !== false).slice(0, 3);
+    const secondaryColumns = columns.filter(col => col.mobileVisible === false);
+
+    return (
+      <Card 
+        className={cn("cursor-pointer hover:shadow-md transition-shadow", cardClassName)}
+        onClick={() => onRowClick?.(item)}
+      >
+        <CardHeader className="pb-2">
+          <div className="space-y-2">
+            {primaryColumns.map((column, index) => (
+              <div 
+                key={column.key}
+                className={index === 0 ? "font-medium" : "text-sm text-muted-foreground"}
+              >
+                {column.cell(item)}
+              </div>
+            ))}
+          </div>
+        </CardHeader>
+        
+        {secondaryColumns.length > 0 && (
+          <CardContent className="pt-0">
+            <div className="space-y-1 text-sm">
+              {secondaryColumns.map((column) => (
+                <div key={column.key} className="flex justify-between">
+                  <span className="text-muted-foreground">{column.header}:</span>
+                  <span className="text-right">{column.cell(item)}</span>
+                </div>
+              ))}
+            </div>
+          </CardContent>
+        )}
+      </Card>
+    );
+  };
+
+  const mobileCardRenderer = renderMobileCard || defaultMobileCard;
+
+  return (
+    <div className={cn("responsive-table", className)}>
+      {/* Desktop Table View */}
+      <div className={cn("hidden md:block rounded-md border", tableClassName)}>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              {columns.map((column) => (
+                <TableHead key={column.key}>
+                  {column.header}
+                </TableHead>
+              ))}
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {data.map((item) => (
+              <TableRow
+                key={item.id}
+                className={cn(
+                  "cursor-pointer hover:bg-muted/50",
+                  onRowClick && "cursor-pointer"
+                )}
+                onClick={() => onRowClick?.(item)}
+              >
+                {columns.map((column) => (
+                  <TableCell key={column.key}>
+                    {column.cell(item)}
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+
+      {/* Mobile Card View */}
+      <div className="md:hidden space-y-3">
+        {data.map((item) => (
+          <div key={item.id}>
+            {mobileCardRenderer(item, onRowClick)}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default ResponsiveTable;


### PR DESCRIPTION
## Summary

This PR implements mobile-responsive design for the session table, addressing the ticket requirements for mobile usability improvements.

## Changes Made

### 📱 Mobile Card View
- **Session table now switches to card layout on mobile** (< 768px breakpoint)
- **Key information prominently displayed**: session name, status badge, last active time, duration
- **Expandable details section**: tap chevron to show model, tokens, and session ID
- **Maintains click-to-navigate functionality**

### 🖥️ Desktop Experience Preserved
- **Original table layout unchanged** on desktop and tablet (≥ 768px)
- **All existing sorting functionality preserved**
- **Same data and interactions as before**

### 🔧 Technical Implementation
- **Responsive breakpoints using Tailwind  classes** 
- **Shared `ResponsiveTable` component created** for future use
- **Card components using existing UI library** (Card, CardHeader, CardContent)
- **Expandable state management with chevron icons**
- **Proper loading and error states for both layouts**

## Design Pattern Applied



## Testing

- ✅ **Build passes**: 
> trap-6@0.1.0 build
> next build

▲ Next.js 16.1.6 (Turbopack)
- Environments: .env.local

  Creating an optimized production build ...
✓ Compiled successfully in 3.4s
  Running TypeScript ...
  Collecting page data using 23 workers ...
  Generating static pages using 23 workers (0/17) ...
  Generating static pages using 23 workers (4/17) 
  Generating static pages using 23 workers (8/17) 
  Generating static pages using 23 workers (12/17) 
✓ Generating static pages using 23 workers (17/17) in 255.0ms
  Finalizing page optimization ...

Route (app)
┌ ○ /
├ ○ /_not-found
├ ○ /agents
├ ƒ /agents/[id]
├ ○ /agents/new
├ ƒ /api/agents
├ ƒ /api/agents/[id]
├ ƒ /api/chats
├ ƒ /api/chats/[id]
├ ƒ /api/chats/[id]/events
├ ƒ /api/chats/[id]/messages
├ ƒ /api/chats/[id]/typing
├ ƒ /api/dispatch/pending
├ ƒ /api/gate
├ ƒ /api/notifications
├ ƒ /api/notifications/[id]
├ ƒ /api/projects
├ ƒ /api/projects/[id]
├ ƒ /api/signal
├ ƒ /api/signal/[id]/respond
├ ƒ /api/tasks
├ ƒ /api/tasks/[id]
├ ƒ /api/tasks/[id]/comments
├ ƒ /api/tasks/[id]/complete
├ ƒ /api/tasks/[id]/dispatch
├ ƒ /api/tasks/reorder
├ ƒ /api/voice
├ ƒ /projects/[slug]
├ ƒ /projects/[slug]/board
├ ƒ /projects/[slug]/chat
├ ƒ /projects/[slug]/sessions
├ ƒ /projects/[slug]/settings
├ ƒ /projects/[slug]/voice
├ ○ /sessions
└ ƒ /sessions/[id]


○  (Static)   prerendered as static content
ƒ  (Dynamic)  server-rendered on demand successful
- ✅ **Dev server running**: Hot-reload working on port 3002
- ✅ **Responsive breakpoints tested**: Cards appear on mobile, table on desktop
- ✅ **All interactions working**: Click navigation, expand/collapse, sorting

## Files Modified

-  - Main responsive implementation
-  - New shared component for future use

## Mobile UX Improvements

- ❌ **Before**: Table overflow, squished columns, unreadable text
- ✅ **After**: Clean card layout, readable text, intuitive tap interactions

This resolves the mobile usability issues mentioned in the ticket while maintaining full desktop functionality.