### PR TITLE
feat: child process manager for OpenClaw sessions

### DIFF
--- a/worker/children.test.ts
+++ b/worker/children.test.ts
@@ -1,0 +1,523 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import type { ChildProcess } from "node:child_process"
+
+// Track the mock spawn function so we can access it in tests
+let mockSpawnFn = vi.fn()
+
+vi.mock(import("node:child_process"), async (importOriginal) => {
+  const actual = await importOriginal()
+  return {
+    ...actual,
+    default: { ...actual, spawn: (...args: unknown[]) => mockSpawnFn(...args) },
+    spawn: (...args: unknown[]) => mockSpawnFn(...args),
+  }
+})
+
+// Import after mock setup
+const { ChildManager } = await import("./children")
+import type { SpawnParams } from "./children"
+
+describe("ChildManager", () => {
+  let manager: InstanceType<typeof ChildManager>
+
+  // Helper to create a mock ChildProcess
+  function createMockChildProcess(pid: number): ChildProcess {
+    const stdout = {
+      on: vi.fn(),
+    }
+    const stderr = {
+      on: vi.fn(),
+    }
+    const proc = {
+      pid,
+      stdout,
+      stderr,
+      kill: vi.fn(),
+      on: vi.fn(),
+    } as unknown as ChildProcess
+
+    return proc
+  }
+
+  beforeEach(() => {
+    manager = new ChildManager()
+    vi.useFakeTimers()
+    mockSpawnFn = vi.fn()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  describe("spawn", () => {
+    it("should spawn openclaw chat with message", () => {
+      const mockProc = createMockChildProcess(1234)
+      mockSpawnFn.mockReturnValue(mockProc)
+
+      const params: SpawnParams = {
+        taskId: "task-123",
+        projectId: "proj-456",
+        role: "dev",
+        message: "Implement feature",
+      }
+
+      const child = manager.spawn(params)
+
+      expect(mockSpawnFn).toHaveBeenCalledWith(
+        "openclaw",
+        ["chat", "--message", "Implement feature"],
+        {
+          stdio: ["ignore", "pipe", "pipe"],
+          env: expect.any(Object),
+        }
+      )
+      expect(child.pid).toBe(1234)
+      expect(child.taskId).toBe("task-123")
+      expect(child.projectId).toBe("proj-456")
+      expect(child.role).toBe("dev")
+      expect(child.sessionKey).toBe("workloop:dev:task-123")
+    })
+
+    it("should include model flag when provided", () => {
+      const mockProc = createMockChildProcess(1234)
+      mockSpawnFn.mockReturnValue(mockProc)
+
+      manager.spawn({
+        taskId: "task-123",
+        projectId: "proj-456",
+        role: "dev",
+        message: "Do work",
+        model: "claude-sonnet",
+      })
+
+      expect(mockSpawnFn).toHaveBeenCalledWith(
+        "openclaw",
+        ["chat", "--message", "Do work", "--model", "claude-sonnet"],
+        expect.any(Object)
+      )
+    })
+
+    it("should include label flag when provided", () => {
+      const mockProc = createMockChildProcess(1234)
+      mockSpawnFn.mockReturnValue(mockProc)
+
+      manager.spawn({
+        taskId: "task-123",
+        projectId: "proj-456",
+        role: "dev",
+        message: "Do work",
+        label: "my-task",
+      })
+
+      expect(mockSpawnFn).toHaveBeenCalledWith(
+        "openclaw",
+        ["chat", "--message", "Do work", "--label", "my-task"],
+        expect.any(Object)
+      )
+    })
+
+    it("should throw if process has no pid", () => {
+      const mockProc = createMockChildProcess(1234)
+      // Create a copy without pid to simulate failure case
+      const procWithoutPid = { ...mockProc, pid: undefined } as unknown as ChildProcess
+      mockSpawnFn.mockReturnValue(procWithoutPid)
+
+      expect(() =>
+        manager.spawn({
+          taskId: "task-123",
+          projectId: "proj-456",
+          role: "dev",
+          message: "Do work",
+        })
+      ).toThrow("Failed to spawn openclaw process for task task-123")
+    })
+
+    it("should track child and allow retrieval", () => {
+      const mockProc = createMockChildProcess(1234)
+      mockSpawnFn.mockReturnValue(mockProc)
+
+      const child = manager.spawn({
+        taskId: "task-123",
+        projectId: "proj-456",
+        role: "dev",
+        message: "Do work",
+      })
+
+      expect(manager.get("task-123")).toBe(child)
+      expect(manager.size()).toBe(1)
+    })
+  })
+
+  describe("stdout/stderr tracking", () => {
+    it("should update lastOutput on stdout data", () => {
+      const mockProc = createMockChildProcess(1234)
+      mockSpawnFn.mockReturnValue(mockProc)
+
+      vi.setSystemTime(1000)
+      manager.spawn({
+        taskId: "task-123",
+        projectId: "proj-456",
+        role: "dev",
+        message: "Do work",
+      })
+
+      vi.setSystemTime(2000)
+      const stdoutHandler = mockProc.stdout?.on as ReturnType<typeof vi.fn>
+      const dataHandler = stdoutHandler.mock.calls.find((call) => call[0] === "data")?.[1]
+
+      dataHandler(Buffer.from("hello"))
+
+      const child = manager.get("task-123")
+      expect(child?.lastOutput).toBe(2000)
+      expect(child?.totalBytes).toBe(5)
+    })
+
+    it("should update lastOutput on stderr data", () => {
+      const mockProc = createMockChildProcess(1234)
+      mockSpawnFn.mockReturnValue(mockProc)
+
+      vi.setSystemTime(1000)
+      manager.spawn({
+        taskId: "task-123",
+        projectId: "proj-456",
+        role: "dev",
+        message: "Do work",
+      })
+
+      vi.setSystemTime(3000)
+      const stderrHandler = mockProc.stderr?.on as ReturnType<typeof vi.fn>
+      const dataHandler = stderrHandler.mock.calls.find((call) => call[0] === "data")?.[1]
+
+      dataHandler(Buffer.from("error"))
+
+      const child = manager.get("task-123")
+      expect(child?.lastOutput).toBe(3000)
+    })
+  })
+
+  describe("exit handling", () => {
+    it("should set exitCode when process exits", () => {
+      const mockProc = createMockChildProcess(1234)
+      mockSpawnFn.mockReturnValue(mockProc)
+
+      manager.spawn({
+        taskId: "task-123",
+        projectId: "proj-456",
+        role: "dev",
+        message: "Do work",
+      })
+
+      const onHandler = mockProc.on as ReturnType<typeof vi.fn>
+      const exitHandler = onHandler.mock.calls.find((call) => call[0] === "exit")?.[1]
+
+      exitHandler(0)
+
+      const child = manager.get("task-123")
+      expect(child?.exitCode).toBe(0)
+    })
+
+    it("should set exitCode to 1 when process exits with null code", () => {
+      const mockProc = createMockChildProcess(1234)
+      mockSpawnFn.mockReturnValue(mockProc)
+
+      manager.spawn({
+        taskId: "task-123",
+        projectId: "proj-456",
+        role: "dev",
+        message: "Do work",
+      })
+
+      const onHandler = mockProc.on as ReturnType<typeof vi.fn>
+      const exitHandler = onHandler.mock.calls.find((call) => call[0] === "exit")?.[1]
+
+      exitHandler(null)
+
+      const child = manager.get("task-123")
+      expect(child?.exitCode).toBe(1)
+    })
+  })
+
+  describe("active", () => {
+    it("should return only non-exited processes", () => {
+      const mockProc1 = createMockChildProcess(1234)
+      const mockProc2 = createMockChildProcess(5678)
+      mockSpawnFn.mockReturnValueOnce(mockProc1).mockReturnValueOnce(mockProc2)
+
+      manager.spawn({
+        taskId: "task-1",
+        projectId: "proj-456",
+        role: "dev",
+        message: "Work 1",
+      })
+      manager.spawn({
+        taskId: "task-2",
+        projectId: "proj-456",
+        role: "dev",
+        message: "Work 2",
+      })
+
+      // Exit first process
+      const onHandler = mockProc1.on as ReturnType<typeof vi.fn>
+      const exitHandler = onHandler.mock.calls.find((call) => call[0] === "exit")?.[1]
+      exitHandler(0)
+
+      const active = manager.active()
+      expect(active).toHaveLength(1)
+      expect(active[0].taskId).toBe("task-2")
+    })
+  })
+
+  describe("activeCount", () => {
+    it("should return total active count when no project filter", () => {
+      const mockProc1 = createMockChildProcess(1234)
+      const mockProc2 = createMockChildProcess(5678)
+      mockSpawnFn.mockReturnValueOnce(mockProc1).mockReturnValueOnce(mockProc2)
+
+      manager.spawn({
+        taskId: "task-1",
+        projectId: "proj-a",
+        role: "dev",
+        message: "Work 1",
+      })
+      manager.spawn({
+        taskId: "task-2",
+        projectId: "proj-b",
+        role: "dev",
+        message: "Work 2",
+      })
+
+      expect(manager.activeCount()).toBe(2)
+    })
+
+    it("should return filtered count when projectId provided", () => {
+      const mockProc1 = createMockChildProcess(1234)
+      const mockProc2 = createMockChildProcess(5678)
+      mockSpawnFn.mockReturnValueOnce(mockProc1).mockReturnValueOnce(mockProc2)
+
+      manager.spawn({
+        taskId: "task-1",
+        projectId: "proj-a",
+        role: "dev",
+        message: "Work 1",
+      })
+      manager.spawn({
+        taskId: "task-2",
+        projectId: "proj-b",
+        role: "dev",
+        message: "Work 2",
+      })
+
+      expect(manager.activeCount("proj-a")).toBe(1)
+      expect(manager.activeCount("proj-b")).toBe(1)
+      expect(manager.activeCount("proj-c")).toBe(0)
+    })
+  })
+
+  describe("reap", () => {
+    it("should return completed children and remove from tracking", () => {
+      const mockProc = createMockChildProcess(1234)
+      mockSpawnFn.mockReturnValue(mockProc)
+
+      vi.setSystemTime(1000)
+      manager.spawn({
+        taskId: "task-123",
+        projectId: "proj-456",
+        role: "dev",
+        message: "Do work",
+      })
+
+      // Process exits
+      const onHandler = mockProc.on as ReturnType<typeof vi.fn>
+      const exitHandler = onHandler.mock.calls.find((call) => call[0] === "exit")?.[1]
+      exitHandler(42)
+
+      vi.setSystemTime(5000)
+      const reaped = manager.reap()
+
+      expect(reaped).toHaveLength(1)
+      expect(reaped[0]).toEqual({
+        taskId: "task-123",
+        exitCode: 42,
+        durationMs: 4000,
+      })
+      expect(manager.size()).toBe(0)
+      expect(manager.get("task-123")).toBeUndefined()
+    })
+
+    it("should return empty array when no completed children", () => {
+      const mockProc = createMockChildProcess(1234)
+      mockSpawnFn.mockReturnValue(mockProc)
+
+      manager.spawn({
+        taskId: "task-123",
+        projectId: "proj-456",
+        role: "dev",
+        message: "Do work",
+      })
+
+      const reaped = manager.reap()
+      expect(reaped).toHaveLength(0)
+      expect(manager.size()).toBe(1)
+    })
+  })
+
+  describe("kill", () => {
+    it("should send SIGTERM to active process", () => {
+      const mockProc = createMockChildProcess(1234)
+      mockSpawnFn.mockReturnValue(mockProc)
+
+      manager.spawn({
+        taskId: "task-123",
+        projectId: "proj-456",
+        role: "dev",
+        message: "Do work",
+      })
+
+      manager.kill("task-123")
+
+      expect(mockProc.kill).toHaveBeenCalledWith("SIGTERM")
+    })
+
+    it("should not throw for unknown taskId", () => {
+      expect(() => manager.kill("unknown")).not.toThrow()
+    })
+
+    it("should not kill already exited process", () => {
+      const mockProc = createMockChildProcess(1234)
+      mockSpawnFn.mockReturnValue(mockProc)
+
+      manager.spawn({
+        taskId: "task-123",
+        projectId: "proj-456",
+        role: "dev",
+        message: "Do work",
+      })
+
+      // Process exits
+      const onHandler = mockProc.on as ReturnType<typeof vi.fn>
+      const exitHandler = onHandler.mock.calls.find((call) => call[0] === "exit")?.[1]
+      exitHandler(0)
+
+      manager.kill("task-123")
+
+      expect(mockProc.kill).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("killAll", () => {
+    it("should send SIGTERM to all active processes", () => {
+      const mockProc1 = createMockChildProcess(1234)
+      const mockProc2 = createMockChildProcess(5678)
+      mockSpawnFn.mockReturnValueOnce(mockProc1).mockReturnValueOnce(mockProc2)
+
+      manager.spawn({
+        taskId: "task-1",
+        projectId: "proj-456",
+        role: "dev",
+        message: "Work 1",
+      })
+      manager.spawn({
+        taskId: "task-2",
+        projectId: "proj-456",
+        role: "dev",
+        message: "Work 2",
+      })
+
+      manager.killAll()
+
+      expect(mockProc1.kill).toHaveBeenCalledWith("SIGTERM")
+      expect(mockProc2.kill).toHaveBeenCalledWith("SIGTERM")
+    })
+
+    it("should not kill already exited processes", () => {
+      const mockProc1 = createMockChildProcess(1234)
+      const mockProc2 = createMockChildProcess(5678)
+      mockSpawnFn.mockReturnValueOnce(mockProc1).mockReturnValueOnce(mockProc2)
+
+      manager.spawn({
+        taskId: "task-1",
+        projectId: "proj-456",
+        role: "dev",
+        message: "Work 1",
+      })
+      manager.spawn({
+        taskId: "task-2",
+        projectId: "proj-456",
+        role: "dev",
+        message: "Work 2",
+      })
+
+      // First process exits
+      const onHandler = mockProc1.on as ReturnType<typeof vi.fn>
+      const exitHandler = onHandler.mock.calls.find((call) => call[0] === "exit")?.[1]
+      exitHandler(0)
+
+      manager.killAll()
+
+      expect(mockProc1.kill).not.toHaveBeenCalled()
+      expect(mockProc2.kill).toHaveBeenCalledWith("SIGTERM")
+    })
+  })
+
+  describe("stale", () => {
+    it("should return children with no output for threshold period", () => {
+      const mockProc = createMockChildProcess(1234)
+      mockSpawnFn.mockReturnValue(mockProc)
+
+      vi.setSystemTime(0)
+      manager.spawn({
+        taskId: "task-123",
+        projectId: "proj-456",
+        role: "dev",
+        message: "Do work",
+      })
+
+      vi.setSystemTime(10000)
+      const stale = manager.stale(5000)
+
+      expect(stale).toHaveLength(1)
+      expect(stale[0].taskId).toBe("task-123")
+    })
+
+    it("should not return active children under threshold", () => {
+      const mockProc = createMockChildProcess(1234)
+      mockSpawnFn.mockReturnValue(mockProc)
+
+      vi.setSystemTime(0)
+      manager.spawn({
+        taskId: "task-123",
+        projectId: "proj-456",
+        role: "dev",
+        message: "Do work",
+      })
+
+      vi.setSystemTime(1000)
+      const stale = manager.stale(5000)
+
+      expect(stale).toHaveLength(0)
+    })
+
+    it("should not return exited children", () => {
+      const mockProc = createMockChildProcess(1234)
+      mockSpawnFn.mockReturnValue(mockProc)
+
+      vi.setSystemTime(0)
+      manager.spawn({
+        taskId: "task-123",
+        projectId: "proj-456",
+        role: "dev",
+        message: "Do work",
+      })
+
+      // Process exits
+      const onHandler = mockProc.on as ReturnType<typeof vi.fn>
+      const exitHandler = onHandler.mock.calls.find((call) => call[0] === "exit")?.[1]
+      exitHandler(0)
+
+      vi.setSystemTime(10000)
+      const stale = manager.stale(5000)
+
+      expect(stale).toHaveLength(0)
+    })
+  })
+})

--- a/worker/children.ts
+++ b/worker/children.ts
@@ -1,0 +1,237 @@
+import { spawn as nodeSpawn, type ChildProcess } from "node:child_process"
+
+/**
+ * A tracked child process running an OpenClaw session
+ */
+export interface TrackedChild {
+  /** Process ID */
+  pid: number
+  /** The underlying ChildProcess instance */
+  process: ChildProcess
+  /** Associated task ID */
+  taskId: string
+  /** Project ID the task belongs to */
+  projectId: string
+  /** Generated session key for the OpenClaw session */
+  sessionKey: string
+  /** Role of the agent (dev, pm, qa, etc.) */
+  role: string
+  /** Timestamp when the process was spawned (ms since epoch) */
+  spawnedAt: number
+  /** Timestamp of last stdout/stderr activity (ms since epoch) */
+  lastOutput: number
+  /** Exit code when the process exits, null while running */
+  exitCode: number | null
+  /** Total bytes received on stdout */
+  totalBytes: number
+}
+
+/**
+ * Parameters for spawning a new child process
+ */
+export interface SpawnParams {
+  /** Task ID to associate with the process */
+  taskId: string
+  /** Project ID the task belongs to */
+  projectId: string
+  /** Role of the agent */
+  role: string
+  /** The message/prompt to send to the OpenClaw session */
+  message: string
+  /** Optional model override */
+  model?: string
+  /** Optional label for the session */
+  label?: string
+}
+
+/**
+ * Information about a completed child process
+ */
+export interface ReapedChild {
+  /** Task ID */
+  taskId: string
+  /** Exit code from the process */
+  exitCode: number
+  /** Duration in milliseconds from spawn to exit */
+  durationMs: number
+}
+
+/**
+ * Manages a collection of child OpenClaw processes.
+ *
+ * Tracks lifecycle, output activity, and provides methods for
+ * monitoring, reaping completed processes, and graceful shutdown.
+ */
+export class ChildManager {
+  private children = new Map<string, TrackedChild>()
+
+  /**
+   * Spawn a new openclaw session for a task.
+   *
+   * Creates a child process running `openclaw chat` with the given message
+   * and optional parameters. The process is tracked for lifecycle monitoring.
+   *
+   * @param params - Spawn parameters including taskId, projectId, role, and message
+   * @returns The tracked child process information
+   * @throws Error if the process fails to spawn or has no PID
+   */
+  spawn(params: SpawnParams): TrackedChild {
+    const args = ["chat", "--message", params.message]
+    if (params.model) args.push("--model", params.model)
+    if (params.label) args.push("--label", params.label)
+
+    const child = nodeSpawn("openclaw", args, {
+      stdio: ["ignore", "pipe", "pipe"],
+      env: { ...process.env },
+    })
+
+    if (child.pid === undefined) {
+      throw new Error(`Failed to spawn openclaw process for task ${params.taskId}`)
+    }
+
+    const now = Date.now()
+    const tracked: TrackedChild = {
+      pid: child.pid,
+      process: child,
+      taskId: params.taskId,
+      projectId: params.projectId,
+      sessionKey: `workloop:${params.role}:${params.taskId.slice(0, 8)}`,
+      role: params.role,
+      spawnedAt: now,
+      lastOutput: now,
+      exitCode: null,
+      totalBytes: 0,
+    }
+
+    child.stdout?.on("data", (chunk: Buffer) => {
+      tracked.lastOutput = Date.now()
+      tracked.totalBytes += chunk.length
+    })
+
+    child.stderr?.on("data", () => {
+      tracked.lastOutput = Date.now()
+    })
+
+    child.on("exit", (code: number | null) => {
+      tracked.exitCode = code ?? 1
+    })
+
+    this.children.set(params.taskId, tracked)
+    return tracked
+  }
+
+  /**
+   * Get all active (non-exited) child processes.
+   *
+   * @returns Array of tracked children that have not yet exited
+   */
+  active(): TrackedChild[] {
+    return Array.from(this.children.values()).filter((child) => child.exitCode === null)
+  }
+
+  /**
+   * Get the count of active child processes.
+   *
+   * @param projectId - Optional project ID to filter by
+   * @returns Number of active children, optionally filtered by project
+   */
+  activeCount(projectId?: string): number {
+    const active = this.active()
+    if (projectId === undefined) {
+      return active.length
+    }
+    return active.filter((child) => child.projectId === projectId).length
+  }
+
+  /**
+   * Check for completed children and remove them from tracking.
+   *
+   * @returns Array of reaped child information including exit codes and durations
+   */
+  reap(): ReapedChild[] {
+    const reaped: ReapedChild[] = []
+    const now = Date.now()
+
+    for (const [taskId, child] of this.children) {
+      if (child.exitCode !== null) {
+        reaped.push({
+          taskId,
+          exitCode: child.exitCode,
+          durationMs: now - child.spawnedAt,
+        })
+        this.children.delete(taskId)
+      }
+    }
+
+    return reaped
+  }
+
+  /**
+   * Kill a specific child process by task ID.
+   *
+   * Sends SIGTERM to the process. The process will remain in tracking
+   * until it actually exits and is reaped.
+   *
+   * @param taskId - The task ID of the child to kill
+   */
+  kill(taskId: string): void {
+    const child = this.children.get(taskId)
+    if (child && child.exitCode === null) {
+      child.process.kill("SIGTERM")
+    }
+  }
+
+  /**
+   * Kill all tracked child processes.
+   *
+   * Sends SIGTERM to all active processes. Processes remain in tracking
+   * until they exit and are reaped.
+   */
+  killAll(): void {
+    for (const child of this.children.values()) {
+      if (child.exitCode === null) {
+        child.process.kill("SIGTERM")
+      }
+    }
+  }
+
+  /**
+   * Get stale children that have had no output for a threshold period.
+   *
+   * @param thresholdMs - Threshold in milliseconds of inactivity
+   * @returns Array of tracked children with no output for the threshold period
+   */
+  stale(thresholdMs: number): TrackedChild[] {
+    const now = Date.now()
+    return Array.from(this.children.values()).filter(
+      (child) => child.exitCode === null && now - child.lastOutput > thresholdMs
+    )
+  }
+
+  /**
+   * Get a specific child by task ID.
+   *
+   * @param taskId - The task ID to look up
+   * @returns The tracked child, or undefined if not found
+   */
+  get(taskId: string): TrackedChild | undefined {
+    return this.children.get(taskId)
+  }
+
+  /**
+   * Get the total number of tracked children (including exited).
+   *
+   * @returns Total count of tracked processes
+   */
+  size(): number {
+    return this.children.size
+  }
+}
+
+/**
+ * Default singleton instance for convenience.
+ *
+ * Use this for the global child manager, or create new ChildManager
+ * instances for isolated testing.
+ */
+export const childManager = new ChildManager()


### PR DESCRIPTION
## Summary

Builds the module that spawns `openclaw` CLI child processes and tracks their lifecycle. The orchestrator uses this to start agent sessions and monitor them.

## Changes

- **worker/children.ts**: New ChildManager class with:
  - `spawn()`: creates `openclaw chat` child processes with piped stdio
  - `active()`: returns all non-exited processes
  - `activeCount()`: returns count, optionally filtered by projectId
  - `reap()`: returns completed children and removes from tracking
  - `stale()`: detects children with no output for threshold period
  - `kill()`: sends SIGTERM to a specific child
  - `killAll()`: sends SIGTERM to all tracked children

- **worker/children.test.ts**: Unit tests mocking `child_process.spawn`

## Acceptance Criteria

- [x] `ChildManager` class exported from `worker/children.ts`
- [x] `spawn()` creates a real `openclaw chat` child process with piped stdio
- [x] `reap()` returns completed children and removes them from tracking
- [x] `stale()` detects children with no stdout/stderr activity for threshold
- [x] `killAll()` sends SIGTERM to all tracked children
- [x] `activeCount()` returns count, optionally filtered by projectId
- [x] Unit tests verify tracking logic with mocked child_process
- [x] `pnpm typecheck` and `pnpm lint` pass

Ticket: c4153352-f116-4fd7-aefc-6154e433423b