### PR TITLE
Fix: Remove duplicate message forwarding path

### DIFF
--- a/app/api/chats/[id]/messages/route.ts
+++ b/app/api/chats/[id]/messages/route.ts
@@ -5,62 +5,6 @@ import { broadcastToChat } from "@/lib/sse/connections"
 
 type RouteParams = { params: Promise<{ id: string }> }
 
-const OPENCLAW_HOOKS_URL = process.env.OPENCLAW_HOOKS_URL || "http://localhost:18789/hooks"
-const OPENCLAW_HOOKS_TOKEN = process.env.OPENCLAW_HOOKS_TOKEN || ""
-
-// Forward message to OpenClaw for agent processing
-async function forwardToOpenClaw(chatId: string, message: string, author: string) {
-  if (!OPENCLAW_HOOKS_TOKEN) {
-    console.warn("[Chat] No OPENCLAW_HOOKS_TOKEN configured, skipping forward")
-    return
-  }
-  
-  // Show Ada typing immediately
-  broadcastToChat(chatId, {
-    type: "typing",
-    data: { chatId, author: "ada", typing: true },
-  })
-  
-  try {
-    const response = await fetch(`${OPENCLAW_HOOKS_URL}/agent`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "Authorization": `Bearer ${OPENCLAW_HOOKS_TOKEN}`,
-      },
-      body: JSON.stringify({
-        message: `[Trap Chat from ${author}]\n\n${message}`,
-        name: "Trap",
-        sessionKey: "main",
-        wakeMode: "now",
-        deliver: true,
-        channel: "trap",
-        to: chatId,
-      }),
-    })
-    
-    if (!response.ok) {
-      const error = await response.text()
-      console.error("[Chat] Failed to forward to OpenClaw:", response.status, error)
-      // Clear typing on error
-      broadcastToChat(chatId, {
-        type: "typing",
-        data: { chatId, author: "ada", typing: false },
-      })
-    } else {
-      const data = await response.json()
-      console.log("[Chat] Forwarded to OpenClaw, runId:", data.runId)
-    }
-  } catch (error) {
-    console.error("[Chat] Error forwarding to OpenClaw:", error)
-    // Clear typing on error
-    broadcastToChat(chatId, {
-      type: "typing",
-      data: { chatId, author: "ada", typing: false },
-    })
-  }
-}
-
 // GET /api/chats/[id]/messages — Get messages (paginated)
 export async function GET(request: NextRequest, { params }: RouteParams) {
   const { id } = await params
@@ -175,12 +119,6 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     type: "message",
     data: message,
   })
-
-  // Forward non-Ada messages to OpenClaw via webhook (server-side, reliable)
-  // This ensures responses persist even if frontend disconnects
-  if (author !== "ada") {
-    forwardToOpenClaw(id, content, author).catch(console.error)
-  }
 
   return NextResponse.json({ message }, { status: 201 })
 }


### PR DESCRIPTION
## Problem
Messages were being sent through TWO redundant paths:

Path 1 (Frontend → OpenClaw WS): Frontend calls sendToOpenClaw() via WebSocket, OpenClaw processes and POSTs response back.

Path 2 (Backend forwarding): Frontend calls sendMessageToDb(), then messages/route.ts had forwardToOpenClaw() that POSTs to OpenClaw hooks, creating a SECOND delivery attempt.

## Solution
Removed Path 2 (backend forwarding):
- Deleted forwardToOpenClaw() function from messages/route.ts
- Removed redundant HTTP hooks forwarding  
- Kept Path 1 (WebSocket) as the single message delivery path

## Testing
- TypeScript compilation passes
- No new linting errors introduced
- Message flow simplified to single WebSocket path

Resolves duplicate message forwarding issue.