### PR TITLE
Improve chat readability with Inter font and 16px base size

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -8,6 +8,7 @@
   --color-foreground: var(--foreground);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
+  --font-chat: var(--font-inter);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
@@ -156,10 +157,12 @@
   
   /* Improve text rendering specifically for chat content */
   .chat-text {
-    -webkit-font-smoothing: subpixel-antialiased;
-    -moz-osx-font-smoothing: auto;
+    font-family: var(--font-chat), system-ui, -apple-system, sans-serif;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
     text-rendering: optimizeLegibility;
-    font-feature-settings: "liga", "kern";
+    font-feature-settings: "liga", "kern", "calt";
+    letter-spacing: 0.01em;
   }
 }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Geist, Geist_Mono, Inter } from "next/font/google";
 import "./globals.css";
 import { Providers } from "@/components/providers";
 import { MainLayout } from "@/components/layout/main-layout";
@@ -16,6 +16,13 @@ const geistMono = Geist_Mono({
   subsets: ["latin"],
 });
 
+const inter = Inter({
+  variable: "--font-inter",
+  subsets: ["latin"],
+  weight: ["400", "500", "600", "700"],
+  display: "swap",
+});
+
 export const metadata: Metadata = {
   title: "The Trap - OpenClaw Dashboard",
   description: "Real-time dashboard for OpenClaw AI agents",
@@ -29,7 +36,7 @@ export default function RootLayout({
   return (
     <html lang="en" className="dark">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} font-sans subpixel-antialiased`}
+        className={`${geistSans.variable} ${geistMono.variable} ${inter.variable} font-sans subpixel-antialiased`}
         style={{ fontOpticalSizing: "auto" }}
       >
         <Providers>

--- a/components/chat/markdown-content.tsx
+++ b/components/chat/markdown-content.tsx
@@ -50,7 +50,7 @@ export function MarkdownContent({ content, className = "" }: MarkdownContentProp
 
           // Paragraphs
           p: ({ children }) => (
-            <p className="text-[15px] leading-relaxed mb-2 last:mb-0 font-normal">
+            <p className="text-base leading-relaxed mb-2 last:mb-0 font-normal">
               {children}
             </p>
           ),
@@ -109,7 +109,7 @@ export function MarkdownContent({ content, className = "" }: MarkdownContentProp
             </ol>
           ),
           li: ({ children }) => (
-            <li className="text-[15px] leading-relaxed font-normal">
+            <li className="text-base leading-relaxed font-normal">
               {children}
             </li>
           ),

--- a/components/chat/message-bubble.tsx
+++ b/components/chat/message-bubble.tsx
@@ -68,7 +68,7 @@ export function MessageBubble({
         
         {/* Bubble */}
         <div 
-          className={`inline-block px-3 md:px-4 py-2 md:py-3 rounded-2xl text-[15px] md:text-base leading-relaxed font-medium chat-text ${
+          className={`inline-block px-3 md:px-4 py-2 md:py-3 rounded-2xl text-base leading-relaxed font-medium chat-text ${
             isOwnMessage
               ? "bg-[var(--accent-blue)] text-white rounded-br-md"
               : "bg-[var(--bg-tertiary)] text-[var(--text-primary)] rounded-bl-md"


### PR DESCRIPTION
## Changes

- **Font family**: Switched chat text from Geist to Inter for improved readability
- **Font size**: Bumped base size from 15px to 16px for chat messages
- **Font rendering**: Optimized antialiasing and rendering settings specifically for chat content
- **Scope**: Changes only apply to chat content - UI chrome still uses Geist

## Implementation

- Added Inter font to 
- Updated  class in  to use Inter with optimized rendering
- Changed  to  in message bubbles and markdown content
- Added letter-spacing and font-feature-settings for enhanced readability

## Testing

- ✅ Build passes successfully
- ✅ Dev server continues running on port 3002
- ✅ TypeScript compilation clean

Fixes: #[ticket 12586922-1bb8-4a31-9a6c-27550a4f198c]

The chat text should now be significantly more readable with less blurriness complaints.