### PR TITLE
fix: crypto.randomUUID crash on non-HTTPS origins

### DIFF
--- a/components/chat/new-issue-dialog.tsx
+++ b/components/chat/new-issue-dialog.tsx
@@ -3,6 +3,7 @@
 import { useState, useRef, useEffect } from "react"
 import { X, Send, Plus } from "lucide-react"
 import { Button } from "@/components/ui/button"
+import { generateUUID } from "@/lib/utils/uuid"
 import type { TaskPriority } from "@/lib/types"
 
 interface NewIssueDialogProps {
@@ -62,7 +63,7 @@ export function NewIssueDialog({
   useEffect(() => {
     if (open && messages.length === 0) {
       const welcomeMessage: Message = {
-        id: crypto.randomUUID(),
+        id: generateUUID(),
         role: "assistant",
         content: "Hi! I'll help you create a new issue. What would you like to build or fix?",
         timestamp: Date.now(),
@@ -88,7 +89,7 @@ export function NewIssueDialog({
 
   const addMessage = (role: "user" | "assistant" | "system", content: string) => {
     const message: Message = {
-      id: crypto.randomUUID(),
+      id: generateUUID(),
       role,
       content,
       timestamp: Date.now(),

--- a/lib/openclaw/rpc.ts
+++ b/lib/openclaw/rpc.ts
@@ -15,6 +15,8 @@
  *   const { runId } = await sendChatMessage('agent:main', 'Hello');
  */
 
+import { generateUUID } from '@/lib/utils/uuid';
+
 // ============================================================================
 // Configuration
 // ============================================================================
@@ -94,18 +96,6 @@ export interface RpcResponse<T = unknown> {
 // ============================================================================
 // Core RPC
 // ============================================================================
-
-/** Generate a UUID for RPC requests */
-function generateUUID(): string {
-  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
-    return crypto.randomUUID();
-  }
-  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
-    const r = Math.random() * 16 | 0;
-    const v = c === 'x' ? r : (r & 0x3 | 0x8);
-    return v.toString(16);
-  });
-}
 
 /**
  * Make a raw HTTP RPC call to OpenClaw gateway.

--- a/lib/utils/uuid.ts
+++ b/lib/utils/uuid.ts
@@ -1,0 +1,26 @@
+/**
+ * UUID generation utilities
+ * 
+ * Provides a cross-platform UUID generator that works in both
+ * secure contexts (HTTPS) and non-secure contexts (HTTP).
+ * 
+ * crypto.randomUUID() is only available in secure contexts,
+ * so we fall back to a Math.random-based implementation.
+ */
+
+/**
+ * Generate a UUID v4 string
+ * 
+ * Uses crypto.randomUUID() when available (secure contexts),
+ * falls back to a manual implementation for HTTP/non-secure origins.
+ */
+export function generateUUID(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+    const r = Math.random() * 16 | 0;
+    const v = c === 'x' ? r : (r & 0x3 | 0x8);
+    return v.toString(16);
+  });
+}


### PR DESCRIPTION
## Summary
Fixes crash when clicking 'New Issue' button in chat on HTTP origins.

## Problem
`crypto.randomUUID()` is only available in secure contexts (HTTPS/localhost). The app is served over HTTP on `192.168.7.200:3002`, causing:
```
TypeError: crypto.randomUUID is not a function
```

## Solution
- Created shared `lib/utils/uuid.ts` with cross-platform UUID generator
- Falls back to Math.random-based implementation when crypto.randomUUID unavailable
- Updated `new-issue-dialog.tsx` to use shared utility
- Updated `lib/openclaw/rpc.ts` to use shared utility (DRY)

## Testing
- `pnpm typecheck` passes
- `pnpm lint` passes (pre-existing warnings only)

Ticket: 0b60425e-d035-4e11-812a-473edf51289f