### PR TITLE
fix: calculate context percentage for session info display

### DIFF
--- a/app/projects/[slug]/chat/page.tsx
+++ b/app/projects/[slug]/chat/page.tsx
@@ -266,6 +266,10 @@ export default function ChatPage({ params }: PageProps) {
     }
 
     fetchSessionInfo()
+    
+    // Refresh session info periodically to keep context percentage up to date
+    const interval = setInterval(fetchSessionInfo, 30000)
+    return () => clearInterval(interval)
   }, [activeChat?.session_key, rpcConnected, getSessionPreview])
 
   // Fetch gateway status and format uptime


### PR DESCRIPTION
Ticket: fb058f79-d305-4c1e-af08-d8e64964189e

## Problem
The SessionInfoDropdown component always showed 0% for context usage because `getSessionPreview` was hardcoding `contextPercentage: 0`.

## Solution
1. **Added model context window mapping** - `getModelContextWindow()` returns context window sizes for all supported models (Claude, Kimi, GPT, Gemini, GLM, MiniMax)
2. **Added context percentage calculation** - `calculateContextPercentage()` computes usage from session tokens / model context window
3. **Updated `getSessionPreview`** - Now fetches actual session token data from `sessions.list` RPC and calculates real context percentage
4. **Added periodic refresh** - Session info refreshes every 30 seconds to keep context % up to date

## Models Supported
- Anthropic Claude (all variants): 200k
- Moonshot Kimi K2: 256k, Kimi for Coding: 262k
- OpenAI GPT-4o/4.5: 128k, GPT-4: 8k, GPT-3.5: 16k
- Google Gemini 1.5: up to 2M tokens
- Z.AI GLM-4: 128k
- MiniMax: 1M

## Testing
- Type check passes
- Lint passes (pre-existing warnings only)