### PR TITLE
feat: implement work phase for work loop

### DIFF
--- a/worker/logger.ts
+++ b/worker/logger.ts
@@ -14,7 +14,7 @@ import { api } from "../convex/_generated/api"
 
 type WorkLoopPhase = "cleanup" | "review" | "work" | "idle" | "error"
 
-interface LogRunParams {
+export interface LogRunParams {
   projectId: string
   cycle: number
   phase: WorkLoopPhase

--- a/worker/phases/work.ts
+++ b/worker/phases/work.ts
@@ -1,0 +1,373 @@
+/**
+ * Work Phase
+ *
+ * Claims ready tasks (respecting dependencies) and spawns appropriately-configured
+ * sub-agents to work on them.
+ */
+
+import type { ConvexHttpClient } from "convex/browser"
+import { api } from "../../convex/_generated/api"
+import type { ChildManager } from "../children"
+import type { WorkLoopConfig } from "../config"
+import type { LogRunParams } from "../logger"
+import type { Task, TaskPriority } from "../../lib/types"
+import { buildPrompt } from "../prompts"
+
+// ============================================
+// Types
+// ============================================
+
+export interface WorkPhaseResult {
+  claimed: boolean
+  taskId?: string
+  role?: string
+}
+
+interface WorkContext {
+  convex: ConvexHttpClient
+  children: ChildManager
+  config: WorkLoopConfig
+  cycle: number
+  projectId: string
+  log: (params: LogRunParams) => Promise<void>
+}
+
+// ============================================
+// Priority Ordering
+// ============================================
+
+const PRIORITY_ORDER: Record<TaskPriority, number> = {
+  urgent: 0,
+  high: 1,
+  medium: 2,
+  low: 3,
+}
+
+/**
+ * Sort tasks by priority (urgent first) then by position
+ */
+function sortTasks(tasks: Task[]): Task[] {
+  return [...tasks].sort((a, b) => {
+    const priorityDiff = PRIORITY_ORDER[a.priority] - PRIORITY_ORDER[b.priority]
+    if (priorityDiff !== 0) return priorityDiff
+    return a.position - b.position
+  })
+}
+
+// ============================================
+// Role → Model Mapping
+// ============================================
+
+const ROLE_MODEL_MAP: Record<string, string | undefined> = {
+  pm: "sonnet",
+  research: "sonnet",
+  reviewer: "sonnet",
+  dev: undefined,  // use default
+  qa: undefined,   // use default
+}
+
+/**
+ * Get the model override for a role
+ */
+function getModelForRole(role: string): string | undefined {
+  return ROLE_MODEL_MAP[role] ?? undefined
+}
+
+// ============================================
+// Dependency Checking
+// ============================================
+
+/**
+ * Check if all dependencies for a task are complete (done)
+ */
+async function areDependenciesMet(
+  convex: ConvexHttpClient,
+  taskId: string
+): Promise<boolean> {
+  try {
+    const deps = await convex.query(api.taskDependencies.getIncomplete, { taskId })
+    return deps.length === 0
+  } catch (error) {
+    // If we can't check dependencies, assume they're not met to be safe
+    console.error(`[WorkPhase] Failed to check dependencies for ${taskId}:`, error)
+    return false
+  }
+}
+
+// ============================================
+// Task Claiming
+// ============================================
+
+/**
+ * Try to claim a task by moving it to in_progress
+ */
+async function claimTask(
+  convex: ConvexHttpClient,
+  taskId: string
+): Promise<Task | null> {
+  try {
+    const result = await convex.mutation(api.tasks.move, {
+      id: taskId,
+      status: "in_progress",
+    })
+    return result
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    // Check if it's a dependency error
+    if (message.includes("dependencies not complete")) {
+      return null  // Dependencies not met, this is expected
+    }
+    // Any other error is unexpected
+    console.error(`[WorkPhase] Unexpected error claiming task ${taskId}:`, message)
+    return null
+  }
+}
+
+// ============================================
+// SOUL Template Loading
+// ============================================
+
+import { readFile } from "node:fs/promises"
+import { join } from "node:path"
+
+const ROLES_DIR = "/home/dan/clawd/roles"
+const DEFAULT_ROLE = "dev"
+
+/**
+ * Load the SOUL template for a role
+ */
+async function loadSoulTemplate(role: string): Promise<string> {
+  const soulPath = join(ROLES_DIR, `${role}.md`)
+  const fallbackPath = join(ROLES_DIR, `${DEFAULT_ROLE}.md`)
+
+  try {
+    return await readFile(soulPath, "utf-8")
+  } catch {
+    // Role file doesn't exist, use fallback
+    try {
+      return await readFile(fallbackPath, "utf-8")
+    } catch {
+      // Even fallback doesn't exist - return a minimal default
+      console.error(`[WorkPhase] Could not load SOUL template for role ${role} or fallback`)
+      return `# Developer\n\nYou are a software developer. Implement the task as specified.`
+    }
+  }
+}
+
+// ============================================
+// Main Work Phase
+// ============================================
+
+/**
+ * Run the work phase: claim ready tasks and spawn agents
+ *
+ * Logic:
+ * 1. Check capacity limits
+ * 2. Query ready tasks, sorted by priority then position
+ * 3. For each candidate, check dependencies and try to claim
+ * 4. Load role SOUL template and build prompt
+ * 5. Spawn sub-agent via ChildManager
+ * 6. Log claim and spawn to Convex
+ */
+export async function runWork(ctx: WorkContext): Promise<WorkPhaseResult> {
+  const { convex, children, config, cycle, projectId, log } = ctx
+
+  // --- 1. Check capacity ---
+  const globalCount = children.activeCount()
+  const projectCount = children.activeCount(projectId)
+
+  if (globalCount >= config.maxAgentsGlobal) {
+    await log({
+      projectId,
+      cycle,
+      phase: "work",
+      action: "capacity_check",
+      details: { globalCount, maxGlobal: config.maxAgentsGlobal, reason: "global_limit" },
+    })
+    return { claimed: false }
+  }
+
+  if (projectCount >= config.maxAgentsPerProject) {
+    await log({
+      projectId,
+      cycle,
+      phase: "work",
+      action: "capacity_check",
+      details: { projectCount, maxPerProject: config.maxAgentsPerProject, reason: "project_limit" },
+    })
+    return { claimed: false }
+  }
+
+  // --- 2. Query ready tasks ---
+  let readyTasks: Task[]
+  try {
+    readyTasks = await convex.query(api.tasks.getByProject, {
+      projectId,
+      status: "ready",
+    })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    await log({
+      projectId,
+      cycle,
+      phase: "work",
+      action: "fetch_failed",
+      details: { error: message },
+    })
+    return { claimed: false }
+  }
+
+  if (readyTasks.length === 0) {
+    await log({
+      projectId,
+      cycle,
+      phase: "work",
+      action: "no_ready_tasks",
+    })
+    return { claimed: false }
+  }
+
+  // Sort by priority then position
+  const sortedTasks = sortTasks(readyTasks)
+
+  await log({
+    projectId,
+    cycle,
+    phase: "work",
+    action: "ready_tasks_found",
+    details: { count: sortedTasks.length },
+  })
+
+  // --- 3. Try to claim a task ---
+  for (const task of sortedTasks) {
+    // Check dependencies first (before attempting claim)
+    const depsMet = await areDependenciesMet(convex, task.id)
+    if (!depsMet) {
+      await log({
+        projectId,
+        cycle,
+        phase: "work",
+        action: "dependency_blocked",
+        taskId: task.id,
+        details: { title: task.title },
+      })
+      continue
+    }
+
+    // Try to claim the task
+    const claimed = await claimTask(convex, task.id)
+    if (!claimed) {
+      // Another process claimed it or deps changed
+      await log({
+        projectId,
+        cycle,
+        phase: "work",
+        action: "claim_failed",
+        taskId: task.id,
+        details: { title: task.title },
+      })
+      continue
+    }
+
+    // Successfully claimed!
+    const role = task.role ?? "dev"
+
+    await log({
+      projectId,
+      cycle,
+      phase: "work",
+      action: "task_claimed",
+      taskId: task.id,
+      details: { title: task.title, role },
+    })
+
+    // --- 4. Load SOUL and build prompt ---
+    const soulTemplate = await loadSoulTemplate(role)
+    const project = await convex.query(api.projects.getById, { id: projectId })
+    const repoDir = project?.local_path ?? "/home/dan/src/trap"
+    const worktreeDir = `/home/dan/src/trap-worktrees/fix/${task.id.slice(0, 8)}`
+
+    const prompt = buildPrompt({
+      role,
+      taskId: task.id,
+      taskTitle: task.title,
+      taskDescription: task.description ?? "",
+      soulTemplate,
+      projectId,
+      repoDir,
+      worktreeDir,
+    })
+
+    // --- 5. Spawn sub-agent ---
+    const model = getModelForRole(role)
+    const label = `trap-${role}-${task.id.slice(0, 8)}`
+
+    try {
+      const child = children.spawn({
+        taskId: task.id,
+        projectId,
+        role,
+        message: prompt,
+        model,
+        label,
+      })
+
+      await log({
+        projectId,
+        cycle,
+        phase: "work",
+        action: "agent_spawned",
+        taskId: task.id,
+        sessionKey: child.sessionKey,
+        details: { pid: child.pid, role, model: model ?? "default" },
+      })
+
+      // Update task with session ID
+      try {
+        await convex.mutation(api.tasks.update, {
+          id: task.id,
+          session_id: child.sessionKey,
+        })
+      } catch (updateError) {
+        // Non-fatal: session tracking is nice-to-have
+        console.error(`[WorkPhase] Failed to update task session_id:`, updateError)
+      }
+
+      // --- 6. Return success (only one task per cycle) ---
+      return { claimed: true, taskId: task.id, role }
+    } catch (spawnError) {
+      const message = spawnError instanceof Error ? spawnError.message : String(spawnError)
+      await log({
+        projectId,
+        cycle,
+        phase: "work",
+        action: "spawn_failed",
+        taskId: task.id,
+        details: { error: message },
+      })
+
+      // Try to move task back to ready since spawn failed
+      try {
+        await convex.mutation(api.tasks.move, {
+          id: task.id,
+          status: "ready",
+        })
+      } catch (moveError) {
+        console.error(`[WorkPhase] Failed to revert task status:`, moveError)
+      }
+
+      return { claimed: false }
+    }
+  }
+
+  // No claimable tasks found
+  await log({
+    projectId,
+    cycle,
+    phase: "work",
+    action: "no_claimable_tasks",
+    details: { readyCount: sortedTasks.length },
+  })
+
+  return { claimed: false }
+}

--- a/worker/prompts.ts
+++ b/worker/prompts.ts
@@ -1,0 +1,258 @@
+/**
+ * Prompt Builder
+ *
+ * Builds role-specific prompts for sub-agents working on tasks.
+ * Replicates the logic from the gate script with proper typing.
+ */
+
+// ============================================
+// Types
+// ============================================
+
+export interface PromptParams {
+  /** The role of the agent (dev, pm, qa, research, reviewer) */
+  role: string
+  /** The task ID */
+  taskId: string
+  /** The task title */
+  taskTitle: string
+  /** The task description */
+  taskDescription: string
+  /** The SOUL template content for the role */
+  soulTemplate: string
+  /** The project ID */
+  projectId: string
+  /** The repository directory */
+  repoDir: string
+  /** The worktree directory for dev tasks */
+  worktreeDir: string
+}
+
+// ============================================
+// Role-Specific Instructions
+// ============================================
+
+/**
+ * Build PM role instructions
+ */
+function buildPmInstructions(params: PromptParams): string {
+  return `## Task: ${params.taskTitle}
+
+**Read /home/dan/src/trap/AGENTS.md first.**
+
+Ticket ID: \`${params.taskId}\`
+Role: \`pm\`
+
+${params.taskDescription}
+
+---
+
+**Your job:** Analyze this ticket and break it down into actionable sub-tickets.
+
+**IMPORTANT:** Every sub-ticket MUST have:
+- \`role\` set (usually \`dev\`, or \`qa\`/\`research\` if appropriate)
+- Clear description with ## Summary, ## Implementation, ## Files, ## Acceptance Criteria
+- Proper priority (urgent/high/medium/low)
+
+**Create tickets:**
+\`\`\`bash
+curl -X POST http://localhost:3002/api/tasks -H 'Content-Type: application/json' -d '{
+  "project_id": "${params.projectId}",
+  "title": "<title>",
+  "description": "<markdown description>",
+  "status": "ready",
+  "priority": "<urgent|high|medium|low>",
+  "role": "dev",
+  "tags": "[\\"tag1\\", \"tag2\\"]"
+}'
+\`\`\`
+
+**Create dependencies between tickets** (task cannot start until dependency is done):
+\`\`\`bash
+curl -X POST http://localhost:3002/api/tasks/<TASK_ID>/dependencies -H 'Content-Type: application/json' -d '{
+  "depends_on_id": "<DEPENDENCY_TASK_ID>"
+}'
+\`\`\`
+
+Use the task IDs from the POST responses to wire up the dependency chain. If ticket B depends on ticket A, create the dependency after both exist.
+
+**When done:** Mark this ticket done:
+\`\`\`bash
+curl -X PATCH http://localhost:3002/api/tasks/${params.taskId} -H 'Content-Type: application/json' -d '{"status": "done"}'
+\`\`\`
+
+**DO NOT:** Create branches, write code, or create PRs. You are a PM.`
+}
+
+/**
+ * Build QA role instructions
+ */
+function buildQaInstructions(params: PromptParams): string {
+  return `## Task: ${params.taskTitle}
+
+**Read /home/dan/src/trap/AGENTS.md first.**
+
+Ticket ID: \`${params.taskId}\`
+Role: \`qa\`
+
+${params.taskDescription}
+
+---
+
+**Your job:** Verify this ticket's requirements are met via browser QA.
+
+Use the managed browser (\`profile=openclaw\`) to navigate to http://192.168.7.200:3002 and verify functionality.
+
+**When verified:** Mark done:
+\`\`\`bash
+curl -X PATCH http://localhost:3002/api/tasks/${params.taskId} -H 'Content-Type: application/json' -d '{"status": "done"}'
+\`\`\`
+
+**If issues found:** Add a comment and move back to ready:
+\`\`\`bash
+curl -X POST http://localhost:3002/api/tasks/${params.taskId}/comments -H 'Content-Type: application/json' -d '{"content": "<findings>"}'
+curl -X PATCH http://localhost:3002/api/tasks/${params.taskId} -H 'Content-Type: application/json' -d '{"status": "ready"}'
+\`\`\``
+}
+
+/**
+ * Build Research role instructions
+ */
+function buildResearchInstructions(params: PromptParams): string {
+  return `## Task: ${params.taskTitle}
+
+**Read /home/dan/src/trap/AGENTS.md first.**
+
+Ticket ID: \`${params.taskId}\`
+Role: \`research\`
+
+${params.taskDescription}
+
+---
+
+**Your job:** Research this topic and post findings.
+
+Write findings as a comment on the ticket:
+\`\`\`bash
+curl -X POST http://localhost:3002/api/tasks/${params.taskId}/comments -H 'Content-Type: application/json' -d '{"content": "<findings>"}'
+\`\`\`
+
+**When done:** Mark this ticket done:
+\`\`\`bash
+curl -X PATCH http://localhost:3002/api/tasks/${params.taskId} -H 'Content-Type: application/json' -d '{"status": "done"}'
+\`\`\`
+
+**DO NOT:** Create branches or write code unless the ticket explicitly asks for a prototype.`
+}
+
+/**
+ * Build Reviewer role instructions
+ */
+function buildReviewerInstructions(params: PromptParams): string {
+  return `## Task: ${params.taskTitle}
+
+**Read /home/dan/src/trap/AGENTS.md first.**
+
+Ticket ID: \`${params.taskId}\`
+Role: \`reviewer\`
+
+${params.taskDescription}
+
+---
+
+**Your job:** Review the PR for this ticket.
+
+**Review steps:**
+1. Check the diff: \`gh pr diff <number>\`
+2. Verify types: \`cd ${params.worktreeDir} && pnpm typecheck\`
+3. Verify lint: \`cd ${params.worktreeDir} && pnpm lint\`
+4. Browser QA if UI changes (use managed browser, \`profile=openclaw\`, navigate to http://192.168.7.200:3002)
+
+**If approved:**
+\`\`\`bash
+gh pr merge <number> --squash --delete-branch
+curl -X PATCH http://localhost:3002/api/tasks/${params.taskId} -H 'Content-Type: application/json' -d '{"status": "done"}'
+cd /home/dan/src/trap && git worktree remove ${params.worktreeDir} --force 2>/dev/null || true
+\`\`\`
+
+**If issues found:** Leave a PR comment, move ticket back to ready:
+\`\`\`bash
+gh pr comment <number> --body '<specific feedback>'
+curl -X PATCH http://localhost:3002/api/tasks/${params.taskId} -H 'Content-Type: application/json' -d '{"status": "ready"}'
+\`\`\``
+}
+
+/**
+ * Build Dev role instructions (default)
+ */
+function buildDevInstructions(params: PromptParams): string {
+  const branchName = `fix/${params.taskId.slice(0, 8)}`
+
+  return `## Task: ${params.taskTitle}
+
+**Read /home/dan/src/trap/AGENTS.md first.**
+
+Ticket ID: \`${params.taskId}\`
+Role: \`dev\`
+
+${params.taskDescription}
+
+---
+
+**Setup worktree:**
+\`\`\`bash
+cd /home/dan/src/trap
+git fetch origin main
+git worktree add ${params.worktreeDir} origin/main -b ${branchName}
+cd ${params.worktreeDir}
+\`\`\`
+
+**After implementation, push and create PR:**
+\`\`\`bash
+cd ${params.worktreeDir}
+git add -A
+git commit -m "feat: <description>"
+git push -u origin ${branchName}
+gh pr create --title "<title>" --body "Ticket: ${params.taskId}"
+\`\`\`
+
+Then update ticket to in_review:
+\`\`\`bash
+curl -X PATCH http://localhost:3002/api/tasks/${params.taskId} -H 'Content-Type: application/json' -d '{"status": "in_review"}'
+\`\`\``
+}
+
+// ============================================
+// Main Prompt Builder
+// ============================================
+
+/**
+ * Build a role-specific prompt for a task
+ *
+ * Combines the role SOUL template with task details and role-specific
+ * instructions for how to complete the task.
+ */
+export function buildPrompt(params: PromptParams): string {
+  const roleInstructions = (() => {
+    switch (params.role) {
+      case "pm":
+        return buildPmInstructions(params)
+      case "qa":
+        return buildQaInstructions(params)
+      case "research":
+      case "researcher":
+        return buildResearchInstructions(params)
+      case "reviewer":
+        return buildReviewerInstructions(params)
+      case "dev":
+      default:
+        return buildDevInstructions(params)
+    }
+  })()
+
+  return `${params.soulTemplate}
+
+---
+
+${roleInstructions}`
+}


### PR DESCRIPTION
Ticket: bf46bb30-b0fb-4bb9-90c1-16bfb473a4b4

## Summary
Implement the work phase of the work loop. Claims \ready\ tasks (respecting dependencies) and spawns appropriately-configured sub-agents to work on them.

## Changes
- **worker/phases/work.ts**: Main work phase implementation
  - Checks capacity limits (global and per-project)
  - Queries ready tasks sorted by priority then position
  - Verifies dependencies are complete before claiming
  - Loads role SOUL templates from disk
  - Spawns sub-agents via ChildManager with model overrides
  - Logs all actions to Convex

- **worker/prompts.ts**: Role-specific prompt builder
  - PM: Creates sub-tickets, sets dependencies, marks done
  - Dev: Sets up worktree, implements, creates PR, moves to in_review
  - QA: Browser testing with managed browser
  - Research: Investigates, posts findings, marks done
  - Reviewer: Reviews PRs, runs checks, merges or requests changes

- **worker/loop.ts**: Wired up work phase with ChildManager
- **worker/logger.ts**: Exported LogRunParams type

## Acceptance Criteria
- ✅ Claims highest-priority unblocked ready task
- ✅ Respects dependency chain (all deps must be done)
- ✅ Spawns sub-agent with correct role SOUL and model
- ✅ Only claims one task per cycle (prevents flooding)
- ✅ Respects agent count limits (per-project and global)
- ✅ Logs claim + spawn to Convex
- ✅ pnpm typecheck passes
- ✅ pnpm lint passes