### PR TITLE
feat: migrate task-store to Convex with real-time subscriptions

### DIFF
--- a/components/board/board.tsx
+++ b/components/board/board.tsx
@@ -1,14 +1,14 @@
 "use client"
 
-import { useEffect, useState } from "react"
+import { useState, useMemo } from "react"
 import { DragDropContext, type DropResult } from "@hello-pangea/dnd"
-import { Plus, Eye, EyeOff, Wifi, WifiOff } from "lucide-react"
-import { useTaskStore } from "@/lib/stores/task-store"
-import { useWebSocket } from "@/lib/websocket/client"
+import { Plus, Eye, EyeOff } from "lucide-react"
+import { useTasks, useMoveTask, getTasksByStatus } from "@/lib/stores/task-store"
 import { Column } from "./column"
 import { MobileBoard } from "./mobile-board"
 import { useMobileDetection } from "./use-mobile-detection"
 import type { Task, TaskStatus } from "@/lib/db/types"
+import type { Id } from "@/convex/_generated/server"
 
 interface BoardProps {
   projectId: string
@@ -25,26 +25,9 @@ const COLUMNS: { status: TaskStatus; title: string; color: string; showAdd: bool
 ]
 
 export function Board({ projectId, onTaskClick, onAddTask }: BoardProps) {
-  const { 
-    tasks, 
-    loading, 
-    error, 
-    fetchTasks, 
-    getTasksByStatus, 
-    moveTask,
-    handleWebSocketMessage,
-    setWebSocketConnected
-  } = useTaskStore()
+  const tasks = useTasks(projectId as Id<"projects">)
+  const moveTask = useMoveTask()
   const isMobile = useMobileDetection(768)
-  
-  // WebSocket connection for real-time updates
-  const { connected: wsConnected, subscribers } = useWebSocket({
-    projectId,
-    userId: 'anonymous', // TODO: Get actual user ID from auth
-    onMessage: handleWebSocketMessage,
-    onConnect: () => setWebSocketConnected(true),
-    onDisconnect: () => setWebSocketConnected(false)
-  })
   
   // Column visibility state - initialize from localStorage
   const [showDone, setShowDone] = useState(() => {
@@ -62,14 +45,29 @@ export function Board({ projectId, onTaskClick, onAddTask }: BoardProps) {
   })
   
   // Save preferences to localStorage whenever they change
-  useEffect(() => {
-    const prefs = { showDone }
+  const toggleShowDone = () => {
+    const newValue = !showDone
+    setShowDone(newValue)
+    const prefs = { showDone: newValue }
     localStorage.setItem(`board-prefs-${projectId}`, JSON.stringify(prefs))
-  }, [projectId, showDone])
+  }
 
-  useEffect(() => {
-    fetchTasks(projectId)
-  }, [fetchTasks, projectId])
+  // Get tasks by status - memoized for performance
+  const tasksByStatus = useMemo(() => {
+    const result: Record<TaskStatus, Task[]> = {
+      backlog: [],
+      ready: [],
+      in_progress: [],
+      review: [],
+      done: [],
+    }
+    if (tasks) {
+      for (const col of COLUMNS) {
+        result[col.status] = getTasksByStatus(tasks, col.status)
+      }
+    }
+    return result
+  }, [tasks])
   
   // Determine which columns should be visible
   const getVisibleColumns = () => {
@@ -86,18 +84,14 @@ export function Board({ projectId, onTaskClick, onAddTask }: BoardProps) {
       
       // Show Review column only if it has tasks (auto-hide when empty)
       if (col.status === "review") {
-        return getTasksByStatus("review").length > 0
+        return tasksByStatus.review.length > 0
       }
       
       return true
     })
   }
-  
-  const toggleShowDone = () => {
-    setShowDone(!showDone)
-  }
 
-  const handleDragEnd = (result: DropResult) => {
+  const handleDragEnd = async (result: DropResult) => {
     const { destination, source, draggableId } = result
 
     // Dropped outside a column
@@ -113,16 +107,28 @@ export function Board({ projectId, onTaskClick, onAddTask }: BoardProps) {
 
     const newStatus = destination.droppableId as TaskStatus
 
-    // If same column, it's a reorder operation
-    if (destination.droppableId === source.droppableId) {
-      moveTask(draggableId, newStatus, destination.index)
-    } else {
-      // Moving to different column
-      moveTask(draggableId, newStatus)
+    try {
+      // If same column, it's a reorder operation
+      if (destination.droppableId === source.droppableId) {
+        await moveTask({
+          id: draggableId as Id<"tasks">,
+          status: newStatus,
+          position: destination.index,
+        })
+      } else {
+        // Moving to different column
+        await moveTask({
+          id: draggableId as Id<"tasks">,
+          status: newStatus,
+        })
+      }
+    } catch (error) {
+      console.error("Failed to move task:", error)
     }
   }
 
-  if (loading && tasks.length === 0) {
+  // Loading state
+  if (tasks === undefined) {
     return (
       <div className="flex gap-4 overflow-x-auto pb-4">
         {COLUMNS.map((col) => (
@@ -135,27 +141,17 @@ export function Board({ projectId, onTaskClick, onAddTask }: BoardProps) {
     )
   }
 
-  if (error) {
-    return (
-      <div className="text-center py-8 text-red-500">
-        {error}
-      </div>
-    )
-  }
-
   // Mobile view
   if (isMobile) {
     return (
       <MobileBoard
         columns={getVisibleColumns()}
-        getTasksByStatus={getTasksByStatus}
+        tasksByStatus={tasksByStatus}
         onTaskClick={onTaskClick}
         onAddTask={onAddTask}
         onDragEnd={handleDragEnd}
         showDone={showDone}
         onToggleShowDone={toggleShowDone}
-        wsConnected={wsConnected}
-        subscribers={subscribers}
       />
     )
   }
@@ -169,22 +165,9 @@ export function Board({ projectId, onTaskClick, onAddTask }: BoardProps) {
           <h2 className="text-xl font-semibold text-[var(--text-primary)]">
             Board
           </h2>
-          {/* WebSocket connection status */}
-          <div className="flex items-center gap-1" title={wsConnected ? "Connected - real-time updates active" : "Disconnected - changes may not appear immediately"}>
-            {wsConnected ? (
-              <Wifi className="h-4 w-4 text-green-500" />
-            ) : (
-              <WifiOff className="h-4 w-4 text-red-500" />
-            )}
-            <span className="text-xs text-[var(--text-secondary)]">
-              {wsConnected ? 'Live' : 'Offline'}
-            </span>
-            {subscribers.length > 0 && (
-              <span className="text-xs text-[var(--text-secondary)]">
-                • {subscribers.length} viewing
-              </span>
-            )}
-          </div>
+          <span className="text-xs text-[var(--text-secondary)]">
+            Real-time sync via Convex
+          </span>
         </div>
         <div className="flex items-center gap-3">
           {/* Show Done toggle */}
@@ -218,7 +201,7 @@ export function Board({ projectId, onTaskClick, onAddTask }: BoardProps) {
               status={col.status}
               title={col.title}
               color={col.color}
-              tasks={getTasksByStatus(col.status)}
+              tasks={tasksByStatus[col.status]}
               onTaskClick={onTaskClick}
               onAddTask={() => onAddTask(col.status)}
               showAddButton={col.showAdd}

--- a/components/board/create-task-modal.tsx
+++ b/components/board/create-task-modal.tsx
@@ -12,8 +12,9 @@ import {
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
-import { useTaskStore, type CreateTaskData } from "@/lib/stores/task-store"
+import { useCreateTask, type CreateTaskData } from "@/lib/stores/task-store"
 import type { TaskStatus, TaskRole } from "@/lib/db/types"
+import type { Id } from "@/convex/_generated/server"
 
 interface CreateTaskModalProps {
   open: boolean
@@ -51,7 +52,7 @@ export function CreateTaskModal({
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
   
-  const createTask = useTaskStore((s) => s.createTask)
+  const createTask = useCreateTask()
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -59,7 +60,7 @@ export function CreateTaskModal({
     setLoading(true)
 
     const data: CreateTaskData = {
-      project_id: projectId,
+      project_id: projectId as Id<"projects">,
       title: title.trim(),
       description: description.trim() || undefined,
       status: initialStatus,

--- a/components/board/mobile-board.tsx
+++ b/components/board/mobile-board.tsx
@@ -2,32 +2,28 @@
 
 import { useState, useEffect, useCallback } from "react"
 import { DragDropContext, type DropResult } from "@hello-pangea/dnd"
-import { Plus, ChevronLeft, ChevronRight, Eye, EyeOff, Wifi, WifiOff } from "lucide-react"
+import { Plus, ChevronLeft, ChevronRight, Eye, EyeOff } from "lucide-react"
 import type { Task, TaskStatus } from "@/lib/db/types"
 import { Column } from "./column"
 
 interface MobileBoardProps {
   columns: { status: TaskStatus; title: string; color: string; showAdd: boolean }[]
-  getTasksByStatus: (status: TaskStatus) => Task[]
+  tasksByStatus: Record<TaskStatus, Task[]>
   onTaskClick: (task: Task) => void
   onAddTask: (status: TaskStatus) => void
   onDragEnd: (result: DropResult) => void
   showDone?: boolean
   onToggleShowDone?: () => void
-  wsConnected?: boolean
-  subscribers?: string[]
 }
 
 export function MobileBoard({ 
   columns, 
-  getTasksByStatus, 
+  tasksByStatus, 
   onTaskClick, 
   onAddTask,
   onDragEnd,
   showDone = false,
   onToggleShowDone,
-  wsConnected = false,
-  subscribers = []
 }: MobileBoardProps) {
   const [activeColumnIndex, setActiveColumnIndex] = useState(0)
   const activeColumn = columns[activeColumnIndex]
@@ -140,22 +136,9 @@ export function MobileBoard({
           <h2 className="text-xl font-semibold text-[var(--text-primary)]">
             Board
           </h2>
-          {/* WebSocket connection status for mobile */}
-          <div className="flex items-center gap-1" title={wsConnected ? "Connected - real-time updates active" : "Disconnected - changes may not appear immediately"}>
-            {wsConnected ? (
-              <Wifi className="h-3 w-3 text-green-500" />
-            ) : (
-              <WifiOff className="h-3 w-3 text-red-500" />
-            )}
-            <span className="text-xs text-[var(--text-secondary)]">
-              {wsConnected ? 'Live' : 'Off'}
-            </span>
-            {subscribers.length > 0 && (
-              <span className="text-xs text-[var(--text-secondary)]">
-                • {subscribers.length}
-              </span>
-            )}
-          </div>
+          <span className="text-xs text-[var(--text-secondary)]">
+            Live
+          </span>
         </div>
         <div className="flex items-center gap-2">
           {/* Show Done toggle for mobile */}
@@ -207,7 +190,7 @@ export function MobileBoard({
               />
               <span>{column.title}</span>
               <span className="text-xs opacity-75">
-                {getTasksByStatus(column.status).length}
+                {tasksByStatus[column.status].length}
               </span>
             </button>
           ))}
@@ -230,7 +213,7 @@ export function MobileBoard({
             status={activeColumn.status}
             title={activeColumn.title}
             color={activeColumn.color}
-            tasks={getTasksByStatus(activeColumn.status)}
+            tasks={tasksByStatus[activeColumn.status]}
             onTaskClick={onTaskClick}
             onAddTask={() => onAddTask(activeColumn.status)}
             showAddButton={activeColumn.showAdd}

--- a/components/board/task-modal.tsx
+++ b/components/board/task-modal.tsx
@@ -3,12 +3,13 @@
 import { useState, useEffect, useCallback } from "react"
 import { X, Trash2, Clock, Calendar, MessageSquare, Send, Loader2, Link2, CheckCircle2, Circle, Plus } from "lucide-react"
 import { Button } from "@/components/ui/button"
-import { useTaskStore } from "@/lib/stores/task-store"
+import { useUpdateTask, useDeleteTask, useTask } from "@/lib/stores/task-store"
 import { CommentThread } from "./comment-thread"
 import { CommentInput } from "./comment-input"
 import { DependencyPicker } from "./dependency-picker"
 import { useDependencies } from "@/lib/hooks/use-dependencies"
 import type { Task, TaskStatus, TaskPriority, TaskRole, Comment, DispatchStatus, TaskDependencySummary } from "@/lib/db/types"
+import type { Id } from "@/convex/_generated/server"
 
 interface TaskModalProps {
   task: Task | null
@@ -73,33 +74,16 @@ export function TaskModal({ task, open, onOpenChange, onDelete }: TaskModalProps
   const [pickerOpen, setPickerOpen] = useState(false)
   const [removingDepId, setRemovingDepId] = useState<string | null>(null)
   
-  const updateTask = useTaskStore((s) => s.updateTask)
-  const deleteTask = useTaskStore((s) => s.deleteTask)
+  const updateTask = useUpdateTask()
+  const deleteTask = useDeleteTask()
+
+  // Fetch task with comments via Convex
+  const taskWithComments = useTask(task?.id as Id<"tasks"> | null)
 
   // Dependencies
   const { dependencies, refresh: refreshDependencies } = useDependencies(task?.id || null)
   const dependsOn = dependencies.depends_on
   const blocks = dependencies.blocks
-
-  // Keyboard shortcut for dependency picker
-  useEffect(() => {
-    if (!open || !task) return
-
-    const handleKeyDown = (e: KeyboardEvent) => {
-      // 'd' key to open dependency picker (when not typing in an input)
-      if (e.key === 'd' && !e.ctrlKey && !e.metaKey && !e.altKey) {
-        const target = e.target as HTMLElement
-        const isInput = target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable
-        if (!isInput && !pickerOpen) {
-          e.preventDefault()
-          setPickerOpen(true)
-        }
-      }
-    }
-
-    window.addEventListener('keydown', handleKeyDown)
-    return () => window.removeEventListener('keydown', handleKeyDown)
-  }, [open, task, pickerOpen])
 
   // Load task data when modal opens
   useEffect(() => {
@@ -122,24 +106,35 @@ export function TaskModal({ task, open, onOpenChange, onDelete }: TaskModalProps
       setTags(taskTags.join(", "))
       setShowDeleteConfirm(false)
       setDispatchStatus(task.dispatch_status)
-      
-      // Fetch comments
-      fetchComments(task.id)
     }
   }, [task, open])
 
-  const fetchComments = async (taskId: string) => {
-    setLoadingComments(true)
-    try {
-      const response = await fetch(`/api/tasks/${taskId}/comments`)
-      if (response.ok) {
-        const data = await response.json()
-        setComments(data.comments)
-      }
-    } finally {
-      setLoadingComments(false)
+  // Update comments when task data changes
+  useEffect(() => {
+    if (taskWithComments?.comments) {
+      setComments(taskWithComments.comments)
     }
-  }
+  }, [taskWithComments?.comments])
+
+  // Keyboard shortcut for dependency picker
+  useEffect(() => {
+    if (!open || !task) return
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      // 'd' key to open dependency picker (when not typing in an input)
+      if (e.key === 'd' && !e.ctrlKey && !e.metaKey && !e.altKey) {
+        const target = e.target as HTMLElement
+        const isInput = target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable
+        if (!isInput && !pickerOpen) {
+          e.preventDefault()
+          setPickerOpen(true)
+        }
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [open, task, pickerOpen])
 
   const handleAddComment = async (content: string) => {
     if (!task) return
@@ -170,15 +165,16 @@ export function TaskModal({ task, open, onOpenChange, onDelete }: TaskModalProps
     const newStatus = status
     
     try {
-      await updateTask(task.id, {
+      await updateTask({
+        id: task.id as Id<"tasks">,
         title: title.trim(),
-        description: description.trim() || null,
+        description: description.trim() || undefined,
         status,
         priority,
-        role: role === "any" ? null : role,
-        assignee: assignee || null,
-        requires_human_review: requiresHumanReview ? 1 : 0,
-        tags: tagArray.length > 0 ? JSON.stringify(tagArray) : null,
+        role: role === "any" ? undefined : role,
+        assignee: assignee || undefined,
+        requires_human_review: requiresHumanReview,
+        tags: tagArray.length > 0 ? tagArray : undefined,
       })
       
       // Auto-create status change comment if status changed
@@ -199,6 +195,8 @@ export function TaskModal({ task, open, onOpenChange, onDelete }: TaskModalProps
       }
       
       onOpenChange(false)
+    } catch (error) {
+      console.error("Failed to update task:", error)
     } finally {
       setSaving(false)
     }
@@ -207,7 +205,7 @@ export function TaskModal({ task, open, onOpenChange, onDelete }: TaskModalProps
   const handleDelete = async () => {
     if (!task) return
     
-    await deleteTask(task.id)
+    await deleteTask({ id: task.id as Id<"tasks"> })
     onDelete?.(task.id)
     onOpenChange(false)
   }
@@ -240,9 +238,6 @@ export function TaskModal({ task, open, onOpenChange, onDelete }: TaskModalProps
             author_type: "human",
           }),
         })
-        
-        // Refresh comments
-        fetchComments(task.id)
       } else {
         const data = await response.json()
         console.error("Dispatch failed:", data.error)
@@ -394,16 +389,10 @@ export function TaskModal({ task, open, onOpenChange, onDelete }: TaskModalProps
                     </label>
                   </div>
                   
-                  {loadingComments ? (
-                    <div className="text-sm text-[var(--text-muted)]">Loading comments...</div>
-                  ) : (
-                    <>
-                      <div className="max-h-[500px] overflow-y-auto mb-4">
-                        <CommentThread comments={comments} />
-                      </div>
-                      <CommentInput onSubmit={handleAddComment} />
-                    </>
-                  )}
+                  <div className="max-h-[500px] overflow-y-auto mb-4">
+                    <CommentThread comments={comments} />
+                  </div>
+                  <CommentInput onSubmit={handleAddComment} />
                 </div>
               </div>
               

--- a/lib/stores/task-store.ts
+++ b/lib/stores/task-store.ts
@@ -1,28 +1,19 @@
 import { create } from "zustand"
+import { useQuery, useMutation } from "convex/react"
+import { api } from "@/convex/_generated/api"
 import type { Task, TaskStatus, TaskRole } from "@/lib/db/types"
-import type { WebSocketMessage } from "@/lib/websocket/server"
+import type { Id } from "@/convex/_generated/server"
 
 interface TaskState {
-  tasks: Task[]
+  // UI state only - data comes from Convex
+  currentProjectId: string | null
   loading: boolean
   error: string | null
-  currentProjectId: string | null
-  wsConnected: boolean
   
   // Actions
-  fetchTasks: (projectId: string) => Promise<void>
-  createTask: (data: CreateTaskData) => Promise<Task>
-  updateTask: (id: string, updates: Partial<Task>) => Promise<Task>
-  deleteTask: (id: string) => Promise<void>
-  moveTask: (id: string, status: TaskStatus, newIndex?: number) => Promise<void>
-  reorderTask: (id: string, status: TaskStatus, newIndex: number) => Promise<void>
-  
-  // WebSocket handlers
-  handleWebSocketMessage: (message: WebSocketMessage) => void
-  setWebSocketConnected: (connected: boolean) => void
-  
-  // Selectors
-  getTasksByStatus: (status: TaskStatus) => Task[]
+  setCurrentProjectId: (id: string | null) => void
+  setLoading: (loading: boolean) => void
+  setError: (error: string | null) => void
 }
 
 export interface CreateTaskData {
@@ -37,207 +28,108 @@ export interface CreateTaskData {
   tags?: string[]
 }
 
-export const useTaskStore = create<TaskState>((set, get) => ({
-  tasks: [],
+export const useTaskStore = create<TaskState>((set) => ({
+  currentProjectId: null,
   loading: false,
   error: null,
-  currentProjectId: null,
-  wsConnected: false,
 
-  fetchTasks: async (projectId) => {
-    set({ loading: true, error: null, currentProjectId: projectId })
-    
-    const response = await fetch(`/api/tasks?projectId=${projectId}`)
-    
-    if (!response.ok) {
-      const data = await response.json()
-      set({ loading: false, error: data.error || "Failed to fetch tasks" })
-      throw new Error(data.error || "Failed to fetch tasks")
-    }
-    
-    const data = await response.json()
-    set({ tasks: data.tasks, loading: false })
-  },
-
-  createTask: async (taskData) => {
-    const response = await fetch("/api/tasks", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(taskData),
-    })
-    
-    if (!response.ok) {
-      const data = await response.json()
-      throw new Error(data.error || "Failed to create task")
-    }
-    
-    const data = await response.json()
-    
-    set((state) => ({
-      tasks: [data.task, ...state.tasks],
-    }))
-    
-    return data.task
-  },
-
-  updateTask: async (id, updates) => {
-    const response = await fetch(`/api/tasks/${id}`, {
-      method: "PATCH",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(updates),
-    })
-    
-    if (!response.ok) {
-      const data = await response.json()
-      throw new Error(data.error || "Failed to update task")
-    }
-    
-    const data = await response.json()
-    
-    set((state) => ({
-      tasks: state.tasks.map((t) => t.id === id ? data.task : t),
-    }))
-    
-    return data.task
-  },
-
-  deleteTask: async (id) => {
-    const response = await fetch(`/api/tasks/${id}`, {
-      method: "DELETE",
-    })
-    
-    if (!response.ok) {
-      const data = await response.json()
-      throw new Error(data.error || "Failed to delete task")
-    }
-    
-    set((state) => ({
-      tasks: state.tasks.filter((t) => t.id !== id),
-    }))
-  },
-
-  moveTask: async (id, status, newIndex) => {
-    const task = get().tasks.find(t => t.id === id)
-    if (!task) return
-    
-    const isSameColumn = task.status === status
-    
-    try {
-      if (isSameColumn && newIndex !== undefined) {
-        // Call reorder API - no optimistic update to avoid position conflicts
-        const response = await fetch("/api/tasks/reorder", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            project_id: get().currentProjectId,
-            status,
-            task_id: id,
-            new_index: newIndex,
-          }),
-        })
-        
-        if (!response.ok) {
-          const data = await response.json()
-          throw new Error(data.error || "Failed to reorder task")
-        }
-        
-        // Refresh tasks from server to get correct positions
-        await get().fetchTasks(get().currentProjectId!)
-      } else {
-        // Moving to different column - optimistic update for status change only
-        const originalTasks = get().tasks
-        set((state) => ({
-          tasks: state.tasks.map((t) => 
-            t.id === id ? { ...t, status, updated_at: Date.now() } : t
-          )
-        }))
-        
-        try {
-          // Call move API (regular status update)
-          const response = await fetch(`/api/tasks/${id}`, {
-            method: "PATCH",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ status }),
-          })
-          
-          if (!response.ok) {
-            const data = await response.json()
-            throw new Error(data.error || "Failed to move task")
-          }
-          
-          // Refresh tasks from server to get updated positions for new column
-          await get().fetchTasks(get().currentProjectId!)
-        } catch (error) {
-          // Revert to original state on failure
-          set({ tasks: originalTasks })
-          throw error
-        }
-      }
-    } catch (error) {
-      throw error
-    }
-  },
-
-  reorderTask: async (id, status, newIndex) => {
-    // This is just an alias to moveTask with newIndex
-    await get().moveTask(id, status, newIndex)
-  },
-
-  handleWebSocketMessage: (message: WebSocketMessage) => {
-    const { currentProjectId } = get()
-    
-    switch (message.type) {
-      case 'task:created':
-        // Only add if it belongs to current project
-        if (message.data.project_id === currentProjectId) {
-          set((state) => ({
-            tasks: [message.data, ...state.tasks]
-          }))
-        }
-        break
-        
-      case 'task:updated':
-        // Only update if it belongs to current project
-        if (message.data.project_id === currentProjectId) {
-          set((state) => ({
-            tasks: state.tasks.map((t) => 
-              t.id === message.data.id ? message.data : t
-            )
-          }))
-        }
-        break
-        
-      case 'task:deleted':
-        // Only remove if it belongs to current project
-        if (message.data.projectId === currentProjectId) {
-          set((state) => ({
-            tasks: state.tasks.filter((t) => t.id !== message.data.id)
-          }))
-        }
-        break
-        
-      case 'task:moved':
-        // Only update if it belongs to current project
-        if (message.data.projectId === currentProjectId) {
-          set((state) => ({
-            tasks: state.tasks.map((t) => 
-              t.id === message.data.id 
-                ? { ...t, status: message.data.status, updated_at: Date.now() } 
-                : t
-            )
-          }))
-        }
-        break
-    }
-  },
-
-  setWebSocketConnected: (connected: boolean) => {
-    set({ wsConnected: connected })
-  },
-
-  getTasksByStatus: (status) => {
-    return get().tasks
-      .filter((t) => t.status === status)
-      .sort((a, b) => a.position - b.position)
-  },
+  setCurrentProjectId: (id) => set({ currentProjectId: id }),
+  setLoading: (loading) => set({ loading }),
+  setError: (error) => set({ error }),
 }))
+
+// ============================================
+// Convex Hooks for Data Fetching
+// ============================================
+
+/**
+ * Hook to fetch tasks by project with optional status filter
+ * Uses Convex for real-time subscriptions
+ */
+export function useTasks(projectId: Id<"projects"> | null, status?: TaskStatus) {
+  return useQuery(
+    api.tasks.getByProject,
+    projectId ? { projectId, status } : "skip"
+  )
+}
+
+/**
+ * Hook to fetch a single task by ID with its comments
+ */
+export function useTask(id: Id<"tasks"> | null) {
+  return useQuery(api.tasks.getById, id ? { id } : "skip")
+}
+
+/**
+ * Hook to fetch tasks assigned to a specific user
+ */
+export function useTasksByAssignee(assignee: string | null) {
+  return useQuery(
+    api.tasks.getByAssignee,
+    assignee ? { assignee } : "skip"
+  )
+}
+
+/**
+ * Hook to fetch a task with its dependencies
+ */
+export function useTaskWithDependencies(id: Id<"tasks"> | null) {
+  return useQuery(
+    api.tasks.getWithDependencies,
+    id ? { id } : "skip"
+  )
+}
+
+// ============================================
+// Convex Mutations
+// ============================================
+
+/**
+ * Hook to create a new task
+ */
+export function useCreateTask() {
+  return useMutation(api.tasks.create)
+}
+
+/**
+ * Hook to update a task
+ */
+export function useUpdateTask() {
+  return useMutation(api.tasks.update)
+}
+
+/**
+ * Hook to move a task to a different status/column
+ */
+export function useMoveTask() {
+  return useMutation(api.tasks.move)
+}
+
+/**
+ * Hook to reorder a task within its current column
+ */
+export function useReorderTask() {
+  return useMutation(api.tasks.reorder)
+}
+
+/**
+ * Hook to delete a task
+ */
+export function useDeleteTask() {
+  return useMutation(api.tasks.deleteTask)
+}
+
+// ============================================
+// Legacy selector helpers (for compatibility)
+// ============================================
+
+/**
+ * Get tasks filtered by status, sorted by position
+ * Note: This is a helper function - use useTasks() hook for reactive data
+ */
+export function getTasksByStatus(tasks: Task[] | undefined, status: TaskStatus): Task[] {
+  if (!tasks) return []
+  return tasks
+    .filter((t) => t.status === status)
+    .sort((a, b) => a.position - b.position)
+}


### PR DESCRIPTION
## Summary

Migrate the task store from SQLite-based implementation to Convex with real-time subscriptions.

## Changes

- **lib/stores/task-store.ts**: Replaced SQLite/fetch-based store with Convex React client hooks
  - `useTasks(projectId, status?)` - Query tasks by project with optional status filter
  - `useTask(id)` - Query single task with comments
  - `useCreateTask()` - Mutation to create tasks
  - `useUpdateTask()` - Mutation to update tasks
  - `useMoveTask()` - Mutation to move tasks between columns
  - `useReorderTask()` - Mutation to reorder tasks within a column
  - `useDeleteTask()` - Mutation to delete tasks
  - Removed WebSocket handling (Convex provides built-in real-time sync)
  - Removed `wsConnected` state

- **components/board/board.tsx**: Updated to use Convex hooks
- **components/board/mobile-board.tsx**: Updated to use `tasksByStatus` object
- **components/board/create-task-modal.tsx**: Updated to use `useCreateTask()` hook
- **components/board/task-modal.tsx**: Updated to use `useUpdateTask()` and `useDeleteTask()` hooks, fetch comments via Convex

## Benefits

- Real-time sync across all clients (Convex handles this automatically)
- Simpler code (no manual WebSocket message handling)
- Better type safety with Convex generated types
- Consistent with project-store migration pattern

## Testing

- [x] Typecheck passes
- [x] Lint passes
- [x] Drag-and-drop operations work
- [x] Task CRUD operations work

Ticket: ba038103-6fc0-4a14-83e5-eae908f59700