### PR TITLE
Fix sessions.preview API call - change sessionKey to keys array

### DIFF
--- a/lib/hooks/use-openclaw-rpc.ts
+++ b/lib/hooks/use-openclaw-rpc.ts
@@ -24,7 +24,7 @@ export function useOpenClawRpc() {
 
   // Get session preview with history
   const getSessionPreview = useCallback(async (sessionKey: string, limit?: number) => {
-    return rpc<SessionPreview>("sessions.preview", { sessionKey, limit: limit || 50 });
+    return rpc<SessionPreview>("sessions.preview", { keys: [sessionKey], limit: limit || 50 });
   }, [rpc]);
 
   // Reset session


### PR DESCRIPTION
## Problem

The ContextIndicator component was failing with the error:
```
[ContextIndicator] Failed to fetch context: Error: invalid sessions.preview params: 
must have required property 'keys'; at root: unexpected property 'sessionKey'
```

## Solution

The OpenClaw  API expects  as an array parameter, not  as a string.

Fixed by updating  to pass:
```typescript
{ keys: [sessionKey], limit: limit || 50 }
```

## Testing

- ✅ TypeScript compilation passes
- ✅ Dev server is running and hot-reloads the changes
- ✅ API parameter now matches OpenClaw specification

Resolves trap ticket: 2a047a92-fa9a-48a6-87c2-775a15759bde