### PR TITLE
feat: add task_dependencies table

### DIFF
--- a/lib/db/schema.sql
+++ b/lib/db/schema.sql
@@ -138,3 +138,16 @@ CREATE INDEX IF NOT EXISTS idx_signals_kind ON signals(kind);
 CREATE INDEX IF NOT EXISTS idx_signals_blocking ON signals(blocking);
 CREATE INDEX IF NOT EXISTS idx_signals_responded ON signals(responded_at);
 CREATE INDEX IF NOT EXISTS idx_signals_created ON signals(created_at DESC);
+
+-- Task Dependencies
+CREATE TABLE IF NOT EXISTS task_dependencies (
+  id TEXT PRIMARY KEY,
+  task_id TEXT NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+  depends_on_id TEXT NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+  created_at INTEGER NOT NULL DEFAULT (unixepoch() * 1000),
+  UNIQUE(task_id, depends_on_id),
+  CHECK(task_id != depends_on_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_task_dependencies_task ON task_dependencies(task_id);
+CREATE INDEX IF NOT EXISTS idx_task_dependencies_depends ON task_dependencies(depends_on_id);


### PR DESCRIPTION
Implements the database schema for task dependencies.

## Changes
- Added `task_dependencies` table to `lib/db/schema.sql`

## Schema
- `id`: Primary key
- `task_id`: The task that has a dependency (FK to tasks, CASCADE delete)
- `depends_on_id`: The task that must be completed first (FK to tasks, CASCADE delete)
- `created_at`: Timestamp

## Constraints
- UNIQUE(task_id, depends_on_id) — prevents duplicate dependencies
- CHECK(task_id != depends_on_id) — prevents self-referencing

## Indexes
- idx_task_dependencies_task — for lookups by task_id
- idx_task_dependencies_depends — for lookups by depends_on_id

Ticket: 1cd14e2e-c91d-4ada-870a-877b1d2a3536