### PR TITLE
Fix ESLint errors to enable pre-commit hooks

### DIFF
--- a/app/api/signal/route.ts
+++ b/app/api/signal/route.ts
@@ -12,7 +12,7 @@ export async function GET(request: NextRequest) {
   const limit = parseInt(searchParams.get("limit") || "50")
   
   const whereConditions: string[] = []
-  const params: any[] = []
+  const params: unknown[] = []
   
   if (taskId) {
     whereConditions.push("task_id = ?")

--- a/app/api/work-loop/setup/route.ts
+++ b/app/api/work-loop/setup/route.ts
@@ -37,7 +37,7 @@ export async function GET() {
     const { stdout } = await execAsync("openclaw cron list --json")
     const cronData = JSON.parse(stdout)
     
-    const workLoopJobs = cronData.jobs?.filter((job: any) => 
+    const workLoopJobs = cronData.jobs?.filter((job: { jobId?: string }) => 
       job.jobId?.startsWith('trap-work-loop-')
     ) || []
     

--- a/app/projects/[slug]/chat/page.tsx
+++ b/app/projects/[slug]/chat/page.tsx
@@ -128,35 +128,40 @@ export default function ChatPage({ params }: PageProps) {
   // Subscribe to OpenClaw events (replaces useOpenClawChat hook)
   useEffect(() => {
     const unsubscribers = [
-      subscribe('chat.typing.start', (data: { runId: string; sessionKey?: string }) => {
+      subscribe('chat.typing.start', (data: unknown) => {
+        const typedData = data as { runId: string; sessionKey?: string }
         // Only handle events for our session or global events
-        if (!data.sessionKey || data.sessionKey === sessionKey) {
+        if (!typedData.sessionKey || typedData.sessionKey === sessionKey) {
           handleOpenClawTyping(true, "thinking")
         }
       }),
       
-      subscribe('chat.typing.end', (data: { sessionKey?: string } | undefined) => {
+      subscribe('chat.typing.end', (data: unknown) => {
+        const typedData = data as { sessionKey?: string } | undefined
         // Only handle events for our session or global events
-        if (!data?.sessionKey || data.sessionKey === sessionKey) {
+        if (!typedData?.sessionKey || typedData.sessionKey === sessionKey) {
           handleOpenClawTyping(false)
         }
       }),
       
-      subscribe('chat.delta', ({ delta, runId, sessionKey: eventSessionKey }: { delta: string; runId: string; sessionKey?: string }) => {
+      subscribe('chat.delta', (data: unknown) => {
+        const { delta, runId, sessionKey: eventSessionKey } = data as { delta: string; runId: string; sessionKey?: string }
         // Only handle events for our session or global events
         if (!eventSessionKey || eventSessionKey === sessionKey) {
           handleOpenClawDelta(delta, runId)
         }
       }),
       
-      subscribe('chat.message', ({ message, runId, sessionKey: eventSessionKey }: { message: { role: string; content: string | Array<{ type: string; text?: string }> }; runId: string; sessionKey?: string }) => {
+      subscribe('chat.message', (data: unknown) => {
+        const { message, runId, sessionKey: eventSessionKey } = data as { message: { role: string; content: string | Array<{ type: string; text?: string }> }; runId: string; sessionKey?: string }
         // Only handle events for our session or global events
         if (!eventSessionKey || eventSessionKey === sessionKey) {
           handleOpenClawMessage(message, runId)
         }
       }),
       
-      subscribe('chat.error', ({ error, sessionKey: eventSessionKey }: { error: string; runId: string; sessionKey?: string }) => {
+      subscribe('chat.error', (data: unknown) => {
+        const { error, sessionKey: eventSessionKey } = data as { error: string; runId: string; sessionKey?: string }
         // Only handle events for our session or global events
         if (!eventSessionKey || eventSessionKey === sessionKey) {
           console.error('[Chat] OpenClaw chat error:', error)

--- a/lib/hooks/use-chat-events.ts
+++ b/lib/hooks/use-chat-events.ts
@@ -25,6 +25,7 @@ export function useChatEvents({
   const reconnectTimeoutRef = useRef<NodeJS.Timeout | null>(null)
   const reconnectAttemptsRef = useRef(0)
   const wasDisconnectedRef = useRef(false)
+  const connectRef = useRef<(() => void) | null>(null)
   const maxReconnectAttempts = 10
   const baseReconnectDelay = 1000
 
@@ -90,13 +91,18 @@ export function useChatEvents({
         console.log(`[ChatEvents] Reconnecting in ${delay}ms (attempt ${reconnectAttemptsRef.current})`)
         
         reconnectTimeoutRef.current = setTimeout(() => {
-          connect()
+          connectRef.current?.()
         }, delay)
       } else {
         console.error("[ChatEvents] Max reconnect attempts reached")
       }
     }
   }, [chatId, enabled, onMessage, onTyping, onConnect, onRefreshMessages])
+
+  // Update the ref whenever connect changes
+  useEffect(() => {
+    connectRef.current = connect
+  }, [connect])
 
   useEffect(() => {
     connect()

--- a/lib/providers/openclaw-ws-provider.tsx
+++ b/lib/providers/openclaw-ws-provider.tsx
@@ -50,7 +50,7 @@ type ChatResponse = {
   errorMessage?: string;
 };
 
-type EventCallback = (data: any) => void;
+type EventCallback = (data: unknown) => void;
 type PendingRequest = {
   resolve: (value: unknown) => void;
   reject: (error: Error) => void;
@@ -102,7 +102,7 @@ export function OpenClawWSProvider({ children }: OpenClawWSProviderProps) {
   }, []);
 
   // Emit event to subscribers
-  const emitEvent = useCallback((event: string, data: any) => {
+  const emitEvent = useCallback((event: string, data: unknown) => {
     const subscribers = eventSubscribers.current.get(event);
     if (subscribers) {
       subscribers.forEach(callback => {

--- a/plugins/trap-signal.ts
+++ b/plugins/trap-signal.ts
@@ -18,8 +18,15 @@ type OpenClawPluginToolContext = {
   agentId?: string;
 };
 
+type OpenClawPluginTool = {
+  name: string;
+  description: string;
+  parameters: Record<string, unknown>;
+  execute: (params: unknown) => Promise<unknown>;
+};
+
 type OpenClawPluginApi = {
-  registerTool: (tool: any, opts?: { optional?: boolean }) => void;
+  registerTool: (tool: OpenClawPluginTool | ((ctx: OpenClawPluginToolContext) => OpenClawPluginTool), opts?: { optional?: boolean }) => void;
   logger: { info: (msg: string) => void };
 };
 

--- a/scripts/work-loop/setup-crons.ts
+++ b/scripts/work-loop/setup-crons.ts
@@ -6,10 +6,10 @@
 
 import { db } from "../../lib/db"
 import type { Project } from "../../lib/db/types"
-import { spawn } from "child_process"
+import { spawn, exec as execCallback } from "child_process"
 import { promisify } from "util"
 
-const exec = promisify(require("child_process").exec)
+const exec = promisify(execCallback)
 
 interface CronJob {
   jobId: string
@@ -113,8 +113,8 @@ async function listExistingCrons(): Promise<string[]> {
     const { stdout } = await exec(`openclaw cron list --json`)
     const cronData = JSON.parse(stdout)
     return cronData.jobs
-      .filter((job: any) => job.jobId?.startsWith('trap-work-loop-'))
-      .map((job: any) => job.jobId.replace('trap-work-loop-', ''))
+      .filter((job: { jobId?: string }) => job.jobId?.startsWith('trap-work-loop-'))
+      .map((job: { jobId: string }) => job.jobId.replace('trap-work-loop-', ''))
   } catch (error) {
     console.error("Failed to list existing crons:", error)
     return []


### PR DESCRIPTION
Resolves ticket 28985fb8-88d2-4e14-9154-30b570122cec

Fixed all 11 ESLint errors that were blocking pre-commit hooks:

**Changes:**
- Replaced `any` types with specific types in route handlers and providers
- Fixed React hooks errors (ref updates during render, temporal dead zone)  
- Replaced `require()` import with ES import in setup-crons.ts
- Added proper type casting for WebSocket event handlers

**Result:**
- ✅ `pnpm lint` now passes with 0 errors (22 warnings remaining)
- ✅ Pre-commit hooks enabled and working
- ✅ Type checking passes
- ✅ All tests green

Warnings can be addressed in separate tickets as noted in the original task.