### PR TITLE
feat: SQLite to Convex data migration script

### DIFF
--- a/convex/migrate.ts
+++ b/convex/migrate.ts
@@ -1,0 +1,324 @@
+import { mutation } from './_generated/server'
+import { v } from 'convex/values'
+
+/**
+ * Migration mutations for SQLite → Convex data migration
+ * These mutations accept full data including IDs and timestamps for idempotent migration
+ */
+
+// ============================================
+// Projects
+// ============================================
+
+export const createProject = mutation({
+  args: {
+    slug: v.string(),
+    name: v.string(),
+    description: v.optional(v.string()),
+    color: v.string(),
+    repo_url: v.optional(v.string()),
+    context_path: v.optional(v.string()),
+    local_path: v.optional(v.string()),
+    github_repo: v.optional(v.string()),
+    chat_layout: v.union(v.literal('slack'), v.literal('imessage')),
+    work_loop_enabled: v.boolean(),
+    work_loop_schedule: v.string(),
+    created_at: v.number(),
+    updated_at: v.number(),
+  },
+  handler: async (ctx, args) => {
+    // Check if project with this slug already exists
+    const existing = await ctx.db
+      .query('projects')
+      .withIndex('by_slug', (q) => q.eq('slug', args.slug))
+      .unique()
+
+    if (existing) {
+      return { _id: existing._id, skipped: true }
+    }
+
+    const projectId = await ctx.db.insert('projects', args)
+    return { _id: projectId, skipped: false }
+  },
+})
+
+// ============================================
+// Tasks
+// ============================================
+
+export const createTask = mutation({
+  args: {
+    project_id: v.id('projects'),
+    title: v.string(),
+    description: v.optional(v.string()),
+    status: v.union(
+      v.literal('backlog'),
+      v.literal('ready'),
+      v.literal('in_progress'),
+      v.literal('review'),
+      v.literal('done')
+    ),
+    priority: v.union(v.literal('low'), v.literal('medium'), v.literal('high'), v.literal('urgent')),
+    role: v.optional(v.union(v.literal('any'), v.literal('pm'), v.literal('dev'), v.literal('qa'), v.literal('research'), v.literal('security'))),
+    assignee: v.optional(v.string()),
+    requires_human_review: v.boolean(),
+    tags: v.optional(v.array(v.string())),
+    session_id: v.optional(v.string()),
+    dispatch_status: v.optional(v.union(v.literal('pending'), v.literal('spawning'), v.literal('active'), v.literal('completed'), v.literal('failed'))),
+    dispatch_requested_at: v.optional(v.number()),
+    dispatch_requested_by: v.optional(v.string()),
+    position: v.number(),
+    created_at: v.number(),
+    updated_at: v.number(),
+    completed_at: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    // For idempotency, check if a task with same project_id, title, and created_at exists
+    const existing = await ctx.db
+      .query('tasks')
+      .withIndex('by_project', (q) => q.eq('project_id', args.project_id))
+      .collect()
+
+    const duplicate = existing.find(
+      (t) => t.title === args.title && t.created_at === args.created_at
+    )
+
+    if (duplicate) {
+      return { _id: duplicate._id, skipped: true }
+    }
+
+    const taskId = await ctx.db.insert('tasks', args)
+    return { _id: taskId, skipped: false }
+  },
+})
+
+// ============================================
+// Comments
+// ============================================
+
+export const createComment = mutation({
+  args: {
+    task_id: v.id('tasks'),
+    author: v.string(),
+    author_type: v.union(v.literal('coordinator'), v.literal('agent'), v.literal('human')),
+    content: v.string(),
+    type: v.union(v.literal('message'), v.literal('status_change'), v.literal('request_input'), v.literal('completion')),
+    responded_at: v.optional(v.number()),
+    created_at: v.number(),
+  },
+  handler: async (ctx, args) => {
+    // Check for duplicate by task_id + created_at
+    const existing = await ctx.db
+      .query('comments')
+      .withIndex('by_task', (q) => q.eq('task_id', args.task_id))
+      .collect()
+
+    const duplicate = existing.find((c) => c.created_at === args.created_at)
+
+    if (duplicate) {
+      return { _id: duplicate._id, skipped: true }
+    }
+
+    const commentId = await ctx.db.insert('comments', args)
+    return { _id: commentId, skipped: false }
+  },
+})
+
+// ============================================
+// Chats
+// ============================================
+
+export const createChat = mutation({
+  args: {
+    project_id: v.id('projects'),
+    title: v.string(),
+    participants: v.optional(v.array(v.string())),
+    session_key: v.optional(v.string()),
+    created_at: v.number(),
+    updated_at: v.number(),
+  },
+  handler: async (ctx, args) => {
+    // Check for duplicate by project_id + title
+    const existing = await ctx.db
+      .query('chats')
+      .withIndex('by_project', (q) => q.eq('project_id', args.project_id))
+      .collect()
+
+    const duplicate = existing.find((c) => c.title === args.title)
+
+    if (duplicate) {
+      return { _id: duplicate._id, skipped: true }
+    }
+
+    const chatId = await ctx.db.insert('chats', args)
+    return { _id: chatId, skipped: false }
+  },
+})
+
+// ============================================
+// Chat Messages
+// ============================================
+
+export const createChatMessage = mutation({
+  args: {
+    chat_id: v.id('chats'),
+    author: v.string(),
+    content: v.string(),
+    run_id: v.optional(v.string()),
+    session_key: v.optional(v.string()),
+    is_automated: v.optional(v.boolean()),
+    created_at: v.number(),
+  },
+  handler: async (ctx, args) => {
+    // Check for duplicate by chat_id + created_at
+    const existing = await ctx.db
+      .query('chatMessages')
+      .withIndex('by_chat', (q) => q.eq('chat_id', args.chat_id))
+      .collect()
+
+    const duplicate = existing.find((m) => m.created_at === args.created_at)
+
+    if (duplicate) {
+      return { _id: duplicate._id, skipped: true }
+    }
+
+    const messageId = await ctx.db.insert('chatMessages', args)
+    return { _id: messageId, skipped: false }
+  },
+})
+
+// ============================================
+// Notifications
+// ============================================
+
+export const createNotification = mutation({
+  args: {
+    task_id: v.optional(v.id('tasks')),
+    project_id: v.optional(v.id('projects')),
+    type: v.union(v.literal('escalation'), v.literal('request_input'), v.literal('completion'), v.literal('system')),
+    severity: v.union(v.literal('info'), v.literal('warning'), v.literal('critical')),
+    title: v.string(),
+    message: v.string(),
+    agent: v.optional(v.string()),
+    read: v.boolean(),
+    created_at: v.number(),
+  },
+  handler: async (ctx, args) => {
+    // Check for duplicate by created_at (rough dedup)
+    const existing = await ctx.db
+      .query('notifications')
+      .withIndex('by_created', (q) => q.eq('created_at', args.created_at))
+      .unique()
+
+    if (existing) {
+      return { _id: existing._id, skipped: true }
+    }
+
+    const notificationId = await ctx.db.insert('notifications', args)
+    return { _id: notificationId, skipped: false }
+  },
+})
+
+// ============================================
+// Events
+// ============================================
+
+export const createEvent = mutation({
+  args: {
+    project_id: v.optional(v.id('projects')),
+    task_id: v.optional(v.id('tasks')),
+    type: v.union(
+      v.literal('task_created'),
+      v.literal('task_moved'),
+      v.literal('task_assigned'),
+      v.literal('task_completed'),
+      v.literal('comment_added'),
+      v.literal('agent_started'),
+      v.literal('agent_completed'),
+      v.literal('chat_created'),
+      v.literal('message_sent')
+    ),
+    actor: v.string(),
+    data: v.optional(v.string()),
+    created_at: v.number(),
+  },
+  handler: async (ctx, args) => {
+    // Check for duplicate by created_at
+    const existing = await ctx.db
+      .query('events')
+      .withIndex('by_created', (q) => q.eq('created_at', args.created_at))
+      .unique()
+
+    if (existing) {
+      return { _id: existing._id, skipped: true }
+    }
+
+    const eventId = await ctx.db.insert('events', args)
+    return { _id: eventId, skipped: false }
+  },
+})
+
+// ============================================
+// Signals
+// ============================================
+
+export const createSignal = mutation({
+  args: {
+    task_id: v.id('tasks'),
+    session_key: v.string(),
+    agent_id: v.string(),
+    kind: v.union(v.literal('question'), v.literal('blocker'), v.literal('alert'), v.literal('fyi')),
+    severity: v.union(v.literal('normal'), v.literal('high'), v.literal('critical')),
+    message: v.string(),
+    blocking: v.boolean(),
+    responded_at: v.optional(v.number()),
+    response: v.optional(v.string()),
+    created_at: v.number(),
+  },
+  handler: async (ctx, args) => {
+    // Check for duplicate by task_id + created_at
+    const existing = await ctx.db
+      .query('signals')
+      .withIndex('by_task', (q) => q.eq('task_id', args.task_id))
+      .collect()
+
+    const duplicate = existing.find((s) => s.created_at === args.created_at)
+
+    if (duplicate) {
+      return { _id: duplicate._id, skipped: true }
+    }
+
+    const signalId = await ctx.db.insert('signals', args)
+    return { _id: signalId, skipped: false }
+  },
+})
+
+// ============================================
+// Task Dependencies
+// ============================================
+
+export const createTaskDependency = mutation({
+  args: {
+    task_id: v.id('tasks'),
+    depends_on_id: v.id('tasks'),
+    created_at: v.number(),
+  },
+  handler: async (ctx, args) => {
+    // Check for duplicate by task_id + depends_on_id
+    const existing = await ctx.db
+      .query('taskDependencies')
+      .withIndex('by_task_depends_on', (q) =>
+        (q as unknown as { eq: (field: string, value: unknown) => typeof q }).eq('task_id', args.task_id)
+      )
+      .collect()
+
+    const duplicate = existing.find((d) => d.depends_on_id === args.depends_on_id)
+
+    if (duplicate) {
+      return { _id: duplicate._id, skipped: true }
+    }
+
+    const depId = await ctx.db.insert('taskDependencies', args)
+    return { _id: depId, skipped: false }
+  },
+})

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test": "vitest",
     "test:ui": "vitest --ui",
     "db:migrate": "tsx scripts/migrate.ts",
+    "convex:migrate": "tsx scripts/migrate-to-convex.ts",
     "ws:start": "tsx scripts/start-websocket-server.ts",
     "ws:dev": "tsx --watch scripts/start-websocket-server.ts",
     "prepare": "husky",

--- a/scripts/migrate-to-convex.ts
+++ b/scripts/migrate-to-convex.ts
@@ -1,0 +1,643 @@
+/**
+ * Migration script: SQLite → Convex
+ * 
+ * Reads all data from SQLite and inserts into Convex.
+ * Designed to be idempotent - can be run multiple times safely.
+ * 
+ * Usage:
+ *   pnpm convex:migrate
+ * 
+ * Requires environment variables:
+ *   - CONVEX_SELF_HOSTED_URL
+ *   - CONVEX_SELF_HOSTED_ADMIN_KEY
+ *   - DATABASE_PATH (optional, defaults to ~/.trap/trap.db)
+ */
+
+import Database from "better-sqlite3"
+import fs from "fs"
+import path from "path"
+
+// Configuration
+const CONVEX_URL = process.env.CONVEX_SELF_HOSTED_URL?.replace(/\/$/, '') // Remove trailing slash
+const ADMIN_KEY = process.env.CONVEX_SELF_HOSTED_ADMIN_KEY
+const DB_PATH = process.env.DATABASE_PATH || 
+  path.join(process.env.HOME || "", ".trap", "trap.db")
+
+const SQLITE_BACKUP_PATH = `${DB_PATH}.backup-${Date.now()}`
+
+// ID mapping: SQLite ID → Convex ID
+const projectIdMap = new Map<string, string>()
+const taskIdMap = new Map<string, string>()
+const chatIdMap = new Map<string, string>()
+
+// Statistics
+const stats = {
+  projects: { migrated: 0, skipped: 0, errors: 0 },
+  tasks: { migrated: 0, skipped: 0, errors: 0 },
+  comments: { migrated: 0, skipped: 0, errors: 0 },
+  chats: { migrated: 0, skipped: 0, errors: 0 },
+  chatMessages: { migrated: 0, skipped: 0, errors: 0 },
+  notifications: { migrated: 0, skipped: 0, errors: 0 },
+  events: { migrated: 0, skipped: 0, errors: 0 },
+  signals: { migrated: 0, skipped: 0, errors: 0 },
+  taskDependencies: { migrated: 0, skipped: 0, errors: 0 },
+}
+
+// SQLite row types
+interface SqliteProject {
+  id: string
+  slug: string
+  name: string
+  description: string | null
+  color: string
+  repo_url: string | null
+  context_path: string | null
+  local_path: string | null
+  github_repo: string | null
+  chat_layout: string
+  work_loop_enabled: number
+  work_loop_schedule: string
+  created_at: number
+  updated_at: number
+}
+
+interface SqliteTask {
+  id: string
+  project_id: string
+  title: string
+  description: string | null
+  status: string
+  priority: string
+  role: string | null
+  assignee: string | null
+  requires_human_review: number
+  tags: string | null
+  session_id: string | null
+  dispatch_status: string | null
+  dispatch_requested_at: number | null
+  dispatch_requested_by: string | null
+  position: number
+  created_at: number
+  updated_at: number
+  completed_at: number | null
+}
+
+interface SqliteComment {
+  id: string
+  task_id: string
+  author: string
+  author_type: string
+  content: string
+  type: string
+  responded_at: number | null
+  created_at: number
+}
+
+interface SqliteChat {
+  id: string
+  project_id: string
+  title: string
+  participants: string | null
+  session_key: string | null
+  created_at: number
+  updated_at: number
+}
+
+interface SqliteChatMessage {
+  id: string
+  chat_id: string
+  author: string
+  content: string
+  run_id: string | null
+  session_key: string | null
+  is_automated: number | null
+  created_at: number
+}
+
+interface SqliteNotification {
+  id: string
+  task_id: string | null
+  project_id: string | null
+  type: string
+  severity: string
+  title: string
+  message: string
+  agent: string | null
+  read: number
+  created_at: number
+}
+
+interface SqliteEvent {
+  id: string
+  project_id: string | null
+  task_id: string | null
+  type: string
+  actor: string
+  data: string | null
+  created_at: number
+}
+
+interface SqliteSignal {
+  id: string
+  task_id: string
+  session_key: string
+  agent_id: string
+  kind: string
+  severity: string
+  message: string
+  blocking: number
+  responded_at: number | null
+  response: string | null
+  created_at: number
+}
+
+interface SqliteTaskDependency {
+  id: string
+  task_id: string
+  depends_on_id: string
+  created_at: number
+}
+
+function validateEnv(): void {
+  if (!CONVEX_URL) {
+    throw new Error("CONVEX_SELF_HOSTED_URL environment variable is required")
+  }
+  if (!ADMIN_KEY) {
+    throw new Error("CONVEX_SELF_HOSTED_ADMIN_KEY environment variable is required")
+  }
+  if (!fs.existsSync(DB_PATH)) {
+    throw new Error(`SQLite database not found at ${DB_PATH}`)
+  }
+}
+
+function backupDatabase(): void {
+  console.log(`Creating backup: ${SQLITE_BACKUP_PATH}`)
+  fs.copyFileSync(DB_PATH, SQLITE_BACKUP_PATH)
+  console.log("✓ Backup created")
+}
+
+async function convexMutation(mutationPath: string, args: Record<string, unknown>): Promise<{ _id: string; skipped: boolean }> {
+  const url = `${CONVEX_URL}/api/mutation`
+  const body = {
+    path: mutationPath,
+    args
+  }
+
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Authorization": `Bearer ${ADMIN_KEY}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  })
+
+  if (!response.ok) {
+    const text = await response.text()
+    throw new Error(`Convex mutation failed: ${response.status} - ${text}`)
+  }
+
+  const result = await response.json()
+  return result as { _id: string; skipped: boolean }
+}
+
+function parseJsonField<T>(field: string | null, defaultValue: T): T {
+  if (!field) return defaultValue
+  try {
+    return JSON.parse(field) as T
+  } catch {
+    return defaultValue
+  }
+}
+
+async function migrateProjects(db: Database.Database): Promise<void> {
+  console.log("\n📁 Migrating projects...")
+  const rows = db.prepare("SELECT * FROM projects").all() as SqliteProject[]
+
+  for (const row of rows) {
+    try {
+      const result = await convexMutation("migrate:createProject", {
+        slug: row.slug,
+        name: row.name,
+        description: row.description || undefined,
+        color: row.color || "#3b82f6",
+        repo_url: row.repo_url || undefined,
+        context_path: row.context_path || undefined,
+        local_path: row.local_path || undefined,
+        github_repo: row.github_repo || undefined,
+        chat_layout: row.chat_layout || "slack",
+        work_loop_enabled: Boolean(row.work_loop_enabled),
+        work_loop_schedule: row.work_loop_schedule || "*/5 * * * *",
+        created_at: row.created_at,
+        updated_at: row.updated_at,
+      })
+
+      projectIdMap.set(row.id, result._id)
+      
+      if (result.skipped) {
+        stats.projects.skipped++
+        console.log(`  ⏭ ${row.slug} (already exists)`)
+      } else {
+        stats.projects.migrated++
+        console.log(`  ✓ ${row.slug} → ${result._id.slice(0, 8)}...`)
+      }
+    } catch (error) {
+      stats.projects.errors++
+      console.error(`  ✗ ${row.slug}:`, error instanceof Error ? error.message : error)
+    }
+  }
+
+  console.log(`  Migrated: ${stats.projects.migrated}, Skipped: ${stats.projects.skipped}, Errors: ${stats.projects.errors}`)
+}
+
+async function migrateTasks(db: Database.Database): Promise<void> {
+  console.log("\n📋 Migrating tasks...")
+  const rows = db.prepare("SELECT * FROM tasks").all() as SqliteTask[]
+
+  for (const row of rows) {
+    try {
+      const convexProjectId = projectIdMap.get(row.project_id)
+      if (!convexProjectId) {
+        console.warn(`  ⚠ Skipping task "${row.title}": project ${row.project_id} not found`)
+        stats.tasks.skipped++
+        continue
+      }
+
+      const result = await convexMutation("migrate:createTask", {
+        project_id: convexProjectId,
+        title: row.title,
+        description: row.description || undefined,
+        status: row.status,
+        priority: row.priority,
+        role: row.role || undefined,
+        assignee: row.assignee || undefined,
+        requires_human_review: Boolean(row.requires_human_review),
+        tags: row.tags ? parseJsonField<string[]>(row.tags, []) : undefined,
+        session_id: row.session_id || undefined,
+        dispatch_status: row.dispatch_status || undefined,
+        dispatch_requested_at: row.dispatch_requested_at || undefined,
+        dispatch_requested_by: row.dispatch_requested_by || undefined,
+        position: row.position || 0,
+        created_at: row.created_at,
+        updated_at: row.updated_at,
+        completed_at: row.completed_at || undefined,
+      })
+
+      taskIdMap.set(row.id, result._id)
+      
+      if (result.skipped) {
+        stats.tasks.skipped++
+      } else {
+        stats.tasks.migrated++
+      }
+    } catch (error) {
+      stats.tasks.errors++
+      console.error(`  ✗ Task "${row.title.slice(0, 30)}...":`, error instanceof Error ? error.message : error)
+    }
+  }
+
+  console.log(`  Migrated: ${stats.tasks.migrated}, Skipped: ${stats.tasks.skipped}, Errors: ${stats.tasks.errors}`)
+}
+
+async function migrateComments(db: Database.Database): Promise<void> {
+  console.log("\n💬 Migrating comments...")
+  const rows = db.prepare("SELECT * FROM comments").all() as SqliteComment[]
+
+  for (const row of rows) {
+    try {
+      const convexTaskId = taskIdMap.get(row.task_id)
+      if (!convexTaskId) {
+        stats.comments.skipped++
+        continue
+      }
+
+      const result = await convexMutation("migrate:createComment", {
+        task_id: convexTaskId,
+        author: row.author,
+        author_type: row.author_type,
+        content: row.content,
+        type: row.type,
+        responded_at: row.responded_at || undefined,
+        created_at: row.created_at,
+      })
+
+      if (result.skipped) {
+        stats.comments.skipped++
+      } else {
+        stats.comments.migrated++
+      }
+    } catch (error) {
+      stats.comments.errors++
+      console.error(`  ✗ Comment ${row.id}:`, error instanceof Error ? error.message : error)
+    }
+  }
+
+  console.log(`  Migrated: ${stats.comments.migrated}, Skipped: ${stats.comments.skipped}, Errors: ${stats.comments.errors}`)
+}
+
+async function migrateChats(db: Database.Database): Promise<void> {
+  console.log("\n💭 Migrating chats...")
+  const rows = db.prepare("SELECT * FROM chats").all() as SqliteChat[]
+
+  for (const row of rows) {
+    try {
+      const convexProjectId = projectIdMap.get(row.project_id)
+      if (!convexProjectId) {
+        stats.chats.skipped++
+        continue
+      }
+
+      const result = await convexMutation("migrate:createChat", {
+        project_id: convexProjectId,
+        title: row.title,
+        participants: row.participants ? parseJsonField<string[]>(row.participants, []) : undefined,
+        session_key: row.session_key || undefined,
+        created_at: row.created_at,
+        updated_at: row.updated_at,
+      })
+
+      chatIdMap.set(row.id, result._id)
+      
+      if (result.skipped) {
+        stats.chats.skipped++
+      } else {
+        stats.chats.migrated++
+      }
+    } catch (error) {
+      stats.chats.errors++
+      console.error(`  ✗ Chat ${row.id}:`, error instanceof Error ? error.message : error)
+    }
+  }
+
+  console.log(`  Migrated: ${stats.chats.migrated}, Skipped: ${stats.chats.skipped}, Errors: ${stats.chats.errors}`)
+}
+
+async function migrateChatMessages(db: Database.Database): Promise<void> {
+  console.log("\n📨 Migrating chat messages...")
+  const rows = db.prepare("SELECT * FROM chat_messages").all() as SqliteChatMessage[]
+
+  for (const row of rows) {
+    try {
+      const convexChatId = chatIdMap.get(row.chat_id)
+      if (!convexChatId) {
+        stats.chatMessages.skipped++
+        continue
+      }
+
+      const result = await convexMutation("migrate:createChatMessage", {
+        chat_id: convexChatId,
+        author: row.author,
+        content: row.content,
+        run_id: row.run_id || undefined,
+        session_key: row.session_key || undefined,
+        is_automated: row.is_automated !== null ? Boolean(row.is_automated) : undefined,
+        created_at: row.created_at,
+      })
+
+      if (result.skipped) {
+        stats.chatMessages.skipped++
+      } else {
+        stats.chatMessages.migrated++
+      }
+    } catch (error) {
+      stats.chatMessages.errors++
+      console.error(`  ✗ Chat message ${row.id}:`, error instanceof Error ? error.message : error)
+    }
+  }
+
+  console.log(`  Migrated: ${stats.chatMessages.migrated}, Skipped: ${stats.chatMessages.skipped}, Errors: ${stats.chatMessages.errors}`)
+}
+
+async function migrateNotifications(db: Database.Database): Promise<void> {
+  console.log("\n🔔 Migrating notifications...")
+  const rows = db.prepare("SELECT * FROM notifications").all() as SqliteNotification[]
+
+  for (const row of rows) {
+    try {
+      const convexTaskId = row.task_id ? taskIdMap.get(row.task_id) : undefined
+      const convexProjectId = row.project_id ? projectIdMap.get(row.project_id) : undefined
+
+      // Skip if task/project was referenced but not found
+      if (row.task_id && !convexTaskId) {
+        stats.notifications.skipped++
+        continue
+      }
+      if (row.project_id && !convexProjectId) {
+        stats.notifications.skipped++
+        continue
+      }
+
+      const result = await convexMutation("migrate:createNotification", {
+        task_id: convexTaskId,
+        project_id: convexProjectId,
+        type: row.type,
+        severity: row.severity,
+        title: row.title,
+        message: row.message,
+        agent: row.agent || undefined,
+        read: Boolean(row.read),
+        created_at: row.created_at,
+      })
+
+      if (result.skipped) {
+        stats.notifications.skipped++
+      } else {
+        stats.notifications.migrated++
+      }
+    } catch (error) {
+      stats.notifications.errors++
+      console.error(`  ✗ Notification ${row.id}:`, error instanceof Error ? error.message : error)
+    }
+  }
+
+  console.log(`  Migrated: ${stats.notifications.migrated}, Skipped: ${stats.notifications.skipped}, Errors: ${stats.notifications.errors}`)
+}
+
+async function migrateEvents(db: Database.Database): Promise<void> {
+  console.log("\n📊 Migrating events...")
+  const rows = db.prepare("SELECT * FROM events").all() as SqliteEvent[]
+
+  for (const row of rows) {
+    try {
+      const convexTaskId = row.task_id ? taskIdMap.get(row.task_id) : undefined
+      const convexProjectId = row.project_id ? projectIdMap.get(row.project_id) : undefined
+
+      // Skip if task/project was referenced but not found
+      if (row.task_id && !convexTaskId) {
+        stats.events.skipped++
+        continue
+      }
+      if (row.project_id && !convexProjectId) {
+        stats.events.skipped++
+        continue
+      }
+
+      const result = await convexMutation("migrate:createEvent", {
+        project_id: convexProjectId,
+        task_id: convexTaskId,
+        type: row.type,
+        actor: row.actor,
+        data: row.data || undefined,
+        created_at: row.created_at,
+      })
+
+      if (result.skipped) {
+        stats.events.skipped++
+      } else {
+        stats.events.migrated++
+      }
+    } catch (error) {
+      stats.events.errors++
+      console.error(`  ✗ Event ${row.id}:`, error instanceof Error ? error.message : error)
+    }
+  }
+
+  console.log(`  Migrated: ${stats.events.migrated}, Skipped: ${stats.events.skipped}, Errors: ${stats.events.errors}`)
+}
+
+async function migrateSignals(db: Database.Database): Promise<void> {
+  console.log("\n📡 Migrating signals...")
+  const rows = db.prepare("SELECT * FROM signals").all() as SqliteSignal[]
+
+  for (const row of rows) {
+    try {
+      const convexTaskId = taskIdMap.get(row.task_id)
+      if (!convexTaskId) {
+        stats.signals.skipped++
+        continue
+      }
+
+      const result = await convexMutation("migrate:createSignal", {
+        task_id: convexTaskId,
+        session_key: row.session_key,
+        agent_id: row.agent_id,
+        kind: row.kind,
+        severity: row.severity,
+        message: row.message,
+        blocking: Boolean(row.blocking),
+        responded_at: row.responded_at || undefined,
+        response: row.response || undefined,
+        created_at: row.created_at,
+      })
+
+      if (result.skipped) {
+        stats.signals.skipped++
+      } else {
+        stats.signals.migrated++
+      }
+    } catch (error) {
+      stats.signals.errors++
+      console.error(`  ✗ Signal ${row.id}:`, error instanceof Error ? error.message : error)
+    }
+  }
+
+  console.log(`  Migrated: ${stats.signals.migrated}, Skipped: ${stats.signals.skipped}, Errors: ${stats.signals.errors}`)
+}
+
+async function migrateTaskDependencies(db: Database.Database): Promise<void> {
+  console.log("\n🔗 Migrating task dependencies...")
+  const rows = db.prepare("SELECT * FROM task_dependencies").all() as SqliteTaskDependency[]
+
+  for (const row of rows) {
+    try {
+      const convexTaskId = taskIdMap.get(row.task_id)
+      const convexDependsOnId = taskIdMap.get(row.depends_on_id)
+      
+      if (!convexTaskId || !convexDependsOnId) {
+        stats.taskDependencies.skipped++
+        continue
+      }
+
+      const result = await convexMutation("migrate:createTaskDependency", {
+        task_id: convexTaskId,
+        depends_on_id: convexDependsOnId,
+        created_at: row.created_at,
+      })
+
+      if (result.skipped) {
+        stats.taskDependencies.skipped++
+      } else {
+        stats.taskDependencies.migrated++
+      }
+    } catch (error) {
+      stats.taskDependencies.errors++
+      console.error(`  ✗ Dependency ${row.id}:`, error instanceof Error ? error.message : error)
+    }
+  }
+
+  console.log(`  Migrated: ${stats.taskDependencies.migrated}, Skipped: ${stats.taskDependencies.skipped}, Errors: ${stats.taskDependencies.errors}`)
+}
+
+function printSummary(): void {
+  console.log("\n" + "=".repeat(50))
+  console.log("MIGRATION SUMMARY")
+  console.log("=".repeat(50))
+  
+  const entities = [
+    ["Projects", stats.projects],
+    ["Tasks", stats.tasks],
+    ["Comments", stats.comments],
+    ["Chats", stats.chats],
+    ["Chat Messages", stats.chatMessages],
+    ["Notifications", stats.notifications],
+    ["Events", stats.events],
+    ["Signals", stats.signals],
+    ["Task Dependencies", stats.taskDependencies],
+  ] as const
+
+  for (const [name, s] of entities) {
+    const total = s.migrated + s.skipped + s.errors
+    if (total > 0) {
+      console.log(`${name.padEnd(20)} migrated: ${s.migrated}, skipped: ${s.skipped}, errors: ${s.errors}`)
+    }
+  }
+
+  const totalMigrated = Object.values(stats).reduce((a, s) => a + s.migrated, 0)
+  const totalSkipped = Object.values(stats).reduce((a, s) => a + s.skipped, 0)
+  const totalErrors = Object.values(stats).reduce((a, s) => a + s.errors, 0)
+
+  console.log("-".repeat(50))
+  console.log(`Total: migrated ${totalMigrated}, skipped ${totalSkipped}, errors ${totalErrors}`)
+  console.log(`\n✅ SQLite backup preserved at: ${SQLITE_BACKUP_PATH}`)
+  
+  if (totalErrors > 0) {
+    console.log("\n⚠️  Some errors occurred. Check logs above for details.")
+    process.exit(1)
+  }
+}
+
+async function main(): Promise<void> {
+  console.log("SQLite → Convex Migration")
+  console.log("=".repeat(50))
+  
+  validateEnv()
+  console.log(`Source: ${DB_PATH}`)
+  console.log(`Target: ${CONVEX_URL}`)
+  
+  backupDatabase()
+  
+  const db = new Database(DB_PATH)
+  db.pragma("journal_mode = WAL")
+  
+  try {
+    // Migration order: projects → tasks → everything else → dependencies last
+    await migrateProjects(db)
+    await migrateTasks(db)
+    await migrateComments(db)
+    await migrateChats(db)
+    await migrateChatMessages(db)
+    await migrateNotifications(db)
+    await migrateEvents(db)
+    await migrateSignals(db)
+    await migrateTaskDependencies(db)
+    
+    printSummary()
+  } finally {
+    db.close()
+  }
+}
+
+main().catch(error => {
+  console.error("Migration failed:", error)
+  process.exit(1)
+})


### PR DESCRIPTION
Ticket: f631eef0-cca4-4934-9019-aaf75af4bbbb

## Summary

Creates a data migration script to move existing SQLite data into Convex.

## Changes

- **scripts/migrate-to-convex.ts** - Main migration script that:
  - Reads all data from SQLite database
  - Transforms data (JSON fields, boolean conversions)
  - Inserts into Convex via HTTP API
  - Is idempotent (can run multiple times safely)
  - Creates SQLite backup before starting
  - Reports progress and errors per entity type

- **convex/migrate.ts** - Migration-specific mutations:
  -  - Preserves all project fields + timestamps
  -  - Preserves task fields, handles idempotency by project+title+created_at
  -  - Links to migrated tasks
  -  - Links to migrated projects
  -  - Links to migrated chats
  -  - Preserves notification data
  -  - Preserves event audit trail
  -  - Links to migrated tasks
  -  - Links tasks after both are migrated

- **package.json** - Added  script

## Migration Order

1. Projects (no dependencies)
2. Tasks (depend on projects)
3. Comments, Chats, Notifications, Events, Signals (depend on tasks/projects)
4. Chat Messages (depend on chats)
5. Task Dependencies (depend on tasks - must be last)

## Usage

```bash
pnpm convex:migrate
```

## Requirements

Environment variables (from `.env.local`):
- `CONVEX_SELF_HOSTED_URL`
- `CONVEX_SELF_HOSTED_ADMIN_KEY`

## Rollback

SQLite backup is created at `~/.trap/trap.db.backup-<timestamp>` before migration starts.