### PR TITLE
fix: align send button with input field in chat

### DIFF
--- a/components/chat/chat-input.tsx
+++ b/components/chat/chat-input.tsx
@@ -223,8 +223,8 @@ export function ChatInput({
         </div>
       )}
       
-      {/* Chat input and send button container - aligned center for better visual balance */}
-      <div className="flex gap-2 md:gap-3 items-center">
+      {/* Chat input and send button container - with proper vertical alignment */}
+      <div className="flex gap-2 md:gap-3 items-end">
         <div className="flex-1">
           <textarea
             ref={textareaRef}
@@ -235,7 +235,7 @@ export function ChatInput({
             placeholder={placeholder}
             disabled={disabled || sending}
             rows={1}
-            className="w-full bg-[var(--bg-primary)] border border-[var(--border)] rounded-xl px-3 md:px-4 py-3 text-sm md:text-base text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus:outline-none focus:border-[var(--accent-blue)] resize-none touch-manipulation"
+            className="w-full bg-[var(--bg-primary)] border border-[var(--border)] rounded-xl px-3 md:px-4 py-3 text-sm md:text-base text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus:outline-none focus:border-[var(--accent-blue)] resize-none touch-manipulation min-h-[44px]"
           />
         </div>
         


### PR DESCRIPTION
## Problem
The chat input box and send button were misaligned. The send button was not vertically centered with the input field, creating an inconsistent visual experience.

## Solution
Fixed the alignment by:
- Changing the container layout from `items-center` to `items-end` for proper baseline alignment
- Adding `min-h-[44px]` to the textarea to ensure it matches the button's 44px height
- This ensures the send button stays properly aligned at the bottom of the container, regardless of textarea content height

## Testing
- ✅ Tested with single line input - button aligns perfectly with input baseline
- ✅ Tested with multi-line input - button stays anchored to bottom as expected
- ✅ Dev server running and hot-reload working correctly
- ✅ No TypeScript compilation errors

## Screenshots
Resolves the alignment issue shown in the uploaded screenshot.

Fixes ticket: 3186b8e8-c2a1-44c7-9b5f-f85cdc741389