### PR TITLE
Fix: Chat list not refreshing when switching projects

### DIFF
--- a/components/chat/chat-sidebar.tsx
+++ b/components/chat/chat-sidebar.tsx
@@ -39,7 +39,7 @@ const STATUS_COLORS: Record<string, string> = {
 }
 
 export function ChatSidebar({ projectId, projectSlug, isOpen = true, onClose, isMobile = false }: ChatSidebarProps) {
-  const { chats, activeChat, setActiveChat, createChat, deleteChat, loading } = useChatStore()
+  const { chats, activeChat, setActiveChat, createChat, deleteChat, loading, fetchChats, currentProjectId } = useChatStore()
   const [creating, setCreating] = useState(false)
   const [deletingChatId, setDeletingChatId] = useState<string | null>(null)
   
@@ -109,6 +109,13 @@ export function ChatSidebar({ projectId, projectSlug, isOpen = true, onClose, is
     const interval = setInterval(fetchWorkQueue, 30000)
     return () => clearInterval(interval)
   }, [fetchWorkQueue])
+
+  // Refetch chats when project changes
+  useEffect(() => {
+    if (projectId && currentProjectId !== projectId) {
+      fetchChats(projectId)
+    }
+  }, [projectId, currentProjectId, fetchChats])
 
   const toggleSection = (status: string) => {
     setWorkQueueSections(prev => prev.map(section => 


### PR DESCRIPTION
## Bug Fix

Fixes the issue where the chat list in the sidebar would still show chats from the previous project until the page was refreshed or a chat was clicked.

## Changes

- Added  in  component to monitor  prop changes
- Component now automatically fetches chats for new project when project switches
- Utilizes existing  state in chat store to detect project changes

## Testing

- [x] TypeScript compilation passes
- [x] Component properly responds to project ID changes
- [x] Chat list immediately updates when switching projects

## Files Changed

- : Added project change detection logic

Resolves the chat list refresh bug by ensuring the sidebar component responds to project changes rather than relying solely on parent component logic.