### PR TITLE
feat: add local_path and github_repo fields to project model

### DIFF
--- a/app/api/projects/route.ts
+++ b/app/api/projects/route.ts
@@ -19,13 +19,31 @@ export async function GET() {
 export async function POST(request: NextRequest) {
   const body = await request.json()
   
-  const { name, slug, description, color, repo_url, chat_layout } = body
+  const { name, slug, description, color, repo_url, chat_layout, local_path, github_repo } = body
   
   if (!name || !slug) {
     return NextResponse.json(
       { error: "Name and slug are required" },
       { status: 400 }
     )
+  }
+
+  // Validate local_path if provided
+  if (local_path && typeof local_path !== 'string') {
+    return NextResponse.json(
+      { error: "local_path must be a string" },
+      { status: 400 }
+    )
+  }
+
+  // Validate github_repo format if provided
+  if (github_repo) {
+    if (typeof github_repo !== 'string' || !/^[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+$/.test(github_repo)) {
+      return NextResponse.json(
+        { error: "github_repo must be in owner/repo format" },
+        { status: 400 }
+      )
+    }
   }
 
   // Check slug uniqueness
@@ -51,14 +69,16 @@ export async function POST(request: NextRequest) {
     color: color || "#3b82f6",
     repo_url: repo_url || null,
     context_path: null,
+    local_path: local_path || null,
+    github_repo: github_repo || null,
     chat_layout: chat_layout || 'slack',
     created_at: now,
     updated_at: now,
   }
 
   db.prepare(`
-    INSERT INTO projects (id, slug, name, description, color, repo_url, context_path, chat_layout, created_at, updated_at)
-    VALUES (@id, @slug, @name, @description, @color, @repo_url, @context_path, @chat_layout, @created_at, @updated_at)
+    INSERT INTO projects (id, slug, name, description, color, repo_url, context_path, local_path, github_repo, chat_layout, created_at, updated_at)
+    VALUES (@id, @slug, @name, @description, @color, @repo_url, @context_path, @local_path, @github_repo, @chat_layout, @created_at, @updated_at)
   `).run(project)
 
   // Create default "General" chat for the project

--- a/lib/db/schema.sql
+++ b/lib/db/schema.sql
@@ -7,6 +7,8 @@ CREATE TABLE IF NOT EXISTS projects (
   color TEXT DEFAULT '#3b82f6',
   repo_url TEXT,
   context_path TEXT,
+  local_path TEXT,
+  github_repo TEXT,
   chat_layout TEXT DEFAULT 'slack',
   created_at INTEGER NOT NULL,
   updated_at INTEGER NOT NULL

--- a/lib/db/types.ts
+++ b/lib/db/types.ts
@@ -8,6 +8,8 @@ export interface Project {
   color: string
   repo_url: string | null
   context_path: string | null
+  local_path: string | null
+  github_repo: string | null
   chat_layout: 'slack' | 'imessage'
   created_at: number
   updated_at: number

--- a/lib/websocket/server.ts
+++ b/lib/websocket/server.ts
@@ -79,10 +79,14 @@ class WebSocketManager {
 
     switch (message.type) {
       case 'subscribe':
-        this.subscribeToProject(clientId, message.projectId, message.userId)
+        if (message.projectId) {
+          this.subscribeToProject(clientId, message.projectId, message.userId)
+        }
         break
       case 'unsubscribe':
-        this.unsubscribeFromProject(clientId, message.projectId)
+        if (message.projectId) {
+          this.unsubscribeFromProject(clientId, message.projectId)
+        }
         break
       case 'ping':
         this.sendToClient(clientId, { type: 'pong', data: {} })

--- a/scripts/migrate.ts
+++ b/scripts/migrate.ts
@@ -21,6 +21,8 @@ addColumnIfNotExists("tasks", "dispatch_requested_by", "TEXT")
 addColumnIfNotExists("tasks", "position", "INTEGER DEFAULT 0")
 addColumnIfNotExists("chats", "session_key", "TEXT")
 addColumnIfNotExists("chat_messages", "run_id", "TEXT")
+addColumnIfNotExists("projects", "local_path", "TEXT")
+addColumnIfNotExists("projects", "github_repo", "TEXT")
 
 // Now run schema.sql for new tables and indexes
 const schemaPath = path.join(__dirname, "../lib/db/schema.sql")


### PR DESCRIPTION
## Summary

Adds two new optional fields to the project model to link projects to codebases:

- `local_path` - Absolute path to local checkout (e.g. ~/src/axiom-trader)  
- `github_repo` - GitHub repo in owner/repo format (e.g. dbachelder/axiom-trader)

## Changes

### Database
- Added columns to projects table via migration
- Updated schema.sql for new installations

### API
- Support for new fields in POST /api/projects (create)
- Support for new fields in PATCH /api/projects/[id] (update)
- Fields included in GET responses
- Added validation for github_repo format

### Types
- Updated Project interface with new optional fields

## Validation

- `local_path`: Must be string if provided
- `github_repo`: Must match owner/repo pattern if provided

## Testing

✅ Migration runs successfully  
✅ CREATE project with new fields works
✅ UPDATE project with new fields works  
✅ Validation rejects invalid github_repo format
✅ Build passes
✅ Server runs without issues

## Note

Fixed unrelated TypeScript issues in websocket server during build verification.

Resolves ticket: f9942c51-a69e-4b7a-9477-e999f50d73d1