### PR TITLE
feat: link in-progress issues to session status in sidebar

### DIFF
--- a/app/api/sessions/status/route.ts
+++ b/app/api/sessions/status/route.ts
@@ -1,0 +1,175 @@
+import { NextRequest, NextResponse } from "next/server"
+
+export interface SessionStatusInfo {
+  id: string
+  status: 'running' | 'idle' | 'completed' | 'error' | 'cancelled' | 'not_found'
+  updatedAt?: string
+  model?: string
+  tokens?: {
+    input: number
+    output: number
+    total: number
+  }
+  lastActivity?: string
+  isActive: boolean
+  isIdle: boolean
+  isStuck: boolean
+}
+
+/**
+ * POST /api/sessions/status
+ * Get status for multiple session IDs
+ * 
+ * Body: { sessionIds: string[] }
+ * Returns: { sessions: Record<string, SessionStatusInfo> }
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const { sessionIds } = await request.json()
+    
+    if (!Array.isArray(sessionIds)) {
+      return NextResponse.json(
+        { error: "sessionIds must be an array" },
+        { status: 400 }
+      )
+    }
+    
+    // OpenClaw gateway HTTP endpoint
+    const openclawUrl = process.env.OPENCLAW_HTTP_URL || 'http://127.0.0.1:4440'
+    const openclawToken = process.env.OPENCLAW_TOKEN || process.env.NEXT_PUBLIC_OPENCLAW_TOKEN || ''
+    
+    const sessions: Record<string, SessionStatusInfo> = {}
+    const now = Date.now()
+    const IDLE_THRESHOLD_MS = 5 * 60 * 1000 // 5 minutes
+    const STUCK_THRESHOLD_MS = 15 * 60 * 1000 // 15 minutes
+    
+    // Fetch session info for each session ID
+    for (const sessionId of sessionIds) {
+      if (!sessionId || typeof sessionId !== 'string') {
+        sessions[sessionId] = {
+          id: sessionId,
+          status: 'not_found',
+          isActive: false,
+          isIdle: false,
+          isStuck: false
+        }
+        continue
+      }
+      
+      try {
+        // Try to get session info via HTTP RPC to OpenClaw
+        const rpcRequest = {
+          type: 'req',
+          id: crypto.randomUUID(),
+          method: 'sessions.list',
+          params: { keys: [sessionId] }
+        }
+        
+        const httpResponse = await fetch(`${openclawUrl}/rpc`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': openclawToken ? `Bearer ${openclawToken}` : ''
+          },
+          body: JSON.stringify(rpcRequest)
+        })
+        
+        if (!httpResponse.ok) {
+          throw new Error(`OpenClaw HTTP ${httpResponse.status}: ${httpResponse.statusText}`)
+        }
+        
+        const rpcResponse = await httpResponse.json()
+        if (!rpcResponse.ok || rpcResponse.error) {
+          throw new Error(rpcResponse.error?.message || 'OpenClaw RPC error')
+        }
+        
+        const sessionInfo = rpcResponse.payload?.sessions?.[0]
+        
+        if (!sessionInfo) {
+          sessions[sessionId] = {
+            id: sessionId,
+            status: 'not_found',
+            isActive: false,
+            isIdle: false,
+            isStuck: false
+          }
+          continue
+        }
+        
+        const updatedAt = sessionInfo.updatedAt
+        const lastActivityMs = updatedAt ? new Date(updatedAt).getTime() : now
+        const timeSinceActivity = now - lastActivityMs
+        
+        // Determine status based on activity
+        const isActive = timeSinceActivity < IDLE_THRESHOLD_MS
+        const isIdle = timeSinceActivity >= IDLE_THRESHOLD_MS && timeSinceActivity < STUCK_THRESHOLD_MS
+        const isStuck = timeSinceActivity >= STUCK_THRESHOLD_MS
+        
+        let status: SessionStatusInfo['status'] = 'idle'
+        if (isActive) status = 'running'
+        else if (isStuck) status = 'error' // Treat stuck as error state
+        
+        sessions[sessionId] = {
+          id: sessionId,
+          status,
+          updatedAt,
+          model: sessionInfo.model,
+          tokens: {
+            input: sessionInfo.inputTokens || 0,
+            output: sessionInfo.outputTokens || 0,
+            total: sessionInfo.totalTokens || 0
+          },
+          lastActivity: updatedAt,
+          isActive,
+          isIdle,
+          isStuck
+        }
+      } catch (error) {
+        console.error(`Failed to get status for session ${sessionId}:`, error)
+        sessions[sessionId] = {
+          id: sessionId,
+          status: 'error',
+          isActive: false,
+          isIdle: false,
+          isStuck: false
+        }
+      }
+    }
+    
+    return NextResponse.json({ sessions })
+  } catch (error) {
+    console.error("Failed to get session status:", error)
+    return NextResponse.json(
+      { error: "Failed to get session status", details: String(error) },
+      { status: 500 }
+    )
+  }
+}
+
+/**
+ * GET /api/sessions/status?sessionId=xxx
+ * Get status for a single session ID (for testing)
+ */
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url)
+  const sessionId = searchParams.get('sessionId')
+  
+  if (!sessionId) {
+    return NextResponse.json(
+      { error: "sessionId parameter is required" },
+      { status: 400 }
+    )
+  }
+  
+  // Use the POST handler with a single session ID
+  const mockRequest = {
+    json: async () => ({ sessionIds: [sessionId] })
+  } as NextRequest
+  
+  const response = await POST(mockRequest)
+  const data = await response.json()
+  
+  return NextResponse.json({
+    session: data.sessions?.[sessionId] || null
+  })
+}

--- a/components/board/task-card.tsx
+++ b/components/board/task-card.tsx
@@ -2,6 +2,7 @@
 
 import { Draggable } from "@hello-pangea/dnd"
 import type { Task } from "@/lib/db/types"
+import { useSingleSessionStatus, getSessionStatusIndicator } from "@/lib/hooks/use-session-status"
 
 interface TaskCardProps {
   task: Task
@@ -18,6 +19,11 @@ const PRIORITY_COLORS: Record<string, string> = {
 }
 
 export function TaskCard({ task, index, onClick, isMobile = false }: TaskCardProps) {
+  // Get session status for in-progress tasks
+  const shouldFetchSessionStatus = task.status === 'in_progress' && task.session_id
+  const { sessionStatus } = useSingleSessionStatus(shouldFetchSessionStatus ? task.session_id || undefined : undefined)
+  const sessionIndicator = getSessionStatusIndicator(sessionStatus || undefined)
+
   const tags = (() => {
     if (!task.tags) return []
     try {
@@ -69,9 +75,23 @@ export function TaskCard({ task, index, onClick, isMobile = false }: TaskCardPro
               style={{ backgroundColor: PRIORITY_COLORS[task.priority] || PRIORITY_COLORS.medium }}
               title={`Priority: ${task.priority}`}
             />
-            <span className="text-sm text-[var(--text-primary)] line-clamp-2">
+            <span className="text-sm text-[var(--text-primary)] line-clamp-2 flex-1">
               {task.title}
             </span>
+            {/* Session status indicator for in-progress tasks */}
+            {task.status === 'in_progress' && (
+              <div 
+                className="flex-shrink-0 text-sm cursor-help"
+                style={{ color: sessionIndicator.color }}
+                title={sessionIndicator.title}
+                onClick={(e) => {
+                  e.stopPropagation()
+                  // TODO: Could open session detail view here
+                }}
+              >
+                {sessionIndicator.emoji}
+              </div>
+            )}
           </div>
           
           {/* Tags + Assignee */}

--- a/lib/hooks/use-session-status.ts
+++ b/lib/hooks/use-session-status.ts
@@ -1,0 +1,139 @@
+"use client"
+
+import { useEffect, useState, useCallback, useRef } from "react"
+import type { SessionStatusInfo } from "@/app/api/sessions/status/route"
+
+export interface SessionStatusMap {
+  [sessionId: string]: SessionStatusInfo
+}
+
+/**
+ * Hook to fetch and manage session status for multiple session IDs
+ */
+export function useSessionStatus(sessionIds: string[]) {
+  const [sessionStatus, setSessionStatus] = useState<SessionStatusMap>({})
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const lastSessionIdsRef = useRef<string>('')
+
+  const fetchSessionStatus = useCallback(async (ids: string[]) => {
+    // Filter out empty/null session IDs
+    const validIds = ids.filter(id => id && typeof id === 'string')
+    
+    if (validIds.length === 0) {
+      setSessionStatus({})
+      setLoading(false)
+      return
+    }
+
+    try {
+      setLoading(true)
+      setError(null)
+
+      const response = await fetch('/api/sessions/status', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ sessionIds: validIds })
+      })
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({ error: 'Unknown error' }))
+        throw new Error(errorData.error || `HTTP ${response.status}`)
+      }
+
+      const data = await response.json()
+      setSessionStatus(data.sessions || {})
+    } catch (err) {
+      console.error('Failed to fetch session status:', err)
+      setError(err instanceof Error ? err.message : String(err))
+      // Keep previous session status on error
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  // Fetch when session IDs change
+  useEffect(() => {
+    const idsString = JSON.stringify(sessionIds.sort())
+    
+    // Only fetch if session IDs actually changed
+    if (idsString !== lastSessionIdsRef.current) {
+      lastSessionIdsRef.current = idsString
+      fetchSessionStatus(sessionIds)
+    }
+  }, [sessionIds, fetchSessionStatus])
+
+  // Auto-refresh every 30 seconds for active sessions
+  useEffect(() => {
+    const hasActiveSessions = Object.values(sessionStatus).some(
+      status => status.isActive || status.status === 'running'
+    )
+    
+    if (!hasActiveSessions) return
+
+    const interval = setInterval(() => {
+      const validIds = sessionIds.filter(id => id && typeof id === 'string')
+      if (validIds.length > 0) {
+        fetchSessionStatus(validIds)
+      }
+    }, 30000) // 30 seconds
+
+    return () => clearInterval(interval)
+  }, [sessionIds, sessionStatus, fetchSessionStatus])
+
+  const refetch = useCallback(() => {
+    fetchSessionStatus(sessionIds)
+  }, [sessionIds, fetchSessionStatus])
+
+  return {
+    sessionStatus,
+    loading,
+    error,
+    refetch
+  }
+}
+
+/**
+ * Hook to get session status for a single session ID
+ */
+export function useSingleSessionStatus(sessionId?: string) {
+  const sessionIds = sessionId ? [sessionId] : []
+  const { sessionStatus, loading, error, refetch } = useSessionStatus(sessionIds)
+  
+  return {
+    sessionStatus: sessionId ? sessionStatus[sessionId] || null : null,
+    loading,
+    error,
+    refetch
+  }
+}
+
+/**
+ * Get session status indicator emoji and color
+ */
+export function getSessionStatusIndicator(status?: SessionStatusInfo) {
+  if (!status) {
+    return { emoji: '⚪', color: '#6b7280', title: 'No session' }
+  }
+
+  if (status.status === 'not_found') {
+    return { emoji: '⚪', color: '#6b7280', title: 'Session not found' }
+  }
+
+  if (status.isActive) {
+    return { emoji: '🟢', color: '#22c55e', title: 'Active - recent activity' }
+  }
+
+  if (status.isStuck) {
+    return { emoji: '🔴', color: '#ef4444', title: 'Stuck/Error - no activity for 15+ minutes' }
+  }
+
+  if (status.isIdle) {
+    return { emoji: '🟡', color: '#eab308', title: 'Idle - no activity for 5+ minutes' }
+  }
+
+  // Default to idle for unknown states
+  return { emoji: '🟡', color: '#eab308', title: 'Unknown status' }
+}

--- a/scripts/work-loop/process-task.md
+++ b/scripts/work-loop/process-task.md
@@ -16,11 +16,14 @@ You are processing a task from the automated work loop for project **{project_na
 
 ## Instructions
 
-1. **Move task to in_progress status:**
+1. **Move task to in_progress status and claim with session ID:**
    ```bash
+   # Get current session key from environment
+   SESSION_KEY="${SESSION_KEY:-$(echo $OPENCLAW_SESSION_KEY)}"
+   
    curl -s -X PATCH http://localhost:3002/api/tasks/{task_id} \
      -H 'Content-Type: application/json' \
-     -d '{"status": "in_progress", "dispatch_status": "active"}'
+     -d "{\"status\": \"in_progress\", \"dispatch_status\": \"active\", \"session_id\": \"$SESSION_KEY\"}"
    ```
 
 2. **Work in the project directory:**


### PR DESCRIPTION
## Summary
For issues shown as "in progress" in the sidebar, display the status of the session working on them.

## Problem
Can't tell if a sub-agent is actively working, stuck, or finished but forgot to update the ticket.

## Implementation
1. **New API endpoint**  - fetches session status for multiple session IDs via OpenClaw RPC
2. **Session status hook**  - manages session status fetching and auto-refresh
3. **TaskCard indicators** - shows status next to in-progress task titles:
   - 🟢 Active (recent activity)
   - 🟡 Idle (no activity in 5+ minutes) 
   - 🔴 Stuck/Error (no activity in 15+ minutes)
   - ⚪ No session or session not found
4. **Work loop integration** - updates process template to set `session_id` when claiming tickets
5. **Auto-refresh** - fetches session status every 30 seconds for active sessions

## Session status data
- Uses OpenClaw `sessions.list` RPC to get session info
- Checks `updatedAt` to determine if active vs idle vs stuck
- Handles connection errors gracefully

## Files changed
- `app/api/sessions/status/route.ts` - New API endpoint
- `lib/hooks/use-session-status.ts` - Session status management hook
- `components/board/task-card.tsx` - Display session indicators
- `scripts/work-loop/process-task.md` - Set session_id when claiming tickets

## Testing
- API endpoint tested with curl
- TypeScript compilation passes
- ESLint passes
- Session status indicators display correctly for in-progress tasks

Resolves issue `3ef7dd17-84d9-48c9-bd3f-077fb7362ba3`