### PR TITLE
feat: Auto-hide Done column and empty In Review column

### DIFF
--- a/components/board/board.tsx
+++ b/components/board/board.tsx
@@ -1,8 +1,8 @@
 "use client"
 
-import { useEffect } from "react"
+import { useEffect, useState } from "react"
 import { DragDropContext, type DropResult } from "@hello-pangea/dnd"
-import { Plus } from "lucide-react"
+import { Plus, Eye, EyeOff } from "lucide-react"
 import { useTaskStore } from "@/lib/stores/task-store"
 import { Column } from "./column"
 import { MobileBoard } from "./mobile-board"
@@ -26,10 +26,57 @@ const COLUMNS: { status: TaskStatus; title: string; color: string; showAdd: bool
 export function Board({ projectId, onTaskClick, onAddTask }: BoardProps) {
   const { tasks, loading, error, fetchTasks, getTasksByStatus, moveTask } = useTaskStore()
   const isMobile = useMobileDetection(768)
+  
+  // Column visibility state - initialize from localStorage
+  const [showDone, setShowDone] = useState(() => {
+    if (typeof window === 'undefined') return false
+    try {
+      const savedPrefs = localStorage.getItem(`board-prefs-${projectId}`)
+      if (savedPrefs) {
+        const prefs = JSON.parse(savedPrefs)
+        return prefs.showDone ?? false
+      }
+    } catch (error) {
+      console.error('Failed to parse board preferences:', error)
+    }
+    return false
+  })
+  
+  // Save preferences to localStorage whenever they change
+  useEffect(() => {
+    const prefs = { showDone }
+    localStorage.setItem(`board-prefs-${projectId}`, JSON.stringify(prefs))
+  }, [projectId, showDone])
 
   useEffect(() => {
     fetchTasks(projectId)
   }, [fetchTasks, projectId])
+  
+  // Determine which columns should be visible
+  const getVisibleColumns = () => {
+    return COLUMNS.filter(col => {
+      // Always show backlog, ready, and in_progress
+      if (["backlog", "ready", "in_progress"].includes(col.status)) {
+        return true
+      }
+      
+      // Show Done column only if user has toggled it on
+      if (col.status === "done") {
+        return showDone
+      }
+      
+      // Show Review column only if it has tasks (auto-hide when empty)
+      if (col.status === "review") {
+        return getTasksByStatus("review").length > 0
+      }
+      
+      return true
+    })
+  }
+  
+  const toggleShowDone = () => {
+    setShowDone(!showDone)
+  }
 
   const handleDragEnd = (result: DropResult) => {
     const { destination, source, draggableId } = result
@@ -81,11 +128,13 @@ export function Board({ projectId, onTaskClick, onAddTask }: BoardProps) {
   if (isMobile) {
     return (
       <MobileBoard
-        columns={COLUMNS}
+        columns={getVisibleColumns()}
         getTasksByStatus={getTasksByStatus}
         onTaskClick={onTaskClick}
         onAddTask={onAddTask}
         onDragEnd={handleDragEnd}
+        showDone={showDone}
+        onToggleShowDone={toggleShowDone}
       />
     )
   }
@@ -98,19 +147,33 @@ export function Board({ projectId, onTaskClick, onAddTask }: BoardProps) {
         <h2 className="text-xl font-semibold text-[var(--text-primary)]">
           Board
         </h2>
-        <button
-          onClick={() => onAddTask("backlog")}
-          className="flex items-center gap-2 px-4 py-2 bg-[var(--accent-blue)] text-white rounded-lg hover:bg-[var(--accent-blue)]/90 transition-colors font-medium"
-        >
-          <Plus className="h-4 w-4" />
-          New Ticket
-        </button>
+        <div className="flex items-center gap-3">
+          {/* Show Done toggle */}
+          <button
+            onClick={toggleShowDone}
+            className="flex items-center gap-2 px-3 py-2 bg-[var(--bg-secondary)] border border-[var(--border)] text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-tertiary)] rounded-lg transition-colors text-sm"
+            title={showDone ? "Hide completed tasks" : "Show completed tasks"}
+          >
+            {showDone ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+            {showDone ? "Hide Done" : "Show Done"}
+          </button>
+          
+          <button
+            onClick={() => onAddTask("backlog")}
+            className="flex items-center gap-2 px-4 py-2 bg-[var(--accent-blue)] text-white rounded-lg hover:bg-[var(--accent-blue)]/90 transition-colors font-medium"
+          >
+            <Plus className="h-4 w-4" />
+            New Ticket
+          </button>
+        </div>
       </div>
 
       {/* Board Columns */}
       <DragDropContext onDragEnd={handleDragEnd}>
-        <div className="flex gap-4 overflow-x-auto pb-4 lg:grid lg:grid-cols-5 lg:overflow-visible">
-          {COLUMNS.map((col) => (
+        <div className="flex gap-4 overflow-x-auto pb-4 lg:grid lg:overflow-visible" style={{
+          gridTemplateColumns: `repeat(${getVisibleColumns().length}, minmax(280px, 1fr))`
+        }}>
+          {getVisibleColumns().map((col) => (
             <Column
               key={col.status}
               status={col.status}

--- a/components/board/mobile-board.tsx
+++ b/components/board/mobile-board.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback } from "react"
 import { DragDropContext, type DropResult } from "@hello-pangea/dnd"
-import { Plus, ChevronLeft, ChevronRight } from "lucide-react"
+import { Plus, ChevronLeft, ChevronRight, Eye, EyeOff } from "lucide-react"
 import type { Task, TaskStatus } from "@/lib/db/types"
 import { Column } from "./column"
 
@@ -12,6 +12,8 @@ interface MobileBoardProps {
   onTaskClick: (task: Task) => void
   onAddTask: (status: TaskStatus) => void
   onDragEnd: (result: DropResult) => void
+  showDone?: boolean
+  onToggleShowDone?: () => void
 }
 
 export function MobileBoard({ 
@@ -19,7 +21,9 @@ export function MobileBoard({
   getTasksByStatus, 
   onTaskClick, 
   onAddTask,
-  onDragEnd 
+  onDragEnd,
+  showDone = false,
+  onToggleShowDone
 }: MobileBoardProps) {
   const [activeColumnIndex, setActiveColumnIndex] = useState(0)
   const activeColumn = columns[activeColumnIndex]
@@ -131,13 +135,27 @@ export function MobileBoard({
         <h2 className="text-xl font-semibold text-[var(--text-primary)]">
           Board
         </h2>
-        <button
-          onClick={() => onAddTask("backlog")}
-          className="flex items-center gap-2 px-3 py-2 bg-[var(--accent-blue)] text-white rounded-lg hover:bg-[var(--accent-blue)]/90 transition-colors font-medium text-sm"
-        >
-          <Plus className="h-4 w-4" />
-          New Ticket
-        </button>
+        <div className="flex items-center gap-2">
+          {/* Show Done toggle for mobile */}
+          {onToggleShowDone && (
+            <button
+              onClick={onToggleShowDone}
+              className="flex items-center gap-1 px-2 py-2 bg-[var(--bg-secondary)] border border-[var(--border)] text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-tertiary)] rounded-lg transition-colors text-xs"
+              title={showDone ? "Hide completed tasks" : "Show completed tasks"}
+            >
+              {showDone ? <EyeOff className="h-3 w-3" /> : <Eye className="h-3 w-3" />}
+              {showDone ? "Hide" : "Show"}
+            </button>
+          )}
+          
+          <button
+            onClick={() => onAddTask("backlog")}
+            className="flex items-center gap-2 px-3 py-2 bg-[var(--accent-blue)] text-white rounded-lg hover:bg-[var(--accent-blue)]/90 transition-colors font-medium text-sm"
+          >
+            <Plus className="h-4 w-4" />
+            New Ticket
+          </button>
+        </div>
       </div>
 
       {/* Column Navigation */}


### PR DESCRIPTION
## Summary
This PR implements intelligent column hiding for the Kanban board to reduce visual clutter.

## Changes
- **Done column**: Hidden by default with a toggle button to show/hide
- **In Review column**: Automatically hidden when empty (no tasks)
- **Visibility controls**: Toggle button in board header for both desktop and mobile
- **Persistence**: Column preferences saved in localStorage per project
- **Responsive**: Dynamic grid layout adjusts based on visible columns
- **Mobile support**: Includes toggle functionality in mobile board view

## Implementation Details
- Column filtering logic in `getVisibleColumns()` function
- localStorage persistence with `board-prefs-{projectId}` key
- Eye/EyeOff icons for intuitive toggle button
- Grid layout dynamically adjusts column count
- Mobile board properly handles filtered columns

## Testing
✅ TypeScript compilation passes  
✅ ESLint passes  
✅ Next.js build succeeds  
✅ Dev server running and hot-reload works

## Closes
Implements ticket: `ecdc2940-86dc-4890-b9b8-9e560711d0c3`

## UI Preview
- **Default state**: Shows Backlog, Ready, In Progress (Done hidden, Review auto-hidden if empty)
- **Show Done**: Click toggle to reveal Done column
- **Review visibility**: Automatically appears when tasks are moved to Review status
- **Preferences**: Settings persist across page loads per project