### PR TITLE
fix: display effective model in session list when model override is applied

### DIFF
--- a/components/sessions/session-row.tsx
+++ b/components/sessions/session-row.tsx
@@ -105,12 +105,17 @@ export function SessionRow({ session }: SessionRowProps) {
         <td className="px-4 py-3">
           <Tooltip>
             <TooltipTrigger asChild>
-              <span className="text-sm truncate max-w-[150px] inline-block">
-                {session.model}
+              <span
+                className={`text-sm truncate max-w-[150px] inline-block ${session.effectiveModel && session.effectiveModel !== session.model ? 'text-primary font-medium' : ''}`}
+              >
+                {session.effectiveModel || session.model}
               </span>
             </TooltipTrigger>
             <TooltipContent>
-              <p>{session.model}</p>
+              <p>{session.effectiveModel || session.model}</p>
+              {session.effectiveModel && session.effectiveModel !== session.model && (
+                <p className="text-xs text-muted-foreground">Override from {session.model}</p>
+              )}
             </TooltipContent>
           </Tooltip>
         </td>

--- a/components/sessions/session-table.tsx
+++ b/components/sessions/session-table.tsx
@@ -42,6 +42,7 @@ interface SessionRowData {
   name: string;
   type: SessionType;
   model: string;
+  effectiveModel?: string;
   status: SessionStatus;
   tokens: {
     input: number;
@@ -134,13 +135,20 @@ const columns: ColumnDef<SessionRowData>[] = [
     ),
   },
   {
-    accessorKey: 'model',
+    accessorKey: 'effectiveModel',
     header: ({ column }) => <SortHeader column={column}>Model</SortHeader>,
-    cell: ({ row }) => (
-      <span className="text-sm truncate max-w-[180px] inline-block" title={row.original.model}>
-        {row.original.model}
-      </span>
-    ),
+    cell: ({ row }) => {
+      const effectiveModel = row.original.effectiveModel || row.original.model;
+      const hasOverride = row.original.effectiveModel && row.original.effectiveModel !== row.original.model;
+      return (
+        <span
+          className={`text-sm truncate max-w-[180px] inline-block ${hasOverride ? 'text-primary font-medium' : ''}`}
+          title={effectiveModel}
+        >
+          {effectiveModel}
+        </span>
+      );
+    },
   },
   {
     accessorKey: 'status',
@@ -250,8 +258,11 @@ function SessionCard({
           <div className="space-y-2 text-sm">
             <div className="flex justify-between">
               <span className="text-muted-foreground">Model:</span>
-              <span className="text-right truncate ml-2" title={session.model}>
-                {session.model}
+              <span
+                className={`text-right truncate ml-2 ${session.effectiveModel && session.effectiveModel !== session.model ? 'text-primary font-medium' : ''}`}
+                title={session.effectiveModel || session.model}
+              >
+                {session.effectiveModel || session.model}
               </span>
             </div>
             <div className="flex justify-between">

--- a/components/sessions/sessions-list.tsx
+++ b/components/sessions/sessions-list.tsx
@@ -115,7 +115,7 @@ export function SessionsList({
   description,
 }: SessionsListProps) {
   const router = useRouter();
-  const { connected, connecting, listSessions } = useOpenClawRpc();
+  const { connected, connecting, listSessionsWithEffectiveModel } = useOpenClawRpc();
   const refreshIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   
   const {
@@ -133,16 +133,16 @@ export function SessionsList({
     ? filterProjectSessions(allSessions, projectSlug)
     : allSessions;
 
-  // Fetch sessions via WebSocket RPC
+  // Fetch sessions via WebSocket RPC with effective model
   const fetchSessions = useCallback(async (isInitialLoad = false) => {
     if (!connected) return;
-    
+
     if (isInitialLoad) {
       setLoading(true);
     }
-    
+
     try {
-      const response = await listSessions({ limit: 10 });
+      const response = await listSessionsWithEffectiveModel({ limit: 10 });
       setSessions(response.sessions);
       if (isInitialLoad) {
         setInitialized(true);
@@ -156,7 +156,7 @@ export function SessionsList({
         setLoading(false);
       }
     }
-  }, [connected, listSessions, setSessions, setLoading, setInitialized, setError]);
+  }, [connected, listSessionsWithEffectiveModel, setSessions, setLoading, setInitialized, setError]);
 
   // Reset initialization on mount to ensure fresh data
   useEffect(() => {
@@ -193,10 +193,10 @@ export function SessionsList({
 
   const handleRefresh = async () => {
     if (!connected) return;
-    
+
     setLoading(true);
     try {
-      const response = await listSessions({ limit: 10 });
+      const response = await listSessionsWithEffectiveModel({ limit: 10 });
       setSessions(response.sessions);
       setError(null);
     } catch (err) {

--- a/lib/types/session.ts
+++ b/lib/types/session.ts
@@ -12,6 +12,11 @@ export interface Session {
   name: string;
   type: SessionType;
   model: string;
+  /**
+   * The actual model used for API calls, extracted from recent messages.
+   * This may differ from `model` when a model override is applied (e.g., via cron jobs).
+   */
+  effectiveModel?: string;
   status: SessionStatus;
   parentId?: string;
   createdAt: string;


### PR DESCRIPTION
## Summary

Fixes the session list to display the actual model being used for API calls instead of the agent default model.

## Problem

When cron jobs or spawn params apply a model override (e.g., ), the session list was still showing the agent's default model (e.g., ). The actual API calls used the correct model (verified via cost data), but the UI was misleading.

## Solution

Added a new  hook that:
1. Fetches sessions via 
2. Fetches recent messages via  for each session
3. Extracts the actual model from message metadata
4. Adds an  field to the Session type

The UI now displays  (falling back to  if unavailable) and visually highlights when a model override is active.

## Changes

- : Added  function
- : Added  field to Session interface
- : Updated to use new function
- : Display  with visual indicator for overrides
- : Same treatment for the row component

## Acceptance Criteria

- [x] Session list displays the model actually being used for API calls
- [x] Model override from cron/spawn is reflected in the UI
- [x] Visual indicator (primary color + tooltip) when model override is active

Ticket: f7466674-098f-4c60-b1db-a7dfbf5130f9