### PR TITLE
Fix chat input and send button alignment

### DIFF
--- a/components/chat/chat-input.tsx
+++ b/components/chat/chat-input.tsx
@@ -223,7 +223,8 @@ export function ChatInput({
         </div>
       )}
       
-      <div className="flex gap-2 md:gap-3 items-end">
+      {/* Chat input and send button container - aligned center for better visual balance */}
+      <div className="flex gap-2 md:gap-3 items-center">
         <div className="flex-1">
           <textarea
             ref={textareaRef}
@@ -244,7 +245,7 @@ export function ChatInput({
             disabled={!onStop || stopping}
             size="lg"
             variant="destructive"
-            className="rounded-xl min-h-[44px] min-w-[44px] touch-manipulation"
+            className="rounded-xl h-[44px] w-[44px] flex-shrink-0 touch-manipulation"
             title="Stop response"
           >
             <Square className="h-4 w-4 md:h-5 md:w-5" />
@@ -254,7 +255,7 @@ export function ChatInput({
             onClick={handleSend}
             disabled={!hasContent || sending || disabled}
             size="lg"
-            className="rounded-xl min-h-[44px] min-w-[44px] touch-manipulation"
+            className="rounded-xl h-[44px] w-[44px] flex-shrink-0 touch-manipulation"
           >
             {sending ? (
               <div className="animate-spin rounded-full h-4 w-4 md:h-5 md:w-5 border-2 border-white border-t-transparent" />


### PR DESCRIPTION
## Problem

The chat input box and send button were misaligned, with the send button appearing pushed too far right and/or cut off from the input field.

## Solution

- Changed flex container from `items-end` to `items-center` for better vertical alignment
- Replaced `min-h`/`min-w` with fixed `h`/`w` values on send button for consistent sizing
- Added `flex-shrink-0` to prevent button compression when textarea expands
- Improved visual balance between textarea and button elements

## Changes

- Modified `components/chat/chat-input.tsx`
- Updated flex alignment and button sizing classes
- Added comment for future maintainability

The alignment is now consistent regardless of textarea content or expansion state.

## Testing

- ✅ Build passes
- ✅ No new TypeScript errors  
- ✅ Hot reload working
- ✅ Server running on port 3002

Fixes Trap ticket: 3186b8e8-c2a1-44c7-9b5f-f85cdc741389