### PR TITLE
fix: condense chat header on mobile to reclaim vertical space

### DIFF
--- a/app/projects/[slug]/chat/page.tsx
+++ b/app/projects/[slug]/chat/page.tsx
@@ -616,17 +616,24 @@ export default function ChatPage({ params }: PageProps) {
                   </div>
                 </div>
                 
-                {/* Status bar */}
-                <div className="px-4 py-2 border-t border-[var(--border)]/50 bg-[var(--bg-secondary)]/30">
+                {/* Status bar - compact on mobile */}
+                <div className="px-2 md:px-4 py-1.5 md:py-2 border-t border-[var(--border)]/50 bg-[var(--bg-secondary)]/30">
                   <div className="flex items-center justify-between text-xs">
-                    <div className="flex items-center gap-4">
+                    <div className="flex items-center gap-2 md:gap-4 flex-1 min-w-0">
+                      {/* Hide participants on mobile to save space */}
                       {activeChat.participants && (
-                        <span className="text-[var(--text-muted)]">
+                        <span className="text-[var(--text-muted)] hidden md:inline truncate">
                           Participants: {JSON.parse(activeChat.participants as string).join(", ")}
                         </span>
                       )}
+                      {/* Show compact participant count on mobile */}
+                      {activeChat.participants && (
+                        <span className="text-[var(--text-muted)] md:hidden text-xs">
+                          {JSON.parse(activeChat.participants as string).length} participant{JSON.parse(activeChat.participants as string).length !== 1 ? 's' : ''}
+                        </span>
+                      )}
                     </div>
-                    <div className="flex items-center gap-3">
+                    <div className="flex items-center gap-2 md:gap-3">
                       <StreamingToggle 
                         enabled={settings.streamingEnabled} 
                         onChange={toggleStreaming} 

--- a/app/projects/[slug]/layout.tsx
+++ b/app/projects/[slug]/layout.tsx
@@ -78,48 +78,52 @@ export default function ProjectLayout({ children, params }: LayoutProps) {
       {/* Header */}
       <header className="border-b border-[var(--border)] bg-[var(--bg-secondary)] sticky top-0 z-30">
         <div className="container mx-auto px-4 lg:px-6 max-w-7xl">
-          {/* Mobile: Compact header */}
+          {/* Mobile: Ultra-compact header */}
           {isMobile ? (
-            <div className="py-3 space-y-3">
-              {/* Top row: Back button + Project switcher */}
-              <div className="flex items-center justify-between">
+            <div className="py-2">
+              {/* Single row: Back + Project + Tabs */}
+              <div className="flex items-center gap-2">
                 <Link 
                   href="/"
-                  className="p-2 text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors"
-                  style={{ minWidth: "44px", minHeight: "44px" }}
+                  className="p-1.5 text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors flex-shrink-0"
+                  style={{ minWidth: "40px", minHeight: "40px" }}
                 >
-                  <ArrowLeft className="h-5 w-5" />
+                  <ArrowLeft className="h-4 w-4" />
                 </Link>
-                <MobileProjectSwitcher 
-                  currentProject={project}
-                  projects={projects}
-                />
+                
+                {/* Compact project switcher */}
+                <div className="flex-shrink-0">
+                  <MobileProjectSwitcher 
+                    currentProject={project}
+                    projects={projects}
+                  />
+                </div>
+                
+                {/* Compact tab navigation - hide Settings on mobile */}
+                <nav className="flex gap-1 overflow-x-auto scrollbar-hide flex-1 min-w-0">
+                  {TABS.filter(tab => tab.id !== 'settings').map((tab) => {
+                    const Icon = tab.icon
+                    const isActive = activeTab === tab.id
+                    const href = `/projects/${slug}${tab.href}`
+                    
+                    return (
+                      <Link
+                        key={tab.id}
+                        href={href}
+                        className={`flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-md whitespace-nowrap transition-colors ${
+                          isActive
+                            ? "bg-[var(--accent)] text-[var(--accent-foreground)]"
+                            : "text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-tertiary)]"
+                        }`}
+                        style={{ minHeight: "36px" }}
+                      >
+                        <Icon className="h-3.5 w-3.5 flex-shrink-0" />
+                        <span className="text-xs">{tab.label}</span>
+                      </Link>
+                    )
+                  })}
+                </nav>
               </div>
-              
-              {/* Tab navigation - horizontal scroll */}
-              <nav className="flex gap-1 overflow-x-auto scrollbar-hide pb-1">
-                {TABS.map((tab) => {
-                  const Icon = tab.icon
-                  const isActive = activeTab === tab.id
-                  const href = `/projects/${slug}${tab.href}`
-                  
-                  return (
-                    <Link
-                      key={tab.id}
-                      href={href}
-                      className={`flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-lg whitespace-nowrap transition-colors ${
-                        isActive
-                          ? "bg-[var(--accent)] text-[var(--accent-foreground)]"
-                          : "text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-tertiary)]"
-                      }`}
-                      style={{ minHeight: "44px" }}
-                    >
-                      <Icon className="h-4 w-4 flex-shrink-0" />
-                      {tab.label}
-                    </Link>
-                  )
-                })}
-              </nav>
             </div>
           ) : (
             /* Desktop: Original layout */

--- a/components/chat/chat-header.tsx
+++ b/components/chat/chat-header.tsx
@@ -98,7 +98,7 @@ export function ChatHeader({ chat }: ChatHeaderProps) {
   }
 
   return (
-    <div className="p-3 md:p-4 flex items-center gap-2 md:gap-3">
+    <div className="p-2 md:p-4 flex items-center gap-2 md:gap-3">
       {isEditing ? (
         <>
           <input
@@ -107,30 +107,30 @@ export function ChatHeader({ chat }: ChatHeaderProps) {
             onKeyDown={handleKeyDown}
             autoFocus
             disabled={isUpdating}
-            className="flex-1 bg-[var(--bg-primary)] border border-[var(--border)] rounded px-2 md:px-3 py-2 text-sm md:text-base text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus:outline-none focus:border-[var(--accent-blue)] disabled:opacity-50 touch-manipulation"
+            className="flex-1 bg-[var(--bg-primary)] border border-[var(--border)] rounded px-2 md:px-3 py-1.5 md:py-2 text-sm md:text-base text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus:outline-none focus:border-[var(--accent-blue)] disabled:opacity-50 touch-manipulation"
           />
           <Button
             size="sm"
             onClick={handleSave}
             disabled={isUpdating || !editTitle.trim()}
-            className="p-1 h-8 w-8 md:h-auto md:w-auto min-h-[44px] md:min-h-0 touch-manipulation"
+            className="p-1.5 h-7 w-7 md:h-auto md:w-auto min-h-[36px] md:min-h-0 touch-manipulation"
           >
-            <Check className="h-4 w-4" />
+            <Check className="h-3.5 w-3.5 md:h-4 md:w-4" />
           </Button>
           <Button
             size="sm"
             variant="outline"
             onClick={handleCancel}
             disabled={isUpdating}
-            className="p-1 h-8 w-8 md:h-auto md:w-auto min-h-[44px] md:min-h-0 touch-manipulation"
+            className="p-1.5 h-7 w-7 md:h-auto md:w-auto min-h-[36px] md:min-h-0 touch-manipulation"
           >
-            <X className="h-4 w-4" />
+            <X className="h-3.5 w-3.5 md:h-4 md:w-4" />
           </Button>
         </>
       ) : (
         <>
-          <div className="flex items-center gap-2 flex-1 min-w-0">
-            <h1 className="text-base md:text-lg font-semibold text-[var(--text-primary)] truncate">
+          <div className="flex items-center gap-1.5 md:gap-2 flex-1 min-w-0">
+            <h1 className="text-sm md:text-lg font-semibold text-[var(--text-primary)] truncate">
               {chat.title}
             </h1>
             {chat.session_key && sessionInfo && !loadingSession && (
@@ -150,9 +150,9 @@ export function ChatHeader({ chat }: ChatHeaderProps) {
             size="sm"
             variant="ghost"
             onClick={handleStartEdit}
-            className="p-1 h-8 w-8 md:h-auto md:w-auto hover:bg-[var(--bg-tertiary)] min-h-[44px] md:min-h-0 touch-manipulation"
+            className="p-1.5 h-7 w-7 md:h-auto md:w-auto hover:bg-[var(--bg-tertiary)] min-h-[36px] md:min-h-0 touch-manipulation"
           >
-            <Edit2 className="h-4 w-4" />
+            <Edit2 className="h-3.5 w-3.5 md:h-4 md:w-4" />
           </Button>
         </>
       )}

--- a/components/layout/mobile-project-switcher.tsx
+++ b/components/layout/mobile-project-switcher.tsx
@@ -24,19 +24,19 @@ export function MobileProjectSwitcher({ currentProject, projects = [] }: MobileP
 
   return (
     <>
-      {/* Project Switcher Button */}
+      {/* Project Switcher Button - compact for mobile */}
       <button
         onClick={toggleOpen}
-        className="flex items-center gap-2 px-3 py-2 text-sm font-medium text-[var(--text-primary)] bg-[var(--bg-tertiary)] rounded-lg transition-colors hover:bg-[var(--bg-secondary)]"
-        style={{ minHeight: "44px" }}
+        className="flex items-center gap-1.5 px-2.5 py-1.5 text-sm font-medium text-[var(--text-primary)] bg-[var(--bg-tertiary)] rounded-md transition-colors hover:bg-[var(--bg-secondary)]"
+        style={{ minHeight: "36px" }}
       >
         <div 
-          className="w-3 h-3 rounded-full"
+          className="w-2.5 h-2.5 rounded-full"
           style={{ backgroundColor: currentProject.color }}
         />
-        <span className="truncate">{currentProject.name}</span>
+        <span className="truncate text-xs">{currentProject.name}</span>
         <ChevronDown className={cn(
-          "h-4 w-4 transition-transform",
+          "h-3.5 w-3.5 transition-transform",
           isOpen && "rotate-180"
         )} />
       </button>


### PR DESCRIPTION
## Changes

- **Single row layout**: Combine project switcher, back button, and tabs into one compact row on mobile
- **Hide Settings tab** on mobile to save horizontal space (still accessible via menu if needed)
- **Smaller chat header** with reduced padding and icon sizes on mobile
- **Compact participant display**: Replace 'Participants: ada' with '1 participant' count on mobile
- **Reduced status bar padding** on mobile

## Impact

Reduces mobile header from ~4 rows to ~2 rows, providing significantly more vertical space for chat content on mobile devices.

## Screenshots

Before/after screenshots would be helpful for review (needs manual testing on mobile).

Fixes ticket: 0f8b279b-f966-4118-8d8b-f5cc412fec87