### PR TITLE
feat: show status age, agent runtime, and last output on task cards

### DIFF
--- a/app/api/sessions/status/route.ts
+++ b/app/api/sessions/status/route.ts
@@ -4,6 +4,7 @@ export interface SessionStatusInfo {
   id: string
   status: 'running' | 'idle' | 'completed' | 'error' | 'cancelled' | 'not_found'
   updatedAt?: string
+  createdAt?: string
   model?: string
   tokens?: {
     input: number
@@ -113,6 +114,7 @@ export async function POST(request: NextRequest) {
           id: sessionId,
           status,
           updatedAt,
+          createdAt: sessionInfo.createdAt,
           model: sessionInfo.model,
           tokens: {
             input: sessionInfo.inputTokens || 0,

--- a/lib/hooks/use-session-status.ts
+++ b/lib/hooks/use-session-status.ts
@@ -65,7 +65,7 @@ export function useSessionStatus(sessionIds: string[]) {
     }
   }, [sessionIds, fetchSessionStatus])
 
-  // Auto-refresh every 30 seconds for active sessions
+  // Auto-refresh every 15 seconds for active sessions (in-progress tasks)
   useEffect(() => {
     const hasActiveSessions = Object.values(sessionStatus).some(
       status => status.isActive || status.status === 'running'
@@ -78,7 +78,7 @@ export function useSessionStatus(sessionIds: string[]) {
       if (validIds.length > 0) {
         fetchSessionStatus(validIds)
       }
-    }, 30000) // 30 seconds
+    }, 15000) // 15 seconds for more responsive updates
 
     return () => clearInterval(interval)
   }, [sessionIds, sessionStatus, fetchSessionStatus])

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -9,6 +9,29 @@ interface FormatDistanceOptions {
   addSuffix?: boolean
 }
 
+/**
+ * Format a timestamp as a compact relative time string
+ * Examples: "2m", "1h", "3d"
+ */
+export function formatCompactTime(timestamp: number): string {
+  const now = Date.now()
+  const diff = now - timestamp
+  const seconds = Math.floor(diff / 1000)
+  const minutes = Math.floor(seconds / 60)
+  const hours = Math.floor(minutes / 60)
+  const days = Math.floor(hours / 24)
+
+  if (seconds < 60) {
+    return `${seconds}s`
+  } else if (minutes < 60) {
+    return `${minutes}m`
+  } else if (hours < 24) {
+    return `${hours}h`
+  } else {
+    return `${days}d`
+  }
+}
+
 export function formatDistanceToNow(timestamp: number, options?: FormatDistanceOptions): string {
   const now = Date.now()
   const diff = now - timestamp


### PR DESCRIPTION
Ticket: 5e411423-5f8f-44bf-850e-f50ecf5bc8ba

## Summary
Task cards now surface key timing and agent metadata at a glance so you can spot stuck or stale work without clicking into each card.

## Changes
- Added `formatCompactTime()` utility for short time display (2m, 1h, 3d)
- Status age shown on all cards with color coding:
  - Green (<1h), yellow (1-4h), red (>4h) for in_progress/in_review
- Agent info displayed for in-progress tasks:
  - Model name (shortened: kimi, claude, gpt, etc.)
  - Agent runtime since session creation
  - Time since last output with color coding
    - Green (<1m), yellow (1-5m), red (>5m = possibly stuck)
- Warning indicator for orphaned in-progress tasks (no agent attached)
- Session data polling every 15s for in-progress tasks
- Live time display updates every 10s

## UI Example
```
Fix token parsing bug
🟢 in_progress 45m
🤖 kimi · 12m · out 30s
```