### PR TITLE
feat: cascade project context to spawned agents

### DIFF
--- a/scripts/work-loop/process-task.md
+++ b/scripts/work-loop/process-task.md
@@ -2,17 +2,17 @@
 
 You are processing a task from the automated work loop for project **{project_name}**.
 
-## Project Context
-- **Name:** {project_name}
-- **Local Path:** {local_path}
-- **GitHub Repo:** {github_repo}
-- **Slug:** {project_slug}
-
 ## Task Details
 - **ID:** {task_id}
 - **Title:** {task_title}
-- **Description:** {task_description}
 - **Priority:** {task_priority}
+- **Project:** {project_name}
+- **Working Directory:** `{local_path}`
+- **GitHub Repo:** {github_repo}
+
+## Description
+
+{task_description}
 
 ## Instructions
 
@@ -31,8 +31,8 @@ You are processing a task from the automated work loop for project **{project_na
 3. **Implement the task:**
    - Read the task description carefully
    - Understand what needs to be built/fixed
+   - Follow project conventions (see Project Files section below)
    - Write clean, working code
-   - Follow project conventions
    - Test your changes
 
 4. **Create a pull request:**
@@ -86,7 +86,7 @@ If you encounter issues:
 ## Success Criteria
 
 - Task implementation matches the description
-- Code follows project standards
+- Code follows project standards (check AGENTS.md if present)
 - Tests pass (if applicable)  
 - PR is created and linked
 - Task status updated to in_review


### PR DESCRIPTION
## Summary

When agents are spawned for project work (sub-agents, work loop), they now inherit full project context.

## Changes

### `lib/dispatch/context.ts`
- Imports and uses `buildProjectContext` and `formatProjectContext` from project-context module
- Task dispatch now includes cascaded project files (AGENTS.md, README.md, etc.)
- Added working directory and GitHub repo to task context header

### `scripts/work-loop/project-gate.sh`
- Fetches full project context from `/api/projects/{id}/context` endpoint
- Uses jq to extract formatted context (with fallback if jq unavailable)
- Appends project context to work instructions

### `scripts/work-loop/process-task.md`
- Cleaned up template to avoid duplication with cascaded context
- Added reference to check AGENTS.md for project standards

## Context Cascade

What spawned agents now receive:
- **Project local_path** → agent working directory
- **Project github_repo** → default for gh commands  
- **Project-specific instructions** from AGENTS.md, README.md, etc.
- **Task context** from Kanban ticket

## Testing

- `npx tsc --noEmit` passes
- `npx eslint lib/dispatch/context.ts` passes
- Context API verified working: `curl http://localhost:3002/api/projects/the-trap/context`
- Gate script syntax verified: `bash -n scripts/work-loop/project-gate.sh`

Closes Trap ticket: ea6248a6-42dd-4957-bd83-5d9937357d46