### PR TITLE
feat: migrate remaining 7 API routes from SQLite to Convex

### DIFF
--- a/app/api/dispatch/pending/route.ts
+++ b/app/api/dispatch/pending/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server"
-import { db } from "@/lib/db"
+import { convexServerClient } from "@/lib/convex-server"
 import type { Task, Project } from "@/lib/db/types"
 import { getAgent } from "@/lib/agents"
 import { buildTaskContext, buildTaskLabel } from "@/lib/dispatch/context"
@@ -19,50 +19,74 @@ interface PendingDispatch {
 
 // GET /api/dispatch/pending — List tasks pending dispatch
 export async function GET() {
-  const tasks = db.prepare(`
-    SELECT * FROM tasks 
-    WHERE dispatch_status = 'pending'
-    ORDER BY 
-      CASE priority
-        WHEN 'urgent' THEN 1
-        WHEN 'high' THEN 2
-        WHEN 'medium' THEN 3
-        WHEN 'low' THEN 4
-      END,
-      dispatch_requested_at ASC
-  `).all() as Task[]
-  
-  const pending: PendingDispatch[] = []
-  
-  for (const task of tasks) {
-    const project = db.prepare(
-      "SELECT * FROM projects WHERE id = ?"
-    ).get(task.project_id) as Project | undefined
+  try {
+    // Get all tasks and filter for pending dispatch
+    const tasks = await convexServerClient.query(
+      // @ts-expect-error - Convex self-hosted uses any api type
+      { name: "tasks/getByStatus" },
+      { status: "in_progress" }
+    ) as Task[]
+
+    const pendingTasks = tasks.filter((t) => t.dispatch_status === "pending")
+
+    const pending: PendingDispatch[] = []
     
-    if (!project) continue
-    
-    const agentId = task.assignee
-    if (!agentId) continue
-    
-    const agent = getAgent(agentId)
-    if (!agent) continue
-    
-    pending.push({
-      task,
-      project,
-      agent: {
-        id: agent.id,
-        name: agent.name,
-        model: agent.model,
-        role: agent.role,
-      },
-      context: buildTaskContext(task, project, agentId),
-      label: buildTaskLabel(task),
+    for (const task of pendingTasks) {
+      // Get project for each task
+      const project = await convexServerClient.query(
+        // @ts-expect-error - Convex self-hosted uses any api type
+        { name: "projects/getById" },
+        { id: task.project_id }
+      ) as Project | null
+      
+      if (!project) continue
+      
+      const agentId = task.assignee
+      if (!agentId) continue
+      
+      const agent = getAgent(agentId)
+      if (!agent) continue
+      
+      pending.push({
+        task,
+        project,
+        agent: {
+          id: agent.id,
+          name: agent.name,
+          model: agent.model,
+          role: agent.role,
+        },
+        context: buildTaskContext(task, project, agentId),
+        label: buildTaskLabel(task),
+      })
+    }
+
+    // Sort by priority
+    const priorityOrder: Record<string, number> = {
+      urgent: 1,
+      high: 2,
+      medium: 3,
+      low: 4,
+    }
+
+    pending.sort((a, b) => {
+      const pDiff = (priorityOrder[a.task.priority] || 5) - (priorityOrder[b.task.priority] || 5)
+      if (pDiff !== 0) return pDiff
+      // Then by dispatch_requested_at
+      const aTime = a.task.dispatch_requested_at || 0
+      const bTime = b.task.dispatch_requested_at || 0
+      return aTime - bTime
     })
+
+    return NextResponse.json({
+      count: pending.length,
+      pending,
+    })
+  } catch (error) {
+    console.error("[dispatch/pending] Error:", error)
+    return NextResponse.json(
+      { error: "Failed to fetch pending dispatches", details: String(error) },
+      { status: 500 }
+    )
   }
-  
-  return NextResponse.json({
-    count: pending.length,
-    pending,
-  })
 }

--- a/app/api/notifications/route.ts
+++ b/app/api/notifications/route.ts
@@ -1,130 +1,99 @@
 import { NextRequest, NextResponse } from "next/server"
-import { db } from "@/lib/db"
-import type { Task } from "@/lib/db/types"
-
-export type NotificationSeverity = "info" | "warning" | "critical"
-
-interface Notification {
-  id: string
-  task_id: string | null
-  project_id: string | null
-  type: "escalation" | "request_input" | "completion" | "system"
-  severity: NotificationSeverity
-  title: string
-  message: string
-  agent: string | null
-  read: number  // SQLite boolean (0/1)
-  created_at: number
-}
+import { convexServerClient } from "@/lib/convex-server"
+import type { Notification, NotificationType, NotificationSeverity } from "@/lib/db/types"
 
 // GET /api/notifications — List notifications
 export async function GET(request: NextRequest) {
-  const { searchParams } = new URL(request.url)
-  const unreadOnly = searchParams.get("unread") === "true"
-  const limit = parseInt(searchParams.get("limit") || "50")
-  
-  const query = `
-    SELECT * FROM notifications 
-    ${unreadOnly ? "WHERE read = 0" : ""}
-    ORDER BY 
-      CASE severity
-        WHEN 'critical' THEN 1
-        WHEN 'warning' THEN 2
-        WHEN 'info' THEN 3
-      END,
-      created_at DESC
-    LIMIT ?
-  `
-  
-  const notifications = db.prepare(query).all(limit) as Notification[]
-  
-  return NextResponse.json({
-    notifications,
-    unreadCount: db.prepare("SELECT COUNT(*) as count FROM notifications WHERE read = 0").get() as { count: number },
-  })
+  try {
+    const { searchParams } = new URL(request.url)
+    const unreadOnly = searchParams.get("unread") === "true"
+    const limit = parseInt(searchParams.get("limit") || "50")
+
+    const result = await convexServerClient.query(
+      // @ts-expect-error - Convex self-hosted uses any api type
+      { name: "notifications/getAll" },
+      {
+        unreadOnly: unreadOnly || undefined,
+        limit,
+      }
+    ) as { notifications: Notification[]; unreadCount: number }
+
+    return NextResponse.json(result)
+  } catch (error) {
+    console.error("[notifications/get] Error:", error)
+    return NextResponse.json(
+      { error: "Failed to fetch notifications", details: String(error) },
+      { status: 500 }
+    )
+  }
 }
 
 // POST /api/notifications — Create notification (escalation, request_input, etc.)
 export async function POST(request: NextRequest) {
-  const body = await request.json()
-  
-  const { 
-    taskId, 
-    projectId,
-    type = "escalation",
-    severity = "info",
-    title,
-    message,
-    agent,
-  } = body
-  
-  if (!message) {
-    return NextResponse.json(
-      { error: "Message is required" },
-      { status: 400 }
-    )
-  }
-  
-  // Resolve project_id from task if not provided
-  let resolvedProjectId = projectId
-  if (!resolvedProjectId && taskId) {
-    const task = db.prepare("SELECT project_id FROM tasks WHERE id = ?").get(taskId) as Task | undefined
-    resolvedProjectId = task?.project_id
-  }
-  
-  const now = Date.now()
-  const id = crypto.randomUUID()
-  
-  // Generate title if not provided
-  const notificationTitle = title || (() => {
-    switch (type) {
-      case "escalation": return `🚨 ${severity === "critical" ? "CRITICAL: " : ""}Escalation`
-      case "request_input": return "❓ Input Requested"
-      case "completion": return "✅ Task Completed"
-      default: return "📢 Notification"
+  try {
+    const body = await request.json()
+
+    const { 
+      taskId, 
+      projectId,
+      type = "escalation",
+      severity = "info",
+      title,
+      message,
+      agent,
+    } = body
+
+    if (!message) {
+      return NextResponse.json(
+        { error: "Message is required" },
+        { status: 400 }
+      )
     }
-  })()
-  
-  const notification: Notification = {
-    id,
-    task_id: taskId || null,
-    project_id: resolvedProjectId || null,
-    type,
-    severity,
-    title: notificationTitle,
-    message,
-    agent: agent || null,
-    read: 0,
-    created_at: now,
-  }
-  
-  db.prepare(`
-    INSERT INTO notifications (id, task_id, project_id, type, severity, title, message, agent, read, created_at)
-    VALUES (@id, @task_id, @project_id, @type, @severity, @title, @message, @agent, @read, @created_at)
-  `).run(notification)
-  
-  // If escalation on a task, also add a comment
-  if (taskId && (type === "escalation" || type === "request_input")) {
-    const commentType = type === "escalation" ? "message" : "request_input"
-    const commentContent = type === "escalation" 
-      ? `## 🚨 Escalation (${severity})\n\n${message}`
-      : `## ❓ Input Requested\n\n${message}`
-    
-    db.prepare(`
-      INSERT INTO comments (id, task_id, author, author_type, content, type, created_at)
-      VALUES (?, ?, ?, 'agent', ?, ?, ?)
-    `).run(
-      crypto.randomUUID(),
-      taskId,
-      agent || "agent",
-      commentContent,
-      commentType,
-      now
+
+    // Create notification
+    const notification = await convexServerClient.mutation(
+      // @ts-expect-error - Convex self-hosted uses any api type
+      { name: "notifications/create" },
+      {
+        taskId: taskId || undefined,
+        projectId: projectId || undefined,
+        type: type as NotificationType,
+        severity: severity as NotificationSeverity,
+        title: title || undefined,
+        message,
+        agent: agent || undefined,
+      }
+    ) as Notification
+
+    // If escalation on a task, also add a comment
+    if (taskId && (type === "escalation" || type === "request_input")) {
+      const commentType = type === "escalation" ? "message" : "request_input"
+      const commentContent = type === "escalation" 
+        ? `## 🚨 Escalation (${severity})\n\n${message}`
+        : `## ❓ Input Requested\n\n${message}`
+
+      await convexServerClient.mutation(
+        // @ts-expect-error - Convex self-hosted uses any api type
+        { name: "comments/create" },
+        {
+          taskId,
+          author: agent || "agent",
+          authorType: "agent",
+          content: commentContent,
+          type: commentType,
+        }
+      )
+    }
+
+    return NextResponse.json({ 
+      notification,
+      success: true,
+    }, { status: 201 })
+  } catch (error) {
+    console.error("[notifications/create] Error:", error)
+    return NextResponse.json(
+      { error: "Failed to create notification", details: String(error) },
+      { status: 500 }
     )
   }
-  
-  return NextResponse.json({ 
-    notification,
-    success: true,
-  }, { status: 201 })
 }

--- a/app/api/projects/[id]/context/route.ts
+++ b/app/api/projects/[id]/context/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server"
-import { db } from "@/lib/db"
+import { convexServerClient } from "@/lib/convex-server"
 import type { Project } from "@/lib/db/types"
 import { buildProjectContext, formatProjectContext } from "@/lib/project-context"
 
@@ -7,25 +7,52 @@ type RouteParams = { params: Promise<{ id: string }> }
 
 // GET /api/projects/[id]/context — Get project context for AI sessions
 export async function GET(request: NextRequest, { params }: RouteParams) {
-  const { id } = await params
-  
-  const project = db.prepare(`
-    SELECT * FROM projects WHERE id = ? OR slug = ?
-  `).get(id, id) as Project | undefined
+  try {
+    const { id } = await params
 
-  if (!project) {
+    // Try to get by ID first, then by slug
+    let project: Project | null = null
+    
+    try {
+      project = await convexServerClient.query(
+        // @ts-expect-error - Convex self-hosted uses any api type
+        { name: "projects/getById" },
+        { id }
+      ) as Project | null
+    } catch {
+      // If not found by ID, try by slug
+      project = null
+    }
+
+    if (!project) {
+      // Try by slug
+      project = await convexServerClient.query(
+        // @ts-expect-error - Convex self-hosted uses any api type
+        { name: "projects/getBySlug" },
+        { slug: id }
+      ) as Project | null
+    }
+
+    if (!project) {
+      return NextResponse.json(
+        { error: "Project not found" },
+        { status: 404 }
+      )
+    }
+
+    const context = buildProjectContext(project)
+    const formatted = formatProjectContext(context)
+
+    return NextResponse.json({
+      context,
+      formatted,
+      sessionKeyPrefix: `trap:${project.slug}`,
+    })
+  } catch (error) {
+    console.error("[projects/context] Error:", error)
     return NextResponse.json(
-      { error: "Project not found" },
-      { status: 404 }
+      { error: "Failed to fetch project context", details: String(error) },
+      { status: 500 }
     )
   }
-
-  const context = buildProjectContext(project)
-  const formatted = formatProjectContext(context)
-
-  return NextResponse.json({
-    context,
-    formatted,
-    sessionKeyPrefix: `trap:${project.slug}`,
-  })
 }

--- a/app/api/signal/[id]/respond/route.ts
+++ b/app/api/signal/[id]/respond/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server"
-import { db } from "@/lib/db"
+import { convexServerClient } from "@/lib/convex-server"
 import type { Signal } from "@/lib/db/types"
 
 // POST /api/signal/[id]/respond — Respond to signal
@@ -7,54 +7,57 @@ export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  const { id } = await params
-  const body = await request.json()
-  
-  const { response } = body
-  
-  if (!response || typeof response !== "string") {
+  try {
+    const { id } = await params
+    const body = await request.json()
+    
+    const { response } = body
+    
+    if (!response || typeof response !== "string") {
+      return NextResponse.json(
+        { error: "response is required and must be a string" },
+        { status: 400 }
+      )
+    }
+
+    const signal = await convexServerClient.mutation(
+      // @ts-expect-error - Convex self-hosted uses any api type
+      { name: "signals/respond" },
+      {
+        id,
+        response,
+      }
+    ) as Signal
+
+    // TODO: Integrate with OpenClaw sessions_send to notify the agent
+    // This will be wired later when OpenClaw session integration is ready
+
+    return NextResponse.json({
+      success: true,
+      signal,
+      // TODO: Add session notification status once OpenClaw integration is ready
+    })
+  } catch (error) {
+    console.error("[signals/respond] Error:", error)
+    
+    if (error instanceof Error) {
+      if (error.message.includes("not found")) {
+        return NextResponse.json(
+          { error: "Signal not found" },
+          { status: 404 }
+        )
+      }
+      if (error.message.includes("already been responded")) {
+        return NextResponse.json(
+          { error: "Signal has already been responded to" },
+          { status: 409 }
+        )
+      }
+    }
+    
     return NextResponse.json(
-      { error: "response is required and must be a string" },
-      { status: 400 }
+      { error: "Failed to respond to signal", details: String(error) },
+      { status: 500 }
     )
   }
-  
-  // Check if signal exists
-  const signal = db.prepare("SELECT * FROM signals WHERE id = ?").get(id) as Signal | undefined
-  
-  if (!signal) {
-    return NextResponse.json(
-      { error: "Signal not found" },
-      { status: 404 }
-    )
-  }
-  
-  // Check if already responded
-  if (signal.responded_at !== null) {
-    return NextResponse.json(
-      { error: "Signal has already been responded to" },
-      { status: 409 }
-    )
-  }
-  
-  const now = Date.now()
-  
-  // Update the signal with response
-  db.prepare(`
-    UPDATE signals 
-    SET response = ?, responded_at = ?
-    WHERE id = ?
-  `).run(response, now, id)
-  
-  // TODO: Integrate with OpenClaw sessions_send to notify the agent
-  // This will be wired later when OpenClaw session integration is ready
-  
-  // Get the updated signal
-  const updatedSignal = db.prepare("SELECT * FROM signals WHERE id = ?").get(id) as Signal
-  
-  return NextResponse.json({
-    success: true,
-    signal: updatedSignal,
-    // TODO: Add session notification status once OpenClaw integration is ready
-  })
 }

--- a/app/api/signal/route.ts
+++ b/app/api/signal/route.ts
@@ -1,142 +1,107 @@
 import { NextRequest, NextResponse } from "next/server"
-import { db } from "@/lib/db"
+import { convexServerClient } from "@/lib/convex-server"
 import type { Signal, SignalKind, SignalSeverity } from "@/lib/db/types"
 
 // GET /api/signal — List pending signals (for gate)
 export async function GET(request: NextRequest) {
-  const { searchParams } = new URL(request.url)
-  const taskId = searchParams.get("task_id")
-  const kind = searchParams.get("kind")
-  const onlyBlocking = searchParams.get("blocking") === "true"
-  const onlyUnresponded = searchParams.get("unresponded") === "true"
-  const limit = parseInt(searchParams.get("limit") || "50")
-  
-  const whereConditions: string[] = []
-  const params: unknown[] = []
-  
-  if (taskId) {
-    whereConditions.push("task_id = ?")
-    params.push(taskId)
+  try {
+    const { searchParams } = new URL(request.url)
+    const taskId = searchParams.get("task_id")
+    const kind = searchParams.get("kind")
+    const onlyBlocking = searchParams.get("blocking") === "true"
+    const onlyUnresponded = searchParams.get("unresponded") === "true"
+    const limit = parseInt(searchParams.get("limit") || "50")
+
+    const result = await convexServerClient.query(
+      // @ts-expect-error - Convex self-hosted uses any api type
+      { name: "signals/getAll" },
+      {
+        taskId: taskId || undefined,
+        kind: kind as SignalKind || undefined,
+        onlyBlocking: onlyBlocking || undefined,
+        onlyUnresponded: onlyUnresponded || undefined,
+        limit,
+      }
+    ) as { signals: Signal[]; pendingCount: number }
+
+    return NextResponse.json(result)
+  } catch (error) {
+    console.error("[signals/get] Error:", error)
+    return NextResponse.json(
+      { error: "Failed to fetch signals", details: String(error) },
+      { status: 500 }
+    )
   }
-  
-  if (kind) {
-    whereConditions.push("kind = ?")
-    params.push(kind)
-  }
-  
-  if (onlyBlocking) {
-    whereConditions.push("blocking = 1")
-  }
-  
-  if (onlyUnresponded) {
-    whereConditions.push("responded_at IS NULL")
-  }
-  
-  const whereClause = whereConditions.length > 0 ? "WHERE " + whereConditions.join(" AND ") : ""
-  
-  const query = `
-    SELECT * FROM signals 
-    ${whereClause}
-    ORDER BY 
-      CASE severity
-        WHEN 'critical' THEN 1
-        WHEN 'high' THEN 2
-        WHEN 'normal' THEN 3
-      END,
-      created_at DESC
-    LIMIT ?
-  `
-  
-  params.push(limit)
-  
-  const signals = db.prepare(query).all(...params) as Signal[]
-  
-  const pendingCount = db.prepare(`
-    SELECT COUNT(*) as count FROM signals 
-    WHERE blocking = 1 AND responded_at IS NULL
-  `).get() as { count: number }
-  
-  return NextResponse.json({
-    signals,
-    pendingCount: pendingCount.count,
-  })
 }
 
 // POST /api/signal — Create signal
 export async function POST(request: NextRequest) {
-  const body = await request.json()
-  
-  const { 
-    taskId,
-    sessionKey,
-    agentId,
-    kind,
-    severity = "normal",
-    message,
-  } = body
-  
-  if (!taskId || !sessionKey || !agentId || !kind || !message) {
+  try {
+    const body = await request.json()
+
+    const { 
+      taskId,
+      sessionKey,
+      agentId,
+      kind,
+      severity = "normal",
+      message,
+    } = body
+
+    if (!taskId || !sessionKey || !agentId || !kind || !message) {
+      return NextResponse.json(
+        { error: "taskId, sessionKey, agentId, kind, and message are required" },
+        { status: 400 }
+      )
+    }
+
+    // Validate kind
+    const validKinds: SignalKind[] = ["question", "blocker", "alert", "fyi"]
+    if (!validKinds.includes(kind)) {
+      return NextResponse.json(
+        { error: `Invalid kind. Must be one of: ${validKinds.join(", ")}` },
+        { status: 400 }
+      )
+    }
+
+    // Validate severity
+    const validSeverities: SignalSeverity[] = ["normal", "high", "critical"]
+    if (!validSeverities.includes(severity)) {
+      return NextResponse.json(
+        { error: `Invalid severity. Must be one of: ${validSeverities.join(", ")}` },
+        { status: 400 }
+      )
+    }
+
+    const signal = await convexServerClient.mutation(
+      // @ts-expect-error - Convex self-hosted uses any api type
+      { name: "signals/create" },
+      {
+        taskId,
+        sessionKey,
+        agentId,
+        kind,
+        severity,
+        message,
+      }
+    ) as Signal
+
+    return NextResponse.json({ 
+      signalId: signal.id,
+      blocking: Boolean(signal.blocking),
+      signal,
+    }, { status: 201 })
+  } catch (error) {
+    console.error("[signals/create] Error:", error)
+    if (error instanceof Error && error.message.includes("not found")) {
+      return NextResponse.json(
+        { error: error.message },
+        { status: 404 }
+      )
+    }
     return NextResponse.json(
-      { error: "taskId, sessionKey, agentId, kind, and message are required" },
-      { status: 400 }
+      { error: "Failed to create signal", details: String(error) },
+      { status: 500 }
     )
   }
-  
-  // Validate kind
-  const validKinds: SignalKind[] = ["question", "blocker", "alert", "fyi"]
-  if (!validKinds.includes(kind)) {
-    return NextResponse.json(
-      { error: `Invalid kind. Must be one of: ${validKinds.join(", ")}` },
-      { status: 400 }
-    )
-  }
-  
-  // Validate severity
-  const validSeverities: SignalSeverity[] = ["normal", "high", "critical"]
-  if (!validSeverities.includes(severity)) {
-    return NextResponse.json(
-      { error: `Invalid severity. Must be one of: ${validSeverities.join(", ")}` },
-      { status: 400 }
-    )
-  }
-  
-  // Verify task exists
-  const task = db.prepare("SELECT id FROM tasks WHERE id = ?").get(taskId)
-  if (!task) {
-    return NextResponse.json(
-      { error: "Task not found" },
-      { status: 404 }
-    )
-  }
-  
-  const now = Date.now()
-  const id = crypto.randomUUID()
-  
-  // Set blocking based on kind (all kinds except "fyi" are blocking)
-  const blocking = kind === "fyi" ? 0 : 1
-  
-  const signal: Signal = {
-    id,
-    task_id: taskId,
-    session_key: sessionKey,
-    agent_id: agentId,
-    kind,
-    severity,
-    message,
-    blocking,
-    responded_at: null,
-    response: null,
-    created_at: now,
-  }
-  
-  db.prepare(`
-    INSERT INTO signals (id, task_id, session_key, agent_id, kind, severity, message, blocking, responded_at, response, created_at)
-    VALUES (@id, @task_id, @session_key, @agent_id, @kind, @severity, @message, @blocking, @responded_at, @response, @created_at)
-  `).run(signal)
-  
-  return NextResponse.json({ 
-    signalId: id,
-    blocking: Boolean(blocking),
-    signal,
-  }, { status: 201 })
 }

--- a/convex/comments.ts
+++ b/convex/comments.ts
@@ -1,0 +1,223 @@
+import { query, mutation } from './_generated/server'
+import { v } from 'convex/values'
+import type { Comment } from '../lib/db/types'
+import type { Id } from './_generated/server'
+
+// ============================================
+// Type Helpers
+// ============================================
+
+type AuthorType = "coordinator" | "agent" | "human"
+type CommentType = "message" | "status_change" | "request_input" | "completion"
+
+// Convert Convex document to Comment type
+function toComment(doc: {
+  _id: string
+  _creationTime: number
+  task_id: string
+  author: string
+  author_type: AuthorType
+  content: string
+  type: CommentType
+  responded_at?: number
+  created_at: number
+}): Comment {
+  return {
+    id: doc._id,
+    task_id: doc.task_id,
+    author: doc.author,
+    author_type: doc.author_type,
+    content: doc.content,
+    type: doc.type,
+    responded_at: doc.responded_at ?? null,
+    created_at: doc.created_at,
+  }
+}
+
+// ============================================
+// Queries
+// ============================================
+
+/**
+ * Get comments for a task
+ */
+export const getByTask = query({
+  args: {
+    taskId: v.id('tasks'),
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, args): Promise<Comment[]> => {
+    let comments = await ctx.db
+      .query('comments')
+      .withIndex('by_task', (q) => q.eq('task_id', args.taskId))
+      .collect()
+
+    // Sort by created_at ascending (oldest first)
+    comments = comments.sort(
+      (a, b) => (a as { created_at: number }).created_at - (b as { created_at: number }).created_at
+    )
+
+    if (args.limit) {
+      comments = comments.slice(0, args.limit)
+    }
+
+    return comments.map((c) => toComment(c as Parameters<typeof toComment>[0]))
+  },
+})
+
+/**
+ * Get a single comment by ID
+ */
+export const getById = query({
+  args: { id: v.id('comments') },
+  handler: async (ctx, args): Promise<Comment | null> => {
+    const comment = await ctx.db.get(args.id)
+
+    if (!comment) {
+      return null
+    }
+
+    return toComment(comment as Parameters<typeof toComment>[0])
+  },
+})
+
+/**
+ * Get pending input requests (unresponded request_input comments)
+ */
+export const getPendingInputs = query({
+  args: { limit: v.optional(v.number()) },
+  handler: async (ctx, args): Promise<Array<Comment & { taskTitle?: string }>> => {
+    const comments = await ctx.db
+      .query('comments')
+      .withIndex('by_type', (q) => q.eq('type', 'request_input'))
+      .collect()
+
+    const pending = comments.filter((c) => !(c as { responded_at?: number }).responded_at)
+
+    // Get task titles
+    const result: Array<Comment & { taskTitle?: string }> = []
+    for (const comment of pending.slice(0, args.limit ?? 10)) {
+      const task = await ctx.db.get((comment as { task_id: string }).task_id as unknown as Id<'tasks'>)
+      const commentData = toComment(comment as Parameters<typeof toComment>[0])
+      result.push({
+        ...commentData,
+        taskTitle: task ? (task as { title: string }).title : undefined,
+      })
+    }
+
+    return result
+  },
+})
+
+/**
+ * Get pending input count
+ */
+export const getPendingInputCount = query({
+  args: {},
+  handler: async (ctx): Promise<number> => {
+    const comments = await ctx.db
+      .query('comments')
+      .withIndex('by_type', (q) => q.eq('type', 'request_input'))
+      .collect()
+
+    return comments.filter((c) => !(c as { responded_at?: number }).responded_at).length
+  },
+})
+
+// ============================================
+// Mutations
+// ============================================
+
+/**
+ * Create a new comment
+ */
+export const create = mutation({
+  args: {
+    taskId: v.id('tasks'),
+    author: v.string(),
+    authorType: v.union(
+      v.literal('coordinator'),
+      v.literal('agent'),
+      v.literal('human')
+    ),
+    content: v.string(),
+    type: v.optional(v.union(
+      v.literal('message'),
+      v.literal('status_change'),
+      v.literal('request_input'),
+      v.literal('completion')
+    )),
+  },
+  handler: async (ctx, args): Promise<Comment> => {
+    if (!args.content || args.content.trim().length === 0) {
+      throw new Error('Content is required')
+    }
+
+    // Verify task exists
+    const task = await ctx.db.get(args.taskId)
+    if (!task) {
+      throw new Error(`Task not found: ${args.taskId}`)
+    }
+
+    const now = Date.now()
+
+    const commentId = await ctx.db.insert('comments', {
+      task_id: args.taskId,
+      author: args.author,
+      author_type: args.authorType,
+      content: args.content.trim(),
+      type: args.type ?? 'message',
+      created_at: now,
+    })
+
+    const comment = await ctx.db.get(commentId)
+    if (!comment) {
+      throw new Error('Failed to create comment')
+    }
+
+    return toComment(comment as Parameters<typeof toComment>[0])
+  },
+})
+
+/**
+ * Mark a request_input comment as responded
+ */
+export const markResponded = mutation({
+  args: { id: v.id('comments') },
+  handler: async (ctx, args): Promise<Comment> => {
+    const existing = await ctx.db.get(args.id)
+
+    if (!existing) {
+      throw new Error(`Comment not found: ${args.id}`)
+    }
+
+    const now = Date.now()
+
+    await ctx.db.patch(args.id, { responded_at: now })
+
+    const updated = await ctx.db.get(args.id)
+    if (!updated) {
+      throw new Error('Failed to update comment')
+    }
+
+    return toComment(updated as Parameters<typeof toComment>[0])
+  },
+})
+
+/**
+ * Delete a comment
+ */
+export const deleteComment = mutation({
+  args: { id: v.id('comments') },
+  handler: async (ctx, args): Promise<{ success: boolean }> => {
+    const existing = await ctx.db.get(args.id)
+
+    if (!existing) {
+      throw new Error(`Comment not found: ${args.id}`)
+    }
+
+    await ctx.db.delete(args.id)
+
+    return { success: true }
+  },
+})

--- a/convex/gate.ts
+++ b/convex/gate.ts
@@ -1,0 +1,349 @@
+import { query } from './_generated/server'
+// Types imported for potential future use
+import type { Id } from './_generated/server'
+
+// ============================================
+// Gate Status Query
+// ============================================
+
+interface GateStatusDetails {
+  readyTasks: number
+  pendingInputs: number
+  stuckTasks: number
+  reviewTasks: number
+  pendingDispatch: number
+  unreadEscalations: number
+  pendingSignals: number
+}
+
+interface GateStatusResponse {
+  needsAttention: boolean
+  reason: string | null
+  details: GateStatusDetails
+  tasks?: {
+    ready: Array<{ id: string; title: string; priority: string }>
+    pendingInput: Array<{ taskId: string; taskTitle: string; author: string; content: string }>
+    stuck: Array<{ id: string; title: string; assignee: string; hours: number }>
+    review: Array<{ id: string; title: string; assignee: string }>
+    pendingDispatch: Array<{ id: string; title: string; assignee: string }>
+  }
+  escalations?: Array<{ id: string; severity: string; message: string; agent: string }>
+  signals?: Array<{ id: string; kind: string; severity: string; message: string; agent_id: string; task_id: string }>
+  timestamp: number
+}
+
+/**
+ * Get full gate status - checks all conditions for coordinator attention
+ */
+export const getStatus = query({
+  args: {},
+  handler: async (ctx): Promise<GateStatusResponse> => {
+    const now = Date.now()
+    const twoHoursAgo = now - (2 * 60 * 60 * 1000)
+
+    // Get all tasks
+    const allTasks = await ctx.db.query('tasks').collect()
+
+    // Count ready tasks (excluding blocked ones)
+    const readyTasks = []
+    for (const task of allTasks) {
+      const taskDoc = task as { _id: string; status: string; assignee?: string; title: string; priority: string }
+      if (taskDoc.status === 'ready' && !taskDoc.assignee) {
+        // Check for incomplete dependencies
+        const deps = await ctx.db
+          .query('taskDependencies')
+          .withIndex('by_task', (q) => q.eq('task_id', taskDoc._id as unknown as Id<'tasks'>))
+          .collect()
+        
+        let hasIncompleteDeps = false
+        for (const dep of deps) {
+          const depTask = await ctx.db.get((dep as { depends_on_id: string }).depends_on_id as unknown as Id<'tasks'>)
+          if (depTask && (depTask as { status: string }).status !== 'done') {
+            hasIncompleteDeps = true
+            break
+          }
+        }
+
+        if (!hasIncompleteDeps) {
+          readyTasks.push(taskDoc)
+        }
+      }
+    }
+
+    // Count stuck tasks (in_progress for > 2 hours)
+    const stuckTasks = allTasks.filter(
+      (t) => (t as { status: string; updated_at: number }).status === 'in_progress' &&
+             (t as { updated_at: number }).updated_at < twoHoursAgo
+    )
+
+    // Count review tasks
+    const reviewTasks = allTasks.filter(
+      (t) => (t as { status: string }).status === 'review'
+    )
+
+    // Count pending dispatch tasks
+    const pendingDispatchTasks = allTasks.filter(
+      (t) => (t as { dispatch_status?: string }).dispatch_status === 'pending'
+    )
+
+    // Count pending input requests
+    const comments = await ctx.db
+      .query('comments')
+      .withIndex('by_type', (q) => q.eq('type', 'request_input'))
+      .collect()
+    const pendingInputs = comments.filter((c) => !(c as { responded_at?: number }).responded_at)
+
+    // Count unread escalations
+    const notifications = await ctx.db
+      .query('notifications')
+      .withIndex('by_read', (q) => q.eq('read', false))
+      .collect()
+    const unreadEscalations = notifications.filter(
+      (n) => (n as { type: string }).type === 'escalation'
+    )
+
+    // Count pending signals (blocking and unresponded)
+    const allSignals = await ctx.db.query('signals').collect()
+    const pendingSignals = allSignals.filter(
+      (s) => (s as { blocking: boolean }).blocking && !(s as { responded_at?: number }).responded_at
+    )
+
+    // Build details
+    const details: GateStatusDetails = {
+      readyTasks: readyTasks.length,
+      pendingInputs: pendingInputs.length,
+      stuckTasks: stuckTasks.length,
+      reviewTasks: reviewTasks.length,
+      pendingDispatch: pendingDispatchTasks.length,
+      unreadEscalations: unreadEscalations.length,
+      pendingSignals: pendingSignals.length,
+    }
+
+    // Build reasons
+    const reasons: string[] = []
+    if (pendingSignals.length > 0) reasons.push(`${pendingSignals.length} pending agent signal(s)`)
+    if (unreadEscalations.length > 0) reasons.push(`${unreadEscalations.length} unread escalation(s)`)
+    if (pendingInputs.length > 0) reasons.push(`${pendingInputs.length} pending input request(s)`)
+    if (pendingDispatchTasks.length > 0) reasons.push(`${pendingDispatchTasks.length} task(s) pending dispatch`)
+    if (readyTasks.length > 0) reasons.push(`${readyTasks.length} task(s) ready for assignment`)
+    if (stuckTasks.length > 0) reasons.push(`${stuckTasks.length} task(s) stuck > 2 hours`)
+    if (reviewTasks.length > 0) reasons.push(`${reviewTasks.length} task(s) ready for review`)
+
+    const needsAttention = reasons.length > 0
+
+    const response: GateStatusResponse = {
+      needsAttention,
+      reason: needsAttention ? reasons.join('; ') : null,
+      details,
+      timestamp: now,
+    }
+
+    // If attention needed, fetch detailed data
+    if (needsAttention) {
+      // Ready tasks (sorted by priority)
+      const priorityOrder: Record<string, number> = { urgent: 1, high: 2, medium: 3, low: 4 }
+      response.tasks = {
+        ready: readyTasks
+          .sort((a, b) => (priorityOrder[a.priority] || 5) - (priorityOrder[b.priority] || 5))
+          .slice(0, 10)
+          .map((t) => ({ id: t._id, title: t.title, priority: t.priority })),
+
+        // Pending inputs with task titles
+        pendingInput: await Promise.all(
+          pendingInputs.slice(0, 10).map(async (c) => {
+            const cDoc = c as { _id: string; task_id: string; author: string; content: string }
+            const task = await ctx.db.get(cDoc.task_id as unknown as Id<'tasks'>)
+            return {
+              taskId: cDoc.task_id,
+              taskTitle: task ? (task as { title: string }).title : 'Unknown',
+              author: cDoc.author,
+              content: cDoc.content,
+            }
+          })
+        ),
+
+        // Stuck tasks
+        stuck: stuckTasks
+          .sort((a, b) => (a as { updated_at: number }).updated_at - (b as { updated_at: number }).updated_at)
+          .slice(0, 10)
+          .map((t) => {
+            const tDoc = t as { _id: string; title: string; assignee?: string; updated_at: number }
+            return {
+              id: tDoc._id,
+              title: tDoc.title,
+              assignee: tDoc.assignee || 'unassigned',
+              hours: Math.floor((now - tDoc.updated_at) / (60 * 60 * 1000)),
+            }
+          }),
+
+        // Review tasks
+        review: reviewTasks
+          .sort((a, b) => (b as { updated_at: number }).updated_at - (a as { updated_at: number }).updated_at)
+          .slice(0, 10)
+          .map((t) => {
+            const tDoc = t as { _id: string; title: string; assignee?: string }
+            return {
+              id: tDoc._id,
+              title: tDoc.title,
+              assignee: tDoc.assignee || 'unassigned',
+            }
+          }),
+
+        // Pending dispatch
+        pendingDispatch: pendingDispatchTasks
+          .sort((a, b) => {
+            const aTime = (a as { dispatch_requested_at?: number }).dispatch_requested_at || 0
+            const bTime = (b as { dispatch_requested_at?: number }).dispatch_requested_at || 0
+            return aTime - bTime
+          })
+          .slice(0, 10)
+          .map((t) => {
+            const tDoc = t as { _id: string; title: string; assignee?: string }
+            return {
+              id: tDoc._id,
+              title: tDoc.title,
+              assignee: tDoc.assignee || 'unassigned',
+            }
+          }),
+      }
+
+      // Escalations
+      if (unreadEscalations.length > 0) {
+        response.escalations = unreadEscalations
+          .sort((a, b) => {
+            const severityOrder: Record<string, number> = { critical: 1, warning: 2, info: 3 }
+            const aDoc = a as { severity: string; created_at: number; _id: string; message: string; agent?: string }
+            const bDoc = b as { severity: string; created_at: number }
+            const sevDiff = (severityOrder[aDoc.severity] || 4) - (severityOrder[bDoc.severity] || 4)
+            if (sevDiff !== 0) return sevDiff
+            return bDoc.created_at - aDoc.created_at
+          })
+          .slice(0, 10)
+          .map((n) => {
+            const nDoc = n as { _id: string; severity: string; message: string; agent?: string }
+            return {
+              id: nDoc._id,
+              severity: nDoc.severity,
+              message: nDoc.message,
+              agent: nDoc.agent || 'unknown',
+            }
+          })
+      }
+
+      // Pending signals
+      if (pendingSignals.length > 0) {
+        response.signals = pendingSignals
+          .sort((a, b) => {
+            const severityOrder: Record<string, number> = { critical: 1, high: 2, normal: 3 }
+            const aDoc = a as { severity: string; created_at: number; _id: string; kind: string; message: string; agent_id: string; task_id: string }
+            const bDoc = b as { severity: string; created_at: number }
+            const sevDiff = (severityOrder[aDoc.severity] || 4) - (severityOrder[bDoc.severity] || 4)
+            if (sevDiff !== 0) return sevDiff
+            return bDoc.created_at - aDoc.created_at
+          })
+          .slice(0, 10)
+          .map((s) => {
+            const sDoc = s as { _id: string; kind: string; severity: string; message: string; agent_id: string; task_id: string }
+            return {
+              id: sDoc._id,
+              kind: sDoc.kind,
+              severity: sDoc.severity,
+              message: sDoc.message,
+              agent_id: sDoc.agent_id,
+              task_id: sDoc.task_id,
+            }
+          })
+      }
+    }
+
+    return response
+  },
+})
+
+/**
+ * Get just the counts for lightweight polling
+ */
+export const getCounts = query({
+  args: {},
+  handler: async (ctx): Promise<GateStatusDetails> => {
+    const now = Date.now()
+    const twoHoursAgo = now - (2 * 60 * 60 * 1000)
+
+    // Get all tasks
+    const allTasks = await ctx.db.query('tasks').collect()
+
+    // Count ready tasks (excluding blocked ones)
+    let readyTasks = 0
+    for (const task of allTasks) {
+      const taskDoc = task as { _id: string; status: string; assignee?: string }
+      if (taskDoc.status === 'ready' && !taskDoc.assignee) {
+        // Check for incomplete dependencies
+        const deps = await ctx.db
+          .query('taskDependencies')
+          .withIndex('by_task', (q) => q.eq('task_id', taskDoc._id as unknown as Id<'tasks'>))
+          .collect()
+        
+        let hasIncompleteDeps = false
+        for (const dep of deps) {
+          const depTask = await ctx.db.get((dep as { depends_on_id: string }).depends_on_id as unknown as Id<'tasks'>)
+          if (depTask && (depTask as { status: string }).status !== 'done') {
+            hasIncompleteDeps = true
+            break
+          }
+        }
+
+        if (!hasIncompleteDeps) {
+          readyTasks++
+        }
+      }
+    }
+
+    // Count stuck tasks (in_progress for > 2 hours)
+    const stuckTasks = allTasks.filter(
+      (t) => (t as { status: string; updated_at: number }).status === 'in_progress' &&
+             (t as { updated_at: number }).updated_at < twoHoursAgo
+    ).length
+
+    // Count review tasks
+    const reviewTasks = allTasks.filter(
+      (t) => (t as { status: string }).status === 'review'
+    ).length
+
+    // Count pending dispatch tasks
+    const pendingDispatch = allTasks.filter(
+      (t) => (t as { dispatch_status?: string }).dispatch_status === 'pending'
+    ).length
+
+    // Count pending input requests
+    const comments = await ctx.db
+      .query('comments')
+      .withIndex('by_type', (q) => q.eq('type', 'request_input'))
+      .collect()
+    const pendingInputs = comments.filter((c) => !(c as { responded_at?: number }).responded_at).length
+
+    // Count unread escalations
+    const notifications = await ctx.db
+      .query('notifications')
+      .withIndex('by_read', (q) => q.eq('read', false))
+      .collect()
+    const unreadEscalations = notifications.filter(
+      (n) => (n as { type: string }).type === 'escalation'
+    ).length
+
+    // Count pending signals (blocking and unresponded)
+    const allSignals = await ctx.db.query('signals').collect()
+    const pendingSignals = allSignals.filter(
+      (s) => (s as { blocking: boolean }).blocking && !(s as { responded_at?: number }).responded_at
+    ).length
+
+    return {
+      readyTasks,
+      pendingInputs,
+      stuckTasks,
+      reviewTasks,
+      pendingDispatch,
+      unreadEscalations,
+      pendingSignals,
+    }
+  },
+})

--- a/convex/notifications.ts
+++ b/convex/notifications.ts
@@ -1,0 +1,289 @@
+import { query, mutation } from './_generated/server'
+import { v } from 'convex/values'
+import type { Notification } from '../lib/db/types'
+
+// ============================================
+// Type Helpers
+// ============================================
+
+type NotificationType = "escalation" | "request_input" | "completion" | "system"
+type NotificationSeverity = "info" | "warning" | "critical"
+
+// Convert Convex document to Notification type
+function toNotification(doc: {
+  _id: string
+  _creationTime: number
+  task_id?: string
+  project_id?: string
+  type: NotificationType
+  severity: NotificationSeverity
+  title: string
+  message: string
+  agent?: string
+  read: boolean
+  created_at: number
+}): Notification {
+  return {
+    id: doc._id,
+    task_id: doc.task_id ?? null,
+    project_id: doc.project_id ?? null,
+    type: doc.type,
+    severity: doc.severity,
+    title: doc.title,
+    message: doc.message,
+    agent: doc.agent ?? null,
+    read: doc.read ? 1 : 0,
+    created_at: doc.created_at,
+  }
+}
+
+// ============================================
+// Queries
+// ============================================
+
+/**
+ * Get all notifications with optional unread filter
+ */
+export const getAll = query({
+  args: {
+    unreadOnly: v.optional(v.boolean()),
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, args): Promise<{ notifications: Notification[]; unreadCount: number }> => {
+    let notifications
+
+    if (args.unreadOnly) {
+      notifications = await ctx.db
+        .query('notifications')
+        .withIndex('by_read', (q) => q.eq('read', false))
+        .collect()
+    } else {
+      notifications = await ctx.db
+        .query('notifications')
+        .order('desc')
+        .collect()
+    }
+
+    // Sort by severity (critical first) then by created_at
+    const sorted = notifications
+      .sort((a, b) => {
+        const severityOrder: Record<NotificationSeverity, number> = {
+          critical: 0,
+          warning: 1,
+          info: 2,
+        }
+        const aDoc = a as { severity: NotificationSeverity; created_at: number }
+        const bDoc = b as { severity: NotificationSeverity; created_at: number }
+        const sevDiff = severityOrder[aDoc.severity] - severityOrder[bDoc.severity]
+        if (sevDiff !== 0) return sevDiff
+        return bDoc.created_at - aDoc.created_at
+      })
+      .slice(0, args.limit ?? 50)
+
+    // Get total unread count
+    const allUnread = await ctx.db
+      .query('notifications')
+      .withIndex('by_read', (q) => q.eq('read', false))
+      .collect()
+
+    return {
+      notifications: sorted.map((n) => toNotification(n as Parameters<typeof toNotification>[0])),
+      unreadCount: allUnread.length,
+    }
+  },
+})
+
+/**
+ * Get a single notification by ID
+ */
+export const getById = query({
+  args: { id: v.id('notifications') },
+  handler: async (ctx, args): Promise<Notification | null> => {
+    const notification = await ctx.db.get(args.id)
+
+    if (!notification) {
+      return null
+    }
+
+    return toNotification(notification as Parameters<typeof toNotification>[0])
+  },
+})
+
+/**
+ * Get unread escalations count
+ */
+export const getUnreadEscalationsCount = query({
+  args: {},
+  handler: async (ctx): Promise<number> => {
+    const notifications = await ctx.db
+      .query('notifications')
+      .withIndex('by_read', (q) => q.eq('read', false))
+      .collect()
+
+    return notifications.filter(
+      (n) => (n as { type: NotificationType }).type === 'escalation'
+    ).length
+  },
+})
+
+/**
+ * Get unread escalations (for gate)
+ */
+export const getUnreadEscalations = query({
+  args: { limit: v.optional(v.number()) },
+  handler: async (ctx, args): Promise<Notification[]> => {
+    const notifications = await ctx.db
+      .query('notifications')
+      .withIndex('by_read', (q) => q.eq('read', false))
+      .collect()
+
+    return notifications
+      .filter((n) => (n as { type: NotificationType }).type === 'escalation')
+      .sort((a, b) => {
+        const severityOrder: Record<NotificationSeverity, number> = {
+          critical: 0,
+          warning: 1,
+          info: 2,
+        }
+        const aDoc = a as { severity: NotificationSeverity; created_at: number }
+        const bDoc = b as { severity: NotificationSeverity; created_at: number }
+        const sevDiff = severityOrder[aDoc.severity] - severityOrder[bDoc.severity]
+        if (sevDiff !== 0) return sevDiff
+        return bDoc.created_at - aDoc.created_at
+      })
+      .slice(0, args.limit ?? 10)
+      .map((n) => toNotification(n as Parameters<typeof toNotification>[0]))
+  },
+})
+
+// ============================================
+// Mutations
+// ============================================
+
+/**
+ * Create a new notification
+ */
+export const create = mutation({
+  args: {
+    taskId: v.optional(v.id('tasks')),
+    projectId: v.optional(v.id('projects')),
+    type: v.optional(v.union(
+      v.literal('escalation'),
+      v.literal('request_input'),
+      v.literal('completion'),
+      v.literal('system')
+    )),
+    severity: v.optional(v.union(
+      v.literal('info'),
+      v.literal('warning'),
+      v.literal('critical')
+    )),
+    title: v.optional(v.string()),
+    message: v.string(),
+    agent: v.optional(v.string()),
+  },
+  handler: async (ctx, args): Promise<Notification> => {
+    if (!args.message || args.message.trim().length === 0) {
+      throw new Error('Message is required')
+    }
+
+    const now = Date.now()
+    const type = args.type ?? 'system'
+    const severity = args.severity ?? 'info'
+
+    // Resolve project_id from task if not provided
+    let resolvedProjectId = args.projectId
+    if (!resolvedProjectId && args.taskId) {
+      const task = await ctx.db.get(args.taskId)
+      if (task) {
+        resolvedProjectId = (task as { project_id: string }).project_id as unknown as typeof resolvedProjectId
+      }
+    }
+
+    // Generate title if not provided
+    const notificationTitle = args.title || (() => {
+      switch (type) {
+        case 'escalation': return `🚨 ${severity === 'critical' ? 'CRITICAL: ' : ''}Escalation`
+        case 'request_input': return '❓ Input Requested'
+        case 'completion': return '✅ Task Completed'
+        default: return '📢 Notification'
+      }
+    })()
+
+    const notificationData: {
+      task_id?: typeof args.taskId
+      project_id?: typeof resolvedProjectId
+      type: typeof type
+      severity: typeof severity
+      title: string
+      message: string
+      agent?: string
+      read: boolean
+      created_at: number
+    } = {
+      type,
+      severity,
+      title: notificationTitle,
+      message: args.message.trim(),
+      read: false,
+      created_at: now,
+    }
+
+    if (args.taskId) notificationData.task_id = args.taskId
+    if (resolvedProjectId) notificationData.project_id = resolvedProjectId
+    if (args.agent) notificationData.agent = args.agent
+
+    const notificationId = await ctx.db.insert('notifications', notificationData)
+
+    const notification = await ctx.db.get(notificationId)
+    if (!notification) {
+      throw new Error('Failed to create notification')
+    }
+
+    return toNotification(notification as Parameters<typeof toNotification>[0])
+  },
+})
+
+/**
+ * Mark notification as read/unread
+ */
+export const markRead = mutation({
+  args: {
+    id: v.id('notifications'),
+    read: v.boolean(),
+  },
+  handler: async (ctx, args): Promise<Notification> => {
+    const existing = await ctx.db.get(args.id)
+
+    if (!existing) {
+      throw new Error(`Notification not found: ${args.id}`)
+    }
+
+    await ctx.db.patch(args.id, { read: args.read })
+
+    const updated = await ctx.db.get(args.id)
+    if (!updated) {
+      throw new Error('Failed to update notification')
+    }
+
+    return toNotification(updated as Parameters<typeof toNotification>[0])
+  },
+})
+
+/**
+ * Delete a notification
+ */
+export const deleteNotification = mutation({
+  args: { id: v.id('notifications') },
+  handler: async (ctx, args): Promise<{ success: boolean }> => {
+    const existing = await ctx.db.get(args.id)
+
+    if (!existing) {
+      throw new Error(`Notification not found: ${args.id}`)
+    }
+
+    await ctx.db.delete(args.id)
+
+    return { success: true }
+  },
+})

--- a/convex/signals.ts
+++ b/convex/signals.ts
@@ -1,0 +1,298 @@
+import { query, mutation } from './_generated/server'
+import { v } from 'convex/values'
+import type { Signal } from '../lib/db/types'
+
+// ============================================
+// Type Helpers
+// ============================================
+
+type SignalKind = "question" | "blocker" | "alert" | "fyi"
+type SignalSeverity = "normal" | "high" | "critical"
+
+// Convert Convex document to Signal type
+function toSignal(doc: {
+  _id: string
+  _creationTime: number
+  task_id: string
+  session_key: string
+  agent_id: string
+  kind: SignalKind
+  severity: SignalSeverity
+  message: string
+  blocking: boolean
+  responded_at?: number
+  response?: string
+  created_at: number
+}): Signal {
+  return {
+    id: doc._id,
+    task_id: doc.task_id,
+    session_key: doc.session_key,
+    agent_id: doc.agent_id,
+    kind: doc.kind,
+    severity: doc.severity,
+    message: doc.message,
+    blocking: doc.blocking ? 1 : 0,
+    responded_at: doc.responded_at ?? null,
+    response: doc.response ?? null,
+    created_at: doc.created_at,
+  }
+}
+
+// ============================================
+// Queries
+// ============================================
+
+/**
+ * Get signals with optional filters
+ */
+export const getAll = query({
+  args: {
+    taskId: v.optional(v.id('tasks')),
+    kind: v.optional(v.union(
+      v.literal('question'),
+      v.literal('blocker'),
+      v.literal('alert'),
+      v.literal('fyi')
+    )),
+    onlyBlocking: v.optional(v.boolean()),
+    onlyUnresponded: v.optional(v.boolean()),
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, args): Promise<{ signals: Signal[]; pendingCount: number }> => {
+    let signals = await ctx.db
+      .query('signals')
+      .order('desc')
+      .collect()
+
+    // Apply filters
+    if (args.taskId) {
+      signals = signals.filter((s) => (s as { task_id: string }).task_id === args.taskId)
+    }
+
+    if (args.kind) {
+      signals = signals.filter((s) => (s as { kind: SignalKind }).kind === args.kind)
+    }
+
+    if (args.onlyBlocking) {
+      signals = signals.filter((s) => (s as { blocking: boolean }).blocking)
+    }
+
+    if (args.onlyUnresponded) {
+      signals = signals.filter((s) => !(s as { responded_at?: number }).responded_at)
+    }
+
+    // Sort by severity (critical first) then by created_at
+    const sorted = signals
+      .sort((a, b) => {
+        const severityOrder: Record<SignalSeverity, number> = {
+          critical: 0,
+          high: 1,
+          normal: 2,
+        }
+        const aDoc = a as { severity: SignalSeverity; created_at: number }
+        const bDoc = b as { severity: SignalSeverity; created_at: number }
+        const sevDiff = severityOrder[aDoc.severity] - severityOrder[bDoc.severity]
+        if (sevDiff !== 0) return sevDiff
+        return bDoc.created_at - aDoc.created_at
+      })
+      .slice(0, args.limit ?? 50)
+
+    // Get pending count (blocking and unresponded)
+    const allSignals = await ctx.db.query('signals').collect()
+    const pendingCount = allSignals.filter(
+      (s) => (s as { blocking: boolean }).blocking && !(s as { responded_at?: number }).responded_at
+    ).length
+
+    return {
+      signals: sorted.map((s) => toSignal(s as Parameters<typeof toSignal>[0])),
+      pendingCount,
+    }
+  },
+})
+
+/**
+ * Get a single signal by ID
+ */
+export const getById = query({
+  args: { id: v.id('signals') },
+  handler: async (ctx, args): Promise<Signal | null> => {
+    const signal = await ctx.db.get(args.id)
+
+    if (!signal) {
+      return null
+    }
+
+    return toSignal(signal as Parameters<typeof toSignal>[0])
+  },
+})
+
+/**
+ * Get pending (blocking and unresponded) signals count
+ */
+export const getPendingCount = query({
+  args: {},
+  handler: async (ctx): Promise<number> => {
+    const signals = await ctx.db
+      .query('signals')
+      .withIndex('by_blocking', (q) => q.eq('blocking', true))
+      .collect()
+
+    return signals.filter((s) => !(s as { responded_at?: number }).responded_at).length
+  },
+})
+
+/**
+ * Get pending signals for gate
+ */
+export const getPending = query({
+  args: { limit: v.optional(v.number()) },
+  handler: async (ctx, args): Promise<Signal[]> => {
+    const signals = await ctx.db
+      .query('signals')
+      .withIndex('by_blocking', (q) => q.eq('blocking', true))
+      .collect()
+
+    return signals
+      .filter((s) => !(s as { responded_at?: number }).responded_at)
+      .sort((a, b) => {
+        const severityOrder: Record<SignalSeverity, number> = {
+          critical: 0,
+          high: 1,
+          normal: 2,
+        }
+        const aDoc = a as { severity: SignalSeverity; created_at: number }
+        const bDoc = b as { severity: SignalSeverity; created_at: number }
+        const sevDiff = severityOrder[aDoc.severity] - severityOrder[bDoc.severity]
+        if (sevDiff !== 0) return sevDiff
+        return bDoc.created_at - aDoc.created_at
+      })
+      .slice(0, args.limit ?? 10)
+      .map((s) => toSignal(s as Parameters<typeof toSignal>[0]))
+  },
+})
+
+// ============================================
+// Mutations
+// ============================================
+
+/**
+ * Create a new signal
+ */
+export const create = mutation({
+  args: {
+    taskId: v.id('tasks'),
+    sessionKey: v.string(),
+    agentId: v.string(),
+    kind: v.union(
+      v.literal('question'),
+      v.literal('blocker'),
+      v.literal('alert'),
+      v.literal('fyi')
+    ),
+    severity: v.optional(v.union(
+      v.literal('normal'),
+      v.literal('high'),
+      v.literal('critical')
+    )),
+    message: v.string(),
+  },
+  handler: async (ctx, args): Promise<Signal> => {
+    // Validate required fields
+    if (!args.message || args.message.trim().length === 0) {
+      throw new Error('Message is required')
+    }
+
+    if (!args.sessionKey || args.sessionKey.trim().length === 0) {
+      throw new Error('Session key is required')
+    }
+
+    if (!args.agentId || args.agentId.trim().length === 0) {
+      throw new Error('Agent ID is required')
+    }
+
+    // Verify task exists
+    const task = await ctx.db.get(args.taskId)
+    if (!task) {
+      throw new Error(`Task not found: ${args.taskId}`)
+    }
+
+    const now = Date.now()
+    const severity = args.severity ?? 'normal'
+    
+    // Set blocking based on kind (all kinds except "fyi" are blocking)
+    const blocking = args.kind !== 'fyi'
+
+    const signalId = await ctx.db.insert('signals', {
+      task_id: args.taskId,
+      session_key: args.sessionKey,
+      agent_id: args.agentId,
+      kind: args.kind,
+      severity,
+      message: args.message.trim(),
+      blocking,
+      created_at: now,
+    })
+
+    const signal = await ctx.db.get(signalId)
+    if (!signal) {
+      throw new Error('Failed to create signal')
+    }
+
+    return toSignal(signal as Parameters<typeof toSignal>[0])
+  },
+})
+
+/**
+ * Respond to a signal
+ */
+export const respond = mutation({
+  args: {
+    id: v.id('signals'),
+    response: v.string(),
+  },
+  handler: async (ctx, args): Promise<Signal> => {
+    const existing = await ctx.db.get(args.id)
+
+    if (!existing) {
+      throw new Error(`Signal not found: ${args.id}`)
+    }
+
+    // Check if already responded
+    if ((existing as { responded_at?: number }).responded_at) {
+      throw new Error('Signal has already been responded to')
+    }
+
+    const now = Date.now()
+
+    await ctx.db.patch(args.id, {
+      response: args.response,
+      responded_at: now,
+    })
+
+    const updated = await ctx.db.get(args.id)
+    if (!updated) {
+      throw new Error('Failed to update signal')
+    }
+
+    return toSignal(updated as Parameters<typeof toSignal>[0])
+  },
+})
+
+/**
+ * Delete a signal
+ */
+export const deleteSignal = mutation({
+  args: { id: v.id('signals') },
+  handler: async (ctx, args): Promise<{ success: boolean }> => {
+    const existing = await ctx.db.get(args.id)
+
+    if (!existing) {
+      throw new Error(`Signal not found: ${args.id}`)
+    }
+
+    await ctx.db.delete(args.id)
+
+    return { success: true }
+  },
+})

--- a/convex/tasks.ts
+++ b/convex/tasks.ts
@@ -98,6 +98,32 @@ function toTaskSummary(doc: {
 // ============================================
 
 /**
+ * Get tasks by status
+ */
+export const getByStatus = query({
+  args: {
+    status: v.union(
+      v.literal('backlog'),
+      v.literal('ready'),
+      v.literal('in_progress'),
+      v.literal('review'),
+      v.literal('done')
+    ),
+  },
+  handler: async (ctx, args): Promise<Task[]> => {
+    const tasks = await ctx.db
+      .query('tasks')
+      .withIndex('by_status', (q) => q.eq('status', args.status))
+      .collect()
+
+    // Sort by position
+    return tasks
+      .sort((a, b) => (a as { position: number }).position - (b as { position: number }).position)
+      .map((t) => toTask(t as Parameters<typeof toTask>[0]))
+  },
+})
+
+/**
  * Get tasks by project with optional status filter
  */
 export const getByProject = query({

--- a/lib/convex-server.ts
+++ b/lib/convex-server.ts
@@ -1,0 +1,23 @@
+import { ConvexHttpClient } from "convex/browser"
+
+const CONVEX_URL = process.env.CONVEX_SELF_HOSTED_URL || process.env.NEXT_PUBLIC_CONVEX_SELF_HOSTED_URL
+
+if (!CONVEX_URL) {
+  throw new Error("CONVEX_SELF_HOSTED_URL or NEXT_PUBLIC_CONVEX_SELF_HOSTED_URL must be set")
+}
+
+/**
+ * Create a Convex HTTP client for server-side use.
+ * Each request should create a new client to avoid sharing state.
+ */
+export function createConvexClient(): ConvexHttpClient {
+  return new ConvexHttpClient(CONVEX_URL!, {
+    skipConvexDeploymentUrlCheck: true,
+  })
+}
+
+/**
+ * Singleton client for cases where creating a new client per request is not feasible.
+ * Use with caution - the ConvexHttpClient is stateful (has auth and queues mutations).
+ */
+export const convexServerClient = createConvexClient()


### PR DESCRIPTION
Migrate the remaining API routes that still import from lib/db (SQLite) to use Convex server client.

## Routes migrated
- app/api/gate/route.ts
- app/api/signal/route.ts  
- app/api/signal/[id]/respond/route.ts
- app/api/dispatch/pending/route.ts
- app/api/notifications/route.ts
- app/api/notifications/[id]/route.ts
- app/api/projects/[id]/context/route.ts

## New Convex functions
- **convex/notifications.ts** - CRUD operations for notifications
- **convex/signals.ts** - CRUD operations for signals  
- **convex/comments.ts** - CRUD operations for comments
- **convex/gate.ts** - Gate status queries for coordinator work loop
- **convex/tasks.ts** - Added getByStatus query

## New utilities
- **lib/convex-server.ts** - Convex HTTP client for server-side use

## Testing
- [x] TypeScript typecheck passes
- [x] ESLint passes (warnings only, no errors)
- [x] Pre-commit hooks pass

Ticket: ef739eaa-3d35-4d25-a244-38b069f41f3a