### PR TITLE
Fix: Replace crypto.randomUUID with browser-compatible fallback

### DIFF
--- a/components/chat/chat-input.tsx
+++ b/components/chat/chat-input.tsx
@@ -5,6 +5,21 @@ import { Send, Square, X } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { ContextIndicator } from "@/components/chat/context-indicator"
 
+// Generate a UUID with fallback for non-secure contexts
+function generateId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID()
+  }
+  // Fallback for browsers/contexts without crypto.randomUUID
+  if (typeof crypto !== 'undefined' && crypto.getRandomValues) {
+    return Array.from(crypto.getRandomValues(new Uint8Array(16)))
+      .map(b => b.toString(16).padStart(2, "0"))
+      .join("")
+  }
+  // Last resort fallback
+  return Date.now().toString(36) + Math.random().toString(36).substr(2)
+}
+
 interface ImagePreview {
   id: string
   file: File
@@ -76,7 +91,7 @@ export function ChatInput({
         if (!file) continue
         
         // Create preview
-        const imageId = crypto.randomUUID()
+        const imageId = generateId()
         const imageUrl = URL.createObjectURL(file)
         
         const imagePreview: ImagePreview = {


### PR DESCRIPTION
Fixes image paste functionality broken by `crypto.randomUUID is not a function` error.

## Problem
Pasting images in chat throws an error in browsers/contexts where `crypto.randomUUID()` is not available (non-HTTPS contexts or older browsers).

## Solution  
- Added `generateId()` function with three-tier fallback:
  1. `crypto.randomUUID()` when available
  2. `crypto.getRandomValues()` for broader browser support
  3. `Date.now() + Math.random()` as last resort

## Files Changed
- `components/chat/chat-input.tsx` - Replace direct crypto.randomUUID() call

## Testing
- TypeScript compilation passes ✅  
- No new lint errors introduced ✅
- Function provides unique IDs for image previews ✅

Resolves ticket: 359ee1eb-1ecd-433d-8fbd-a6343ff50c51