### PR TITLE
refactor: Replace WebSocket with HTTP POST + Convex reactivity

### DIFF
--- a/app/api/chats/[id]/messages/route.ts
+++ b/app/api/chats/[id]/messages/route.ts
@@ -85,7 +85,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       )
     }
 
-    // Check for duplicate run_id to prevent double messages from OpenClaw WebSocket
+    // Check for duplicate run_id to prevent double messages from backend event handler
     if (run_id) {
       const existing = await convex.query(api.chats.getMessageByRunId, { runId: run_id })
       if (existing) {

--- a/app/projects/[slug]/chat/page.tsx
+++ b/app/projects/[slug]/chat/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useState, use, useCallback } from "react"
+import { useEffect, useState, use } from "react"
 import { MessageSquare, Menu } from "lucide-react"
 import { useChatStore } from "@/lib/stores/chat-store"
 import { useSettings } from "@/lib/hooks/use-settings"
@@ -62,8 +62,6 @@ export default function ChatPage({ params }: PageProps) {
     sendMessage: sendMessageToDb,
     setActiveChat,
     setTyping,
-    startStreamingMessage,
-    appendToStreamingMessage,
     clearStreamingMessage,
   } = useChatStore()
 

--- a/lib/stores/chat-store.ts
+++ b/lib/stores/chat-store.ts
@@ -40,7 +40,7 @@ interface ChatState {
   sendMessage: (chatId: string, content: string, author?: string) => Promise<ChatMessage>
   loadMoreMessages: (chatId: string) => Promise<boolean>
   
-  // SSE event handlers
+  // Convex reactivity handlers
   receiveMessage: (chatId: string, message: ChatMessage) => void
   setTyping: (chatId: string, author: string, state: "thinking" | "typing" | false) => void
   
@@ -208,7 +208,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
     set((state) => {
       const existing = state.messages[chatId] || []
       
-      // Check if message already exists (SSE might have added it first)
+      // Check if message already exists (Convex reactivity might have added it first)
       if (existing.some((m) => m.id === data.message.id)) {
         return state
       }
@@ -264,7 +264,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
     return data.hasMore
   },
 
-  // Receive a message from SSE (avoid duplicates)
+  // Receive a message from Convex (avoid duplicates)
   receiveMessage: (chatId, message) => {
     set((state) => {
       const existing = state.messages[chatId] || []
@@ -302,7 +302,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
     })
   },
 
-  // Handle typing indicator from SSE
+  // Handle typing indicator from Convex
   setTyping: (chatId, author, state) => {
     set((store) => {
       const current = store.typingIndicators[chatId] || []


### PR DESCRIPTION
Ticket: aa5f0a8f-1825-4488-be71-7f03486af2c9

## Summary

This PR completes the migration from WebSocket to HTTP POST + Convex reactivity for all frontend operations.

## Changes

- Updated comments in \+lib/stores/chat-store.ts to reflect Convex reactivity (removed outdated SSE references)
- Removed unused streaming message handlers from chat page (streaming now handled via Convex)
- Updated message route comment to clarify backend event handler source
- Verified all pages use HTTP POST for actions and Convex for real-time updates

## Architecture

- **Actions**: HTTP POST to OpenClaw API (reliable, works during gateway restarts)
- **Updates**: Convex reactive queries (useQuery subscriptions) on all pages
- **Backend**: WebSocket client in \+lib/openclaw/client.ts is intentionally kept for server-side event handling from OpenClaw

## Verification

- ✅ Type check passes
- ✅ Lint passes (no new errors)
- ✅ All pages properly use HTTP API + Convex
- ✅ No WebSocket providers remain in provider tree
- ✅ No frontend WebSocket connection code remains