### PR TITLE
Remove participants display from chat header

### DIFF
--- a/app/projects/[slug]/chat/page.tsx
+++ b/app/projects/[slug]/chat/page.tsx
@@ -620,18 +620,7 @@ export default function ChatPage({ params }: PageProps) {
                 <div className="px-2 md:px-4 py-1.5 md:py-2 border-t border-[var(--border)]/50 bg-[var(--bg-secondary)]/30">
                   <div className="flex items-center justify-between text-xs">
                     <div className="flex items-center gap-2 md:gap-4 flex-1 min-w-0">
-                      {/* Hide participants on mobile to save space */}
-                      {activeChat.participants && (
-                        <span className="text-[var(--text-muted)] hidden md:inline truncate">
-                          Participants: {JSON.parse(activeChat.participants as string).join(", ")}
-                        </span>
-                      )}
-                      {/* Show compact participant count on mobile */}
-                      {activeChat.participants && (
-                        <span className="text-[var(--text-muted)] md:hidden text-xs">
-                          {JSON.parse(activeChat.participants as string).length} participant{JSON.parse(activeChat.participants as string).length !== 1 ? 's' : ''}
-                        </span>
-                      )}
+                      {/* Participants display removed - user knows who they're chatting with */}
                     </div>
                     <div className="flex items-center gap-2 md:gap-3">
                       <StreamingToggle 


### PR DESCRIPTION
Ticket: d21b3a72-4269-4785-beb5-2ddb86f9afa9

Removes the 'Participants: ada' text from the chat header status bar. The participant info is unnecessary since the user knows who they're chatting with.