### PR TITLE
feat: replace WS chat.send with HTTP POST to OpenClaw

### DIFF
--- a/lib/openclaw/rpc.ts
+++ b/lib/openclaw/rpc.ts
@@ -1,0 +1,147 @@
+/**
+ * OpenClaw HTTP RPC Client
+ * Standalone HTTP client for OpenClaw RPC calls (no React, no WebSocket)
+ */
+
+// Fallback UUID generator for non-secure contexts
+function generateUUID(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+    const r = Math.random() * 16 | 0;
+    const v = c === 'x' ? r : (r & 0x3 | 0x8);
+    return v.toString(16);
+  });
+}
+
+// Get the OpenClaw HTTP URL from environment or default
+function getOpenClawUrl(): string {
+  if (typeof process !== 'undefined' && process.env?.NEXT_PUBLIC_OPENCLAW_HTTP_URL) {
+    return process.env.NEXT_PUBLIC_OPENCLAW_HTTP_URL;
+  }
+  // Default to localhost:18789 (standard OpenClaw HTTP port)
+  return 'http://127.0.0.1:18789';
+}
+
+// Get the auth token from environment
+function getAuthToken(): string {
+  if (typeof process !== 'undefined' && process.env?.NEXT_PUBLIC_OPENCLAW_TOKEN) {
+    return process.env.NEXT_PUBLIC_OPENCLAW_TOKEN;
+  }
+  return '';
+}
+
+export interface RpcRequest {
+  type: 'req';
+  id: string;
+  method: string;
+  params?: Record<string, unknown>;
+}
+
+export interface RpcResponse<T = unknown> {
+  type: 'res';
+  id: string;
+  ok: boolean;
+  payload?: T;
+  error?: {
+    message: string;
+    code?: string;
+  };
+}
+
+export interface ChatSendResult {
+  runId: string;
+  status: 'started' | 'queued' | 'error';
+}
+
+/**
+ * Make an HTTP RPC call to OpenClaw
+ * @param method - The RPC method name
+ * @param params - Method parameters
+ * @returns Promise with the response payload
+ */
+export async function rpc<T = unknown>(
+  method: string,
+  params?: Record<string, unknown>
+): Promise<T> {
+  const url = `${getOpenClawUrl()}/rpc`;
+  const token = getAuthToken();
+
+  const request: RpcRequest = {
+    type: 'req',
+    id: generateUUID(),
+    method,
+    params: params || {}
+  };
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(token ? { 'Authorization': `Bearer ${token}` } : {})
+    },
+    body: JSON.stringify(request)
+  });
+
+  if (!response.ok) {
+    throw new Error(`OpenClaw HTTP ${response.status}: ${response.statusText}`);
+  }
+
+  const rpcResponse: RpcResponse<T> = await response.json();
+
+  if (!rpcResponse.ok || rpcResponse.error) {
+    throw new Error(rpcResponse.error?.message || 'OpenClaw RPC error');
+  }
+
+  return rpcResponse.payload as T;
+}
+
+/**
+ * Send a chat message via HTTP POST to OpenClaw
+ * @param message - The message content
+ * @param sessionKey - The session key (default: 'main')
+ * @param trapChatId - Optional trap chat ID for context
+ * @returns Promise with runId and status
+ */
+export async function sendChatMessage(
+  message: string,
+  sessionKey = 'main',
+  trapChatId?: string
+): Promise<ChatSendResult> {
+  const idempotencyKey = generateUUID();
+
+  const contextMessage = trapChatId
+    ? `[Trap Chat ID: ${trapChatId}]\n\n${message}`
+    : message;
+
+  const result = await rpc<ChatSendResult>('chat.send', {
+    sessionKey,
+    message: contextMessage,
+    idempotencyKey
+  });
+
+  return result;
+}
+
+/**
+ * Abort an ongoing chat session
+ * @param sessionKey - The session key to abort
+ */
+export async function abortChat(sessionKey: string): Promise<void> {
+  await rpc('chat.abort', { sessionKey });
+}
+
+/**
+ * Check if OpenClaw HTTP API is available
+ * @returns Promise<boolean> indicating if the API is reachable
+ */
+export async function isOpenClawAvailable(): Promise<boolean> {
+  try {
+    // Use a lightweight config.get call to check availability
+    await rpc('config.get', {});
+    return true;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
Replace the WebSocket "chat.send" RPC with a direct HTTP POST to the OpenClaw API for improved reliability.

## Changes
- **Created** "lib/openclaw/rpc.ts" — standalone HTTP RPC client (no React, no WebSocket)
- **Updated** "lib/providers/openclaw-ws-provider.tsx" — use HTTP for chat.send, keep WS for events
- **Updated** "app/projects/[slug]/chat/page.tsx" — remove WS connection check before sending

## Why
- WebSocket connections can drop during gateway restarts, causing message send failures
- HTTP POST is stateless and more reliable for critical operations like sending messages
- WebSocket is still used for best-effort features: typing indicators, streaming deltas

## Testing
- TypeScript typecheck passes
- ESLint passes (warnings are pre-existing)

Ticket: 45983ea8-dcdb-47a5-95c7-08c7bc21c1e4