### PR TITLE
chore: clean up obsolete SQLite scripts and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,21 +26,21 @@ PORT=3002 npm run start
 ### Core Concept
 - **Ada (Opus)** - Coordinator agent, maintains state via board
 - **Worker Agents** - Stateless, fresh session per task (kimi-coder, sonnet-reviewer, haiku-triage)
-- **Board** - SQLite-backed task management (replaces GitHub Projects)
+- **Board** - Convex-backed task management (replaces GitHub Projects)
 - **Chat** - Bidirectional communication with OpenClaw main session
 
 ### Tech Stack
 - Next.js 15, TypeScript, React 19
-- SQLite (better-sqlite3, WAL mode)
+- Convex (self-hosted) for real-time data
 - Zustand for state management
 - Tailwind + shadcn/ui
-- WebSocket for real-time updates
+- Convex reactivity for real-time updates
 
 ## Database
 
-Location: `~/.trap/trap.db`
+Trap uses **Convex** (self-hosted) for real-time data synchronization.
 
-Tables:
+### Tables
 - `projects` - Project metadata, repo links
 - `tasks` - Kanban tasks with status, priority, assignee
 - `comments` - Task comments for agent communication
@@ -50,10 +50,18 @@ Tables:
 - `notifications` - System notifications
 - `events` - Activity log
 
-Run migrations:
+### Convex Setup
+
+Convex runs locally via Docker:
 ```bash
-npm run migrate
+# Start Convex (if not already running)
+docker start convex-local  # or check docker-compose
+
+# Deploy schema changes
+npx convex deploy --url http://127.0.0.1:3210 --admin-key '<admin-key>'
 ```
+
+The Convex URL is configured via `NEXT_PUBLIC_CONVEX_URL` (defaults to `http://127.0.0.1:3210`).
 
 ## OpenClaw Integration
 

--- a/package.json
+++ b/package.json
@@ -10,9 +10,6 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest",
     "test:ui": "vitest --ui",
-    "db:migrate": "tsx scripts/migrate.ts",
-    "ws:start": "tsx scripts/start-websocket-server.ts",
-    "ws:dev": "tsx --watch scripts/start-websocket-server.ts",
     "prepare": "husky",
     "convex:dev": "convex dev",
     "convex:deploy": "convex deploy"


### PR DESCRIPTION
Ticket: b0a89d3f-6fe8-4306-a41f-cb87ac524bfe

## Summary
Removes obsolete scripts and documentation references related to SQLite after the Convex migration.

## Changes
- **package.json**: Removed obsolete scripts:
  - `db:migrate` - SQLite migration script (no longer needed)
  - `ws:start` and `ws:dev` - WebSocket server scripts (replaced by Convex reactivity)
  
- **README.md**: Updated documentation:
  - Changed "SQLite-backed task management" → "Convex-backed task management"
  - Updated Tech Stack: SQLite → Convex (self-hosted)
  - Replaced WebSocket real-time updates → Convex reactivity
  - Added Convex Setup section with Docker and deploy instructions
  - Removed `npm run migrate` command (no longer needed)

## Verification
- [x] No obsolete scripts remain in package.json
- [x] No documentation references to SQLite setup
- [x] All remaining package.json scripts work correctly
- [x] Documentation reflects Convex-only architecture