### PR TITLE
Fix chat input focus after sending message

### DIFF
--- a/components/chat/chat-input.tsx
+++ b/components/chat/chat-input.tsx
@@ -112,6 +112,9 @@ export function ChatInput({
     setImages([])
     setSending(true)
     
+    // Keep focus on input after clearing
+    textareaRef.current?.focus()
+    
     try {
       // Upload images if any
       let uploadedUrls: string[] = []


### PR DESCRIPTION
Fixes issue where chat input loses focus after sending a message, requiring users to click back into the input field to continue typing.

Changes:
- Added textareaRef.current?.focus() call immediately after clearing input content in handleSend()
- This ensures the input maintains focus for seamless continued typing

Testing:
- Verified TypeScript compilation passes
- Confirmed dev server runs without errors

Fixes Trap ticket: 2a49d4aa-5b99-4045-8faf-82c140a8f43c