### PR TITLE
feat: SSE endpoint for real-time message updates

### DIFF
--- a/app/api/chats/[id]/stream/route.ts
+++ b/app/api/chats/[id]/stream/route.ts
@@ -1,0 +1,75 @@
+import { NextRequest } from 'next/server'
+import { chatEvents } from '@/lib/sse/chat-events'
+
+/**
+ * GET /api/chats/[id]/stream
+ * Server-Sent Events endpoint for real-time chat updates
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id: chatId } = await params
+  
+  // Set up SSE headers
+  const headers = new Headers({
+    'Content-Type': 'text/event-stream',
+    'Cache-Control': 'no-cache, no-transform',
+    'Connection': 'keep-alive',
+    'X-Accel-Buffering': 'no', // Disable Nginx buffering
+  })
+  
+  // Create readable stream for SSE
+  const stream = new ReadableStream({
+    start(controller) {
+      const encoder = new TextEncoder()
+      
+      // Helper to send SSE event
+      const sendEvent = (event: string, data: unknown) => {
+        const message = `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`
+        controller.enqueue(encoder.encode(message))
+      }
+      
+      // Send initial connection event
+      sendEvent('connected', { chatId, timestamp: Date.now() })
+      
+      // Subscribe to chat events
+      const unsubscribe = chatEvents.subscribe(chatId, (event) => {
+        try {
+          sendEvent(event.type, event.data)
+        } catch (error) {
+          // Stream might be closed
+          console.error('[SSE] Error sending event:', error)
+        }
+      })
+      
+      // Handle client disconnect
+      request.signal.addEventListener('abort', () => {
+        console.log(`[SSE] Client disconnected from chat ${chatId.substring(0, 8)}...`)
+        unsubscribe()
+        controller.close()
+      })
+      
+      // Keep-alive ping every 30 seconds
+      const pingInterval = setInterval(() => {
+        try {
+          const ping = `: ping ${Date.now()}\n\n`
+          controller.enqueue(encoder.encode(ping))
+        } catch {
+          // Stream closed
+          clearInterval(pingInterval)
+        }
+      }, 30000)
+      
+      // Clean up on close
+      request.signal.addEventListener('abort', () => {
+        clearInterval(pingInterval)
+      })
+    }
+  })
+  
+  return new Response(stream, { headers })
+}
+
+// Disable static generation for SSE endpoint
+export const dynamic = 'force-dynamic'

--- a/lib/sse/chat-events.ts
+++ b/lib/sse/chat-events.ts
@@ -1,0 +1,133 @@
+/**
+ * Chat SSE Event Emitter
+ * Pub/sub system for broadcasting chat events to connected clients
+ */
+
+type ChatEventType = 
+  | 'message'
+  | 'typing.start'
+  | 'typing.end'
+  | 'delta'
+
+interface ChatEvent {
+  type: ChatEventType
+  chatId: string
+  data: {
+    id?: string
+    author?: string
+    content?: string
+    delta?: string
+    runId?: string
+    timestamp?: number
+  }
+}
+
+type EventCallback = (event: ChatEvent) => void
+
+class ChatEventEmitter {
+  // Map of chatId -> Set of subscriber callbacks
+  private subscribers = new Map<string, Set<EventCallback>>()
+  
+  /**
+   * Subscribe to events for a specific chat
+   * Returns unsubscribe function
+   */
+  subscribe(chatId: string, callback: EventCallback): () => void {
+    if (!this.subscribers.has(chatId)) {
+      this.subscribers.set(chatId, new Set())
+    }
+    
+    this.subscribers.get(chatId)!.add(callback)
+    console.log(`[SSE] Subscriber added for chat ${chatId.substring(0, 8)}... (${this.subscribers.get(chatId)!.size} total)`)
+    
+    return () => {
+      const subs = this.subscribers.get(chatId)
+      if (subs) {
+        subs.delete(callback)
+        console.log(`[SSE] Subscriber removed for chat ${chatId.substring(0, 8)}... (${subs.size} remaining)`)
+        if (subs.size === 0) {
+          this.subscribers.delete(chatId)
+        }
+      }
+    }
+  }
+  
+  /**
+   * Emit an event to all subscribers of a chat
+   */
+  emit(event: ChatEvent): void {
+    const subs = this.subscribers.get(event.chatId)
+    if (subs && subs.size > 0) {
+      console.log(`[SSE] Emitting ${event.type} to ${subs.size} subscribers for chat ${event.chatId.substring(0, 8)}...`)
+      subs.forEach(callback => {
+        try {
+          callback(event)
+        } catch (error) {
+          console.error('[SSE] Error in subscriber callback:', error)
+        }
+      })
+    }
+  }
+  
+  /**
+   * Emit a new message event
+   */
+  emitMessage(chatId: string, messageId: string, author: string, content: string, runId?: string): void {
+    this.emit({
+      type: 'message',
+      chatId,
+      data: {
+        id: messageId,
+        author,
+        content,
+        runId,
+        timestamp: Date.now()
+      }
+    })
+  }
+  
+  /**
+   * Emit typing indicator start
+   */
+  emitTypingStart(chatId: string): void {
+    this.emit({
+      type: 'typing.start',
+      chatId,
+      data: { timestamp: Date.now() }
+    })
+  }
+  
+  /**
+   * Emit typing indicator end
+   */
+  emitTypingEnd(chatId: string): void {
+    this.emit({
+      type: 'typing.end',
+      chatId,
+      data: { timestamp: Date.now() }
+    })
+  }
+  
+  /**
+   * Emit streaming delta
+   */
+  emitDelta(chatId: string, delta: string, runId?: string): void {
+    this.emit({
+      type: 'delta',
+      chatId,
+      data: { delta, runId, timestamp: Date.now() }
+    })
+  }
+  
+  /**
+   * Get subscriber count for a chat
+   */
+  getSubscriberCount(chatId: string): number {
+    return this.subscribers.get(chatId)?.size || 0
+  }
+}
+
+// Singleton instance
+export const chatEvents = new ChatEventEmitter()
+
+export type { ChatEvent, ChatEventType }


### PR DESCRIPTION
## Summary
Browser subscribes to SSE endpoint instead of direct OpenClaw WebSocket.

## Changes
- `lib/sse/chat-events.ts` - Pub/sub emitter for broadcasting chat events
- `app/api/chats/[id]/stream/route.ts` - SSE endpoint
- Updated `instrumentation.ts` to emit events

## SSE Events
- `connected` - Initial connection confirmation
- `typing.start` / `typing.end` - Typing indicators
- `delta` - Streaming content chunks
- `message` - Completed message (deduplicated)

## Usage
```javascript
const source = new EventSource('/api/chats/abc123/stream')
source.addEventListener('message', (e) => {
  const msg = JSON.parse(e.data)
  // { id, author, content, runId, timestamp }
})
source.addEventListener('typing.start', () => { /* show indicator */ })
```

## Features
- Multiple subscribers per chat (pub/sub pattern)
- 30s keep-alive pings
- Automatic cleanup on disconnect
- Nginx buffering disabled for low latency

## Part of Epic
1. ✅ Backend WS client
2. ✅ Save messages server-side
3. ✅ **SSE endpoint** (this PR)
4. ⬜ Refactor frontend to read from DB stream

Closes: 1983bb68-63e7-496b-b715-8862fa472737