### PR TITLE
feat: add global work loop toggle and work_loop_max_agents

### DIFF
--- a/app/api/projects/[id]/route.ts
+++ b/app/api/projects/[id]/route.ts
@@ -67,7 +67,7 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
       )
     }
 
-    const { name, slug, description, color, repo_url, context_path, chat_layout, local_path, github_repo, work_loop_enabled, work_loop_schedule } = body
+    const { name, slug, description, color, repo_url, context_path, chat_layout, local_path, github_repo, work_loop_enabled, work_loop_max_agents, work_loop_schedule } = body
 
     // Validate local_path if provided
     if (local_path !== undefined && local_path !== null && typeof local_path !== 'string') {
@@ -95,6 +95,16 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
       )
     }
 
+    // Validate work_loop_max_agents if provided
+    if (work_loop_max_agents !== undefined && work_loop_max_agents !== null) {
+      if (typeof work_loop_max_agents !== 'number' || work_loop_max_agents < 1 || !Number.isInteger(work_loop_max_agents)) {
+        return NextResponse.json(
+          { error: "work_loop_max_agents must be a positive integer" },
+          { status: 400 }
+        )
+      }
+    }
+
     // Validate work_loop_schedule if provided
     if (work_loop_schedule !== undefined && work_loop_schedule !== null) {
       if (typeof work_loop_schedule !== 'string') {
@@ -117,6 +127,7 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
     if (github_repo !== undefined) updates.github_repo = github_repo
     if (chat_layout !== undefined) updates.chat_layout = chat_layout
     if (work_loop_enabled !== undefined) updates.work_loop_enabled = work_loop_enabled
+    if (work_loop_max_agents !== undefined) updates.work_loop_max_agents = work_loop_max_agents
     if (work_loop_schedule !== undefined) updates.work_loop_schedule = work_loop_schedule
 
     const project = await convex.mutation(api.projects.update, {

--- a/app/api/projects/route.ts
+++ b/app/api/projects/route.ts
@@ -21,7 +21,7 @@ export async function GET() {
 export async function POST(request: NextRequest) {
   const body = await request.json()
 
-  const { name, slug, description, color, repo_url, chat_layout, local_path, github_repo, work_loop_enabled, work_loop_schedule } = body
+  const { name, slug, description, color, repo_url, chat_layout, local_path, github_repo, work_loop_enabled, work_loop_max_agents, work_loop_schedule } = body
 
   if (!name || !slug) {
     return NextResponse.json(
@@ -56,6 +56,16 @@ export async function POST(request: NextRequest) {
     )
   }
 
+  // Validate work_loop_max_agents if provided
+  if (work_loop_max_agents !== undefined && work_loop_max_agents !== null) {
+    if (typeof work_loop_max_agents !== 'number' || work_loop_max_agents < 1 || !Number.isInteger(work_loop_max_agents)) {
+      return NextResponse.json(
+        { error: "work_loop_max_agents must be a positive integer" },
+        { status: 400 }
+      )
+    }
+  }
+
   // Validate work_loop_schedule if provided
   if (work_loop_schedule) {
     if (typeof work_loop_schedule !== 'string') {
@@ -78,6 +88,7 @@ export async function POST(request: NextRequest) {
       github_repo: github_repo || undefined,
       chat_layout: chat_layout || undefined,
       work_loop_enabled: work_loop_enabled ?? undefined,
+      work_loop_max_agents: work_loop_max_agents ?? undefined,
       work_loop_schedule: work_loop_schedule || undefined,
     })
 

--- a/convex/projects.ts
+++ b/convex/projects.ts
@@ -53,6 +53,7 @@ function toProject(doc: {
   github_repo?: string
   chat_layout: 'slack' | 'imessage'
   work_loop_enabled: boolean
+  work_loop_max_agents?: number
   work_loop_schedule: string
   created_at: number
   updated_at: number
@@ -69,6 +70,7 @@ function toProject(doc: {
     github_repo: doc.github_repo ?? null,
     chat_layout: doc.chat_layout,
     work_loop_enabled: doc.work_loop_enabled ? 1 : 0,
+    work_loop_max_agents: doc.work_loop_max_agents ?? null,
     work_loop_schedule: doc.work_loop_schedule,
     created_at: doc.created_at,
     updated_at: doc.updated_at,
@@ -161,6 +163,7 @@ export const create = mutation({
     github_repo: v.optional(v.string()),
     chat_layout: v.optional(v.union(v.literal('slack'), v.literal('imessage'))),
     work_loop_enabled: v.optional(v.boolean()),
+    work_loop_max_agents: v.optional(v.number()),
     work_loop_schedule: v.optional(v.string()),
     slug: v.optional(v.string()),
   },
@@ -200,6 +203,7 @@ export const create = mutation({
       github_repo: args.github_repo?.trim() || undefined,
       chat_layout: args.chat_layout || 'slack',
       work_loop_enabled: args.work_loop_enabled ?? false,
+      work_loop_max_agents: args.work_loop_max_agents ?? undefined,
       work_loop_schedule: args.work_loop_schedule?.trim() || '*/5 * * * *',
       created_at: now,
       updated_at: now,
@@ -230,6 +234,7 @@ export const update = mutation({
     github_repo: v.optional(v.string()),
     chat_layout: v.optional(v.union(v.literal('slack'), v.literal('imessage'))),
     work_loop_enabled: v.optional(v.boolean()),
+    work_loop_max_agents: v.optional(v.number()),
     work_loop_schedule: v.optional(v.string()),
     slug: v.optional(v.string()),
   },
@@ -282,6 +287,7 @@ export const update = mutation({
     if (args.github_repo !== undefined) updates.github_repo = args.github_repo?.trim() ?? undefined
     if (args.chat_layout !== undefined) updates.chat_layout = args.chat_layout
     if (args.work_loop_enabled !== undefined) updates.work_loop_enabled = args.work_loop_enabled
+    if (args.work_loop_max_agents !== undefined) updates.work_loop_max_agents = args.work_loop_max_agents
     if (args.work_loop_schedule !== undefined) updates.work_loop_schedule = args.work_loop_schedule.trim()
 
     await ctx.db.patch(existing._id, updates)

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -15,6 +15,7 @@ export default defineSchema({
     github_repo: v.optional(v.string()),
     chat_layout: v.union(v.literal("slack"), v.literal("imessage")),
     work_loop_enabled: v.boolean(),
+    work_loop_max_agents: v.optional(v.number()),
     work_loop_schedule: v.string(),
     created_at: v.number(),
     updated_at: v.number(),

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -35,6 +35,7 @@ export interface Project {
   github_repo: string | null
   chat_layout: 'slack' | 'imessage'
   work_loop_enabled: number  // SQLite boolean (0/1)
+  work_loop_max_agents: number | null
   work_loop_schedule: string  // cron expression
   created_at: number
   updated_at: number

--- a/worker/config.ts
+++ b/worker/config.ts
@@ -1,0 +1,98 @@
+/**
+ * Work loop configuration
+ *
+ * Global defaults for the work loop system. Can be overridden via environment
+ * variables. Per-project settings are stored in Convex on the project record.
+ */
+
+export interface WorkLoopConfig {
+  /** Global on/off switch — default false (disabled) */
+  enabled: boolean
+  /** Sleep between cycles in milliseconds — default 30000 (30s) */
+  cycleIntervalMs: number
+  /** Max concurrent agents per project — default 2 */
+  maxAgentsPerProject: number
+  /** Max concurrent agents globally — default 5 */
+  maxAgentsGlobal: number
+  /** How long before in_progress is considered "stalled" — default 60 minutes */
+  staleTaskMinutes: number
+  /** How long before in_review without PR is stalled — default 30 minutes */
+  staleReviewMinutes: number
+}
+
+/**
+ * Default configuration values
+ */
+const DEFAULT_CONFIG: WorkLoopConfig = {
+  enabled: false,
+  cycleIntervalMs: 30000,
+  maxAgentsPerProject: 2,
+  maxAgentsGlobal: 5,
+  staleTaskMinutes: 60,
+  staleReviewMinutes: 30,
+}
+
+/**
+ * Parse a boolean from an environment variable
+ */
+function parseBool(value: string | undefined, defaultValue: boolean): boolean {
+  if (value === undefined || value === '') {
+    return defaultValue
+  }
+  return value.toLowerCase() === 'true' || value === '1'
+}
+
+/**
+ * Parse a number from an environment variable
+ */
+function parseNumber(value: string | undefined, defaultValue: number): number {
+  if (value === undefined || value === '') {
+    return defaultValue
+  }
+  const parsed = Number(value)
+  if (isNaN(parsed) || parsed < 0) {
+    return defaultValue
+  }
+  return parsed
+}
+
+/**
+ * Load work loop configuration from environment variables
+ *
+ * Environment variables:
+ * - WORK_LOOP_ENABLED — boolean (default: false)
+ * - WORK_LOOP_CYCLE_MS — number in milliseconds (default: 30000)
+ * - WORK_LOOP_MAX_AGENTS — max global agents (default: 5)
+ * - WORK_LOOP_MAX_AGENTS_PER_PROJECT — max per project (default: 2)
+ * - WORK_LOOP_STALE_TASK_MINUTES — minutes before in_progress is stalled (default: 60)
+ * - WORK_LOOP_STALE_REVIEW_MINUTES — minutes before in_review is stalled (default: 30)
+ */
+export function loadConfig(): WorkLoopConfig {
+  return {
+    enabled: parseBool(process.env.WORK_LOOP_ENABLED, DEFAULT_CONFIG.enabled),
+    cycleIntervalMs: parseNumber(process.env.WORK_LOOP_CYCLE_MS, DEFAULT_CONFIG.cycleIntervalMs),
+    maxAgentsPerProject: parseNumber(process.env.WORK_LOOP_MAX_AGENTS_PER_PROJECT, DEFAULT_CONFIG.maxAgentsPerProject),
+    maxAgentsGlobal: parseNumber(process.env.WORK_LOOP_MAX_AGENTS, DEFAULT_CONFIG.maxAgentsGlobal),
+    staleTaskMinutes: parseNumber(process.env.WORK_LOOP_STALE_TASK_MINUTES, DEFAULT_CONFIG.staleTaskMinutes),
+    staleReviewMinutes: parseNumber(process.env.WORK_LOOP_STALE_REVIEW_MINUTES, DEFAULT_CONFIG.staleReviewMinutes),
+  }
+}
+
+/**
+ * Get the effective configuration for a project
+ *
+ * Merges global defaults with per-project overrides from Convex.
+ */
+export function getProjectConfig(
+  globalConfig: WorkLoopConfig,
+  projectOverrides: {
+    work_loop_enabled?: boolean | null
+    work_loop_max_agents?: number | null
+  }
+): WorkLoopConfig {
+  return {
+    ...globalConfig,
+    enabled: projectOverrides.work_loop_enabled ?? globalConfig.enabled,
+    maxAgentsPerProject: projectOverrides.work_loop_max_agents ?? globalConfig.maxAgentsPerProject,
+  }
+}


### PR DESCRIPTION
Ticket: 2e3d8fba-a202-46a1-a53d-20abb789bc97

## Summary
Adds a global on/off toggle for the work loop and API endpoints to control loop state.

## Changes
- **worker/config.ts** — New configuration module with:
  - `WorkLoopConfig` interface
  - `loadConfig()` — reads from env vars
  - `getProjectConfig()` — merges global + per-project overrides
  
- **convex/schema.ts** — Added `work_loop_max_agents` optional number field to projects table

- **lib/types/index.ts** — Added `work_loop_max_agents` to Project interface

- **convex/projects.ts** — Updated create/update mutations to handle new field

- **app/api/projects/[id]/route.ts** — PATCH accepts `work_loop_max_agents`

- **app/api/projects/route.ts** — POST accepts `work_loop_max_agents`

## Defaults (all disabled)
- Global enabled: `false`
- Cycle interval: 30s
- Max agents per project: 2
- Max agents global: 5
- Stale task threshold: 60 minutes
- Stale review threshold: 30 minutes

## Environment Variables
- `WORK_LOOP_ENABLED` — boolean
- `WORK_LOOP_CYCLE_MS` — number
- `WORK_LOOP_MAX_AGENTS` — number
- `WORK_LOOP_MAX_AGENTS_PER_PROJECT` — number
- `WORK_LOOP_STALE_TASK_MINUTES` — number
- `WORK_LOOP_STALE_REVIEW_MINUTES` — number
