### PR TITLE
feat: Prompt Lab page with version history and diff view

### DIFF
--- a/app/api/prompts/[id]/activate/route.ts
+++ b/app/api/prompts/[id]/activate/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from "next/server"
+import { getConvexClient } from "@/lib/convex/server"
+import { api } from "@/convex/_generated/api"
+
+// PATCH /api/prompts/[id]/activate — Set a version as active
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params
+
+  if (!id) {
+    return NextResponse.json(
+      { error: "Missing required parameter: id" },
+      { status: 400 }
+    )
+  }
+
+  try {
+    const convex = getConvexClient()
+    await convex.mutation(api.promptVersions.setActive, { id })
+
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    console.error("[Prompts API] Error activating version:", error)
+    const message = error instanceof Error ? error.message : "Failed to activate prompt version"
+    return NextResponse.json(
+      { error: message },
+      { status: 500 }
+    )
+  }
+}

--- a/app/api/prompts/[id]/route.ts
+++ b/app/api/prompts/[id]/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from "next/server"
+import { getConvexClient } from "@/lib/convex/server"
+import { api } from "@/convex/_generated/api"
+
+// GET /api/prompts/[id] — Get a specific version by UUID
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params
+
+  if (!id) {
+    return NextResponse.json(
+      { error: "Missing required parameter: id" },
+      { status: 400 }
+    )
+  }
+
+  try {
+    const convex = getConvexClient()
+    const version = await convex.query(api.promptVersions.getById, { id })
+
+    if (!version) {
+      return NextResponse.json(
+        { error: "Prompt version not found" },
+        { status: 404 }
+      )
+    }
+
+    return NextResponse.json({ version })
+  } catch (error) {
+    console.error("[Prompts API] Error fetching version:", error)
+    return NextResponse.json(
+      { error: "Failed to fetch prompt version" },
+      { status: 500 }
+    )
+  }
+}

--- a/app/api/prompts/route.ts
+++ b/app/api/prompts/route.ts
@@ -1,0 +1,66 @@
+import { NextRequest, NextResponse } from "next/server"
+import { getConvexClient } from "@/lib/convex/server"
+import { api } from "@/convex/_generated/api"
+
+// GET /api/prompts?role=dev&model=kimi — List versions for a role
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url)
+  const role = searchParams.get("role")
+  const model = searchParams.get("model") || undefined
+
+  if (!role) {
+    return NextResponse.json(
+      { error: "Missing required query parameter: role" },
+      { status: 400 }
+    )
+  }
+
+  try {
+    const convex = getConvexClient()
+    const versions = await convex.query(api.promptVersions.listByRole, {
+      role,
+      model,
+    })
+
+    return NextResponse.json({ versions })
+  } catch (error) {
+    console.error("[Prompts API] Error fetching versions:", error)
+    return NextResponse.json(
+      { error: "Failed to fetch prompt versions" },
+      { status: 500 }
+    )
+  }
+}
+
+// POST /api/prompts — Create a new version
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json()
+    const { role, content, model, change_summary, parent_version_id, created_by } = body
+
+    if (!role || !content) {
+      return NextResponse.json(
+        { error: "Missing required fields: role, content" },
+        { status: 400 }
+      )
+    }
+
+    const convex = getConvexClient()
+    const version = await convex.mutation(api.promptVersions.create, {
+      role,
+      content,
+      model,
+      change_summary,
+      parent_version_id,
+      created_by: created_by || "human",
+    })
+
+    return NextResponse.json({ version })
+  } catch (error) {
+    console.error("[Prompts API] Error creating version:", error)
+    return NextResponse.json(
+      { error: "Failed to create prompt version" },
+      { status: 500 }
+    )
+  }
+}

--- a/app/prompts/components/diff-view.tsx
+++ b/app/prompts/components/diff-view.tsx
@@ -1,0 +1,110 @@
+'use client'
+
+import { useMemo } from 'react'
+import { diffLines } from 'diff'
+
+interface DiffViewProps {
+  oldContent: string
+  newContent: string
+  oldLabel?: string
+  newLabel?: string
+}
+
+export function DiffView({ oldContent, newContent, oldLabel, newLabel }: DiffViewProps) {
+  const changes = useMemo(() => {
+    return diffLines(oldContent, newContent, { newlineIsToken: true })
+  }, [oldContent, newContent])
+
+  return (
+    <div className="border border-[var(--border)] rounded-lg overflow-hidden bg-[var(--bg-primary)]">
+      {/* Header */}
+      <div className="flex border-b border-[var(--border)]">
+        <div className="flex-1 px-4 py-2 bg-red-500/10 border-r border-[var(--border)]">
+          <span className="text-xs font-medium text-red-400">{oldLabel || 'Old Version'}</span>
+        </div>
+        <div className="flex-1 px-4 py-2 bg-green-500/10">
+          <span className="text-xs font-medium text-green-400">{newLabel || 'New Version'}</span>
+        </div>
+      </div>
+
+      {/* Diff content */}
+      <div className="max-h-[500px] overflow-auto font-mono text-xs">
+        {changes.map((change, index) => {
+          if (change.added) {
+            return (
+              <div key={index} className="flex bg-green-500/10">
+                <div className="w-10 px-2 py-1 text-right text-[var(--text-muted)] border-r border-[var(--border)] select-none">
+                  +
+                </div>
+                <pre className="flex-1 px-4 py-1 text-green-400 whitespace-pre-wrap break-all">
+                  {change.value}
+                </pre>
+              </div>
+            )
+          }
+          if (change.removed) {
+            return (
+              <div key={index} className="flex bg-red-500/10">
+                <div className="w-10 px-2 py-1 text-right text-[var(--text-muted)] border-r border-[var(--border)] select-none">
+                  -
+                </div>
+                <pre className="flex-1 px-4 py-1 text-red-400 whitespace-pre-wrap break-all">
+                  {change.value}
+                </pre>
+              </div>
+            )
+          }
+          return (
+            <div key={index} className="flex">
+              <div className="w-10 px-2 py-1 text-right text-[var(--text-muted)] border-r border-[var(--border)] select-none">
+                ·
+              </div>
+              <pre className="flex-1 px-4 py-1 text-[var(--text-secondary)] whitespace-pre-wrap break-all">
+                {change.value}
+              </pre>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+interface UnifiedDiffViewProps {
+  oldContent: string
+  newContent: string
+}
+
+export function UnifiedDiffView({ oldContent, newContent }: UnifiedDiffViewProps) {
+  const changes = useMemo(() => {
+    return diffLines(oldContent, newContent, { newlineIsToken: true })
+  }, [oldContent, newContent])
+
+  return (
+    <div className="border border-[var(--border)] rounded-lg overflow-hidden bg-[var(--bg-primary)] font-mono text-xs">
+      <div className="max-h-[500px] overflow-auto">
+        {changes.map((change, index) => {
+          if (change.added) {
+            return (
+              <pre key={index} className="px-4 py-1 bg-green-500/10 text-green-400 whitespace-pre-wrap break-all border-l-2 border-green-500">
+                + {change.value}
+              </pre>
+            )
+          }
+          if (change.removed) {
+            return (
+              <pre key={index} className="px-4 py-1 bg-red-500/10 text-red-400 whitespace-pre-wrap break-all border-l-2 border-red-500">
+                - {change.value}
+              </pre>
+            )
+          }
+          return (
+            <pre key={index} className="px-4 py-1 text-[var(--text-secondary)] whitespace-pre-wrap break-all">
+              {'  '}{change.value}
+            </pre>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/app/prompts/components/editor-dialog.tsx
+++ b/app/prompts/components/editor-dialog.tsx
@@ -1,0 +1,189 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { FileText, Save } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+import type { PromptVersion } from '../types'
+
+const ROLES = [
+  { id: 'dev', label: 'Developer' },
+  { id: 'pm', label: 'Project Manager' },
+  { id: 'qa', label: 'QA Engineer' },
+  { id: 'researcher', label: 'Researcher' },
+  { id: 'reviewer', label: 'Code Reviewer' },
+  { id: 'pe', label: 'Prompt Engineer' },
+  { id: 'analyzer', label: 'Analyzer' },
+] as const
+
+const MODELS = [
+  { id: 'default', label: 'Default' },
+  { id: 'kimi', label: 'Kimi' },
+  { id: 'sonnet', label: 'Sonnet' },
+  { id: 'opus', label: 'Opus' },
+]
+
+interface EditorDialogProps {
+  isOpen: boolean
+  onClose: () => void
+  onSave: (data: {
+    role: string
+    content: string
+    model?: string
+    change_summary?: string
+    parent_version_id?: string
+  }) => void
+  initialRole?: string
+  initialModel?: string
+  initialContent?: string
+  parentVersion?: PromptVersion | null
+  mode: 'create' | 'duplicate'
+}
+
+export function EditorDialog({
+  isOpen,
+  onClose,
+  onSave,
+  initialRole = 'dev',
+  initialModel = 'default',
+  initialContent = '',
+  parentVersion,
+  mode,
+}: EditorDialogProps) {
+  const [role, setRole] = useState(initialRole)
+  const [model, setModel] = useState(initialModel)
+  const [content, setContent] = useState(initialContent)
+  const [changeSummary, setChangeSummary] = useState('')
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  // Reset form when dialog opens
+  useEffect(() => {
+    if (isOpen) {
+      setRole(initialRole)
+      setModel(initialModel)
+      setContent(initialContent)
+      setChangeSummary('')
+    }
+  }, [isOpen, initialRole, initialModel, initialContent])
+
+  const handleSave = async () => {
+    if (!content.trim()) return
+
+    setIsSubmitting(true)
+    try {
+      await onSave({
+        role,
+        content,
+        model: model === 'default' ? undefined : model,
+        change_summary: changeSummary || undefined,
+        parent_version_id: parentVersion?.id,
+      })
+      onClose()
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  const roleLabel = ROLES.find(r => r.id === role)?.label || role
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent className="max-w-4xl max-h-[90vh] flex flex-col">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <FileText className="h-5 w-5" />
+            {mode === 'duplicate' ? `Duplicate ${roleLabel} Template` : 'New Version'}
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className="flex-1 overflow-y-auto space-y-4 py-4">
+          {/* Role and Model selectors */}
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className="text-sm font-medium text-[var(--text-secondary)] mb-1.5 block">
+                Role
+              </label>
+              <select
+                value={role}
+                onChange={(e) => setRole(e.target.value)}
+                className="w-full px-3 py-2 bg-[var(--bg-tertiary)] border border-[var(--border)] rounded text-[var(--text-primary)] focus:outline-none focus:ring-1 focus:ring-[var(--accent-blue)]"
+              >
+                {ROLES.map(r => (
+                  <option key={r.id} value={r.id}>{r.label}</option>
+                ))}
+              </select>
+            </div>
+
+            <div>
+              <label className="text-sm font-medium text-[var(--text-secondary)] mb-1.5 block">
+                Model Variant
+              </label>
+              <select
+                value={model}
+                onChange={(e) => setModel(e.target.value)}
+                className="w-full px-3 py-2 bg-[var(--bg-tertiary)] border border-[var(--border)] rounded text-[var(--text-primary)] focus:outline-none focus:ring-1 focus:ring-[var(--accent-blue)]"
+              >
+                {MODELS.map(m => (
+                  <option key={m.id} value={m.id}>{m.label}</option>
+                ))}
+              </select>
+            </div>
+          </div>
+
+          {/* Change summary */}
+          <div>
+            <label className="text-sm font-medium text-[var(--text-secondary)] mb-1.5 block">
+              Change Summary (optional)
+            </label>
+            <Input
+              value={changeSummary}
+              onChange={(e) => setChangeSummary(e.target.value)}
+              placeholder="Brief description of what changed..."
+              className="bg-[var(--bg-tertiary)] border-[var(--border)]"
+            />
+          </div>
+
+          {/* Content editor */}
+          <div>
+            <label className="text-sm font-medium text-[var(--text-secondary)] mb-1.5 block">
+              Template Content
+            </label>
+            <Textarea
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
+              placeholder="# Role: Developer
+
+## Responsibilities
+- Implement features according to specifications
+- Write clean, well-tested code
+..."
+              className="min-h-[400px] font-mono text-sm bg-[var(--bg-tertiary)] border-[var(--border)] resize-none"
+            />
+          </div>
+
+          {parentVersion && (
+            <div className="text-xs text-[var(--text-muted)]">
+              Parent: v{parentVersion.version} ({parentVersion.role}{parentVersion.model ? `/${parentVersion.model}` : ''})
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="flex justify-end gap-2 pt-4 border-t border-[var(--border)]">
+          <Button variant="ghost" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button
+            onClick={handleSave}
+            disabled={!content.trim() || isSubmitting}
+          >
+            <Save className="h-4 w-4 mr-2" />
+            {isSubmitting ? 'Saving...' : 'Save Version'}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/app/prompts/components/role-sidebar.tsx
+++ b/app/prompts/components/role-sidebar.tsx
@@ -1,0 +1,182 @@
+'use client'
+
+import { useState } from 'react'
+import { FileText, GitBranch, Plus, Star, ChevronDown, ChevronRight } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import type { PromptVersion } from '../types'
+
+const ROLES = [
+  { id: 'dev', label: 'Developer', description: 'Implements features and fixes bugs' },
+  { id: 'pm', label: 'Project Manager', description: 'Breaks down epics into tasks' },
+  { id: 'qa', label: 'QA Engineer', description: 'Tests and verifies implementations' },
+  { id: 'researcher', label: 'Researcher', description: 'Investigates and documents findings' },
+  { id: 'reviewer', label: 'Code Reviewer', description: 'Reviews PRs and ensures quality' },
+  { id: 'pe', label: 'Prompt Engineer', description: 'Optimizes and refines prompts' },
+  { id: 'analyzer', label: 'Analyzer', description: 'Analyzes task outcomes' },
+] as const
+
+const MODELS = [
+  { id: 'default', label: 'Default' },
+  { id: 'kimi', label: 'Kimi' },
+  { id: 'sonnet', label: 'Sonnet' },
+  { id: 'opus', label: 'Opus' },
+]
+
+interface RoleSidebarProps {
+  selectedRole: string | null
+  selectedModel: string
+  onSelectRole: (role: string) => void
+  onSelectModel: (model: string) => void
+  versions: PromptVersion[]
+  onNewVersion: () => void
+}
+
+export function RoleSidebar({
+  selectedRole,
+  selectedModel,
+  onSelectRole,
+  onSelectModel,
+  versions,
+  onNewVersion,
+}: RoleSidebarProps) {
+  const [expandedRoles, setExpandedRoles] = useState<Set<string>>(new Set())
+
+  const toggleExpanded = (roleId: string) => {
+    const newExpanded = new Set(expandedRoles)
+    if (newExpanded.has(roleId)) {
+      newExpanded.delete(roleId)
+    } else {
+      newExpanded.add(roleId)
+    }
+    setExpandedRoles(newExpanded)
+  }
+
+  const getActiveVersionForRole = (roleId: string, model: string) => {
+    return versions.find(v => v.role === roleId && v.model === (model === 'default' ? undefined : model) && v.active)
+  }
+
+  const getVersionCountForRole = (roleId: string, model: string) => {
+    return versions.filter(v => v.role === roleId && v.model === (model === 'default' ? undefined : model)).length
+  }
+
+  return (
+    <div className="w-full lg:w-72 bg-[var(--bg-secondary)] border-r border-[var(--border)] flex flex-col h-full">
+      {/* Header */}
+      <div className="p-4 border-b border-[var(--border)]">
+        <div className="flex items-center justify-between mb-3">
+          <h2 className="text-sm font-semibold text-[var(--text-primary)]">Role Templates</h2>
+          <Button size="sm" variant="ghost" onClick={onNewVersion}>
+            <Plus className="h-4 w-4" />
+          </Button>
+        </div>
+
+        {/* Model Selector */}
+        <select
+          value={selectedModel}
+          onChange={(e) => onSelectModel(e.target.value)}
+          className="w-full px-3 py-1.5 text-xs bg-[var(--bg-tertiary)] border border-[var(--border)] rounded text-[var(--text-primary)] focus:outline-none focus:ring-1 focus:ring-[var(--accent-blue)]"
+        >
+          {MODELS.map(model => (
+            <option key={model.id} value={model.id}>{model.label}</option>
+          ))}
+        </select>
+      </div>
+
+      {/* Role List */}
+      <div className="flex-1 overflow-y-auto">
+        {ROLES.map(role => {
+          const isSelected = selectedRole === role.id
+          const isExpanded = expandedRoles.has(role.id)
+          const activeVersion = getActiveVersionForRole(role.id, selectedModel)
+          const versionCount = getVersionCountForRole(role.id, selectedModel)
+          const hasVariants = MODELS.some(m => m.id !== 'default' && getVersionCountForRole(role.id, m.id) > 0)
+
+          return (
+            <div key={role.id}>
+              <button
+                onClick={() => onSelectRole(role.id)}
+                className={cn(
+                  "w-full flex items-center gap-2 px-4 py-3 text-left transition-colors",
+                  isSelected
+                    ? "bg-[var(--accent)] text-[var(--accent-foreground)]"
+                    : "hover:bg-[var(--bg-tertiary)] text-[var(--text-secondary)]"
+                )}
+              >
+                {hasVariants && (
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      toggleExpanded(role.id)
+                    }}
+                    className="p-0.5 rounded hover:bg-[var(--bg-tertiary)]"
+                  >
+                    {isExpanded ? (
+                      <ChevronDown className="h-3 w-3" />
+                    ) : (
+                      <ChevronRight className="h-3 w-3" />
+                    )}
+                  </button>
+                )}
+                {!hasVariants && <div className="w-4" />}
+
+                <FileText className="h-4 w-4 flex-shrink-0" />
+
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm font-medium truncate">{role.label}</span>
+                    {activeVersion && (
+                      <Star className="h-3 w-3 fill-[var(--accent-yellow)] text-[var(--accent-yellow)]" />
+                    )}
+                  </div>
+                  <p className={cn(
+                    "text-xs truncate",
+                    isSelected ? "text-[var(--accent-foreground)]/70" : "text-[var(--text-muted)]"
+                  )}>
+                    {versionCount} version{versionCount !== 1 ? 's' : ''}
+                  </p>
+                </div>
+              </button>
+
+              {/* Model variants */}
+              {isExpanded && hasVariants && (
+                <div className="bg-[var(--bg-primary)]">
+                  {MODELS.filter(m => m.id !== 'default').map(model => {
+                    const modelCount = getVersionCountForRole(role.id, model.id)
+                    if (modelCount === 0) return null
+                    const modelActive = getActiveVersionForRole(role.id, model.id)
+
+                    return (
+                      <button
+                        key={model.id}
+                        onClick={() => {
+                          onSelectModel(model.id)
+                          onSelectRole(role.id)
+                        }}
+                        className={cn(
+                          "w-full flex items-center gap-2 pl-10 pr-4 py-2 text-left text-xs transition-colors",
+                          selectedRole === role.id && selectedModel === model.id
+                            ? "bg-[var(--accent)] text-[var(--accent-foreground)]"
+                            : "hover:bg-[var(--bg-tertiary)] text-[var(--text-secondary)]"
+                        )}
+                      >
+                        <GitBranch className="h-3 w-3" />
+                        <span>{model.label}</span>
+                        {modelActive && (
+                          <Badge variant="outline" className="ml-auto text-[10px] px-1 py-0">
+                            Active
+                          </Badge>
+                        )}
+                      </button>
+                    )
+                  })}
+                </div>
+              )}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/app/prompts/components/version-list.tsx
+++ b/app/prompts/components/version-list.tsx
@@ -1,0 +1,214 @@
+'use client'
+
+import { useState } from 'react'
+import { format } from 'date-fns'
+import { Check, ChevronDown, ChevronRight, Copy, GitCompare, Star, User } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card } from '@/components/ui/card'
+import type { PromptVersion } from '../types'
+import { DiffView } from './diff-view'
+
+interface VersionListProps {
+  versions: PromptVersion[]
+  selectedRole: string
+  selectedModel: string
+  onSetActive: (version: PromptVersion) => void
+  onDuplicate: (version: PromptVersion) => void
+}
+
+export function VersionList({ versions, selectedRole, selectedModel, onSetActive, onDuplicate }: VersionListProps) {
+  const [expandedVersion, setExpandedVersion] = useState<string | null>(null)
+  const [diffMode, setDiffMode] = useState<'none' | 'selecting' | 'viewing'>('none')
+  const [diffBase, setDiffBase] = useState<PromptVersion | null>(null)
+  const [diffTarget, setDiffTarget] = useState<PromptVersion | null>(null)
+
+  // Filter versions by role and model
+  const filteredVersions = versions.filter(v =>
+    v.role === selectedRole && v.model === (selectedModel === 'default' ? undefined : selectedModel)
+  ).sort((a, b) => b.version - a.version) // Newest first
+
+  const handleStartDiff = (version: PromptVersion) => {
+    if (diffMode === 'none') {
+      setDiffMode('selecting')
+      setDiffBase(version)
+    } else if (diffMode === 'selecting') {
+      if (diffBase?.id === version.id) {
+        // Cancel diff selection
+        setDiffMode('none')
+        setDiffBase(null)
+      } else {
+        setDiffTarget(version)
+        setDiffMode('viewing')
+      }
+    }
+  }
+
+  const handleCancelDiff = () => {
+    setDiffMode('none')
+    setDiffBase(null)
+    setDiffTarget(null)
+  }
+
+  const handleSwapDiff = () => {
+    if (diffBase && diffTarget) {
+      setDiffBase(diffTarget)
+      setDiffTarget(diffBase)
+    }
+  }
+
+  if (filteredVersions.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center h-64 text-[var(--text-muted)]">
+        <p className="text-sm">No versions found for this role</p>
+        <p className="text-xs mt-1">Create a new version to get started</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Diff mode indicator */}
+      {diffMode !== 'none' && (
+        <div className="flex items-center justify-between px-4 py-2 bg-[var(--accent)]/10 rounded-lg border border-[var(--accent)]/20">
+          <div className="flex items-center gap-2 text-sm">
+            <GitCompare className="h-4 w-4 text-[var(--accent-blue)]" />
+            {diffMode === 'selecting' ? (
+              <span>Select another version to compare with v{diffBase?.version}</span>
+            ) : (
+              <span>Comparing v{diffBase?.version} → v{diffTarget?.version}</span>
+            )}
+          </div>
+          <div className="flex items-center gap-2">
+            {diffMode === 'viewing' && (
+              <Button size="sm" variant="ghost" onClick={handleSwapDiff}>
+                Swap
+              </Button>
+            )}
+            <Button size="sm" variant="ghost" onClick={handleCancelDiff}>
+              Cancel
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {/* Diff view */}
+      {diffMode === 'viewing' && diffBase && diffTarget && (
+        <Card className="p-4">
+          <DiffView
+            oldContent={diffBase.content}
+            newContent={diffTarget.content}
+            oldLabel={`v${diffBase.version}`}
+            newLabel={`v${diffTarget.version}`}
+          />
+        </Card>
+      )}
+
+      {/* Version list */}
+      <div className="space-y-2">
+        {filteredVersions.map(version => {
+          const isExpanded = expandedVersion === version.id
+          const isActive = version.active
+          const isDiffBase = diffBase?.id === version.id
+          const isDiffTarget = diffTarget?.id === version.id
+
+          return (
+            <Card
+              key={version.id}
+              className={cn(
+                "overflow-hidden transition-colors",
+                isActive && "border-[var(--accent-green)]",
+                isDiffBase && "border-[var(--accent-blue)]",
+                isDiffTarget && "border-[var(--accent-purple)]"
+              )}
+            >
+              {/* Header */}
+              <div className="flex items-center gap-3 px-4 py-3">
+                <button
+                  onClick={() => setExpandedVersion(isExpanded ? null : version.id)}
+                  className="p-1 rounded hover:bg-[var(--bg-tertiary)]"
+                >
+                  {isExpanded ? (
+                    <ChevronDown className="h-4 w-4 text-[var(--text-muted)]" />
+                  ) : (
+                    <ChevronRight className="h-4 w-4 text-[var(--text-muted)]" />
+                  )}
+                </button>
+
+                <div className="flex items-center gap-2">
+                  <span className="text-lg font-mono font-semibold text-[var(--text-primary)]">
+                    v{version.version}
+                  </span>
+                  {isActive && (
+                    <Badge className="bg-[var(--accent-green)]/20 text-[var(--accent-green)] hover:bg-[var(--accent-green)]/30">
+                      <Star className="h-3 w-3 mr-1 fill-current" />
+                      Active
+                    </Badge>
+                  )}
+                </div>
+
+                <div className="flex-1" />
+
+                <div className="flex items-center gap-4 text-xs text-[var(--text-muted)]">
+                  <span className="flex items-center gap-1">
+                    <User className="h-3 w-3" />
+                    {version.created_by}
+                  </span>
+                  <span>{format(version.created_at, 'MMM d, yyyy')}</span>
+                </div>
+
+                <div className="flex items-center gap-1">
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    onClick={() => handleStartDiff(version)}
+                    disabled={diffMode === 'viewing'}
+                    className={cn(
+                      isDiffBase && "bg-[var(--accent-blue)]/20 text-[var(--accent-blue)]",
+                      isDiffTarget && "bg-[var(--accent-purple)]/20 text-[var(--accent-purple)]"
+                    )}
+                  >
+                    <GitCompare className="h-4 w-4" />
+                  </Button>
+
+                  {!isActive && (
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      onClick={() => onSetActive(version)}
+                    >
+                      <Check className="h-4 w-4" />
+                    </Button>
+                  )}
+
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    onClick={() => onDuplicate(version)}
+                  >
+                    <Copy className="h-4 w-4" />
+                  </Button>
+                </div>
+              </div>
+
+              {/* Expanded content */}
+              {isExpanded && (
+                <div className="px-4 pb-4 border-t border-[var(--border)]">
+                  {version.change_summary && (
+                    <div className="py-2 text-sm text-[var(--text-secondary)]">
+                      <span className="font-medium">Change Summary:</span> {version.change_summary}
+                    </div>
+                  )}
+                  <pre className="mt-2 p-4 bg-[var(--bg-primary)] rounded text-xs text-[var(--text-secondary)] overflow-auto max-h-96 whitespace-pre-wrap">
+                    {version.content}
+                  </pre>
+                </div>
+              )}
+            </Card>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/app/prompts/page.tsx
+++ b/app/prompts/page.tsx
@@ -1,0 +1,179 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import { FileText, Loader2 } from 'lucide-react'
+import { toast } from 'sonner'
+import { RoleSidebar } from './components/role-sidebar'
+import { VersionList } from './components/version-list'
+import { EditorDialog } from './components/editor-dialog'
+import type { PromptVersion } from './types'
+
+const ROLES = [
+  { id: 'dev', label: 'Developer' },
+  { id: 'pm', label: 'Project Manager' },
+  { id: 'qa', label: 'QA Engineer' },
+  { id: 'researcher', label: 'Researcher' },
+  { id: 'reviewer', label: 'Code Reviewer' },
+  { id: 'pe', label: 'Prompt Engineer' },
+  { id: 'analyzer', label: 'Analyzer' },
+] as const
+
+export default function PromptsPage() {
+  const [selectedRole, setSelectedRole] = useState<string>('dev')
+  const [selectedModel, setSelectedModel] = useState<string>('default')
+  const [versions, setVersions] = useState<PromptVersion[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [isEditorOpen, setIsEditorOpen] = useState(false)
+  const [editorMode, setEditorMode] = useState<'create' | 'duplicate'>('create')
+  const [duplicateSource, setDuplicateSource] = useState<PromptVersion | null>(null)
+
+  // Fetch all versions on mount
+  const fetchVersions = useCallback(async () => {
+    try {
+      // Fetch versions for all roles to populate sidebar counts
+      const allVersions: PromptVersion[] = []
+      for (const role of ROLES) {
+        const res = await fetch(`/api/prompts?role=${role.id}`)
+        if (res.ok) {
+          const data = await res.json()
+          allVersions.push(...data.versions)
+        }
+      }
+      setVersions(allVersions)
+    } catch (error) {
+      console.error('Error fetching versions:', error)
+      toast.error('Failed to load prompt versions')
+    } finally {
+      setIsLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    fetchVersions()
+  }, [fetchVersions])
+
+  const handleSetActive = async (version: PromptVersion) => {
+    try {
+      const res = await fetch(`/api/prompts/${version.id}/activate`, {
+        method: 'PATCH',
+      })
+
+      if (!res.ok) {
+        throw new Error('Failed to activate version')
+      }
+
+      // Update local state
+      setVersions(prev => prev.map(v => ({
+        ...v,
+        active: v.role === version.role && v.model === version.model
+          ? v.id === version.id
+          : v.active
+      })))
+
+      toast.success(`Version v${version.version} is now active`)
+    } catch (error) {
+      console.error('Error activating version:', error)
+      toast.error('Failed to activate version')
+    }
+  }
+
+  const handleCreateVersion = async (data: {
+    role: string
+    content: string
+    model?: string
+    change_summary?: string
+    parent_version_id?: string
+  }) => {
+    const res = await fetch('/api/prompts', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    })
+
+    if (!res.ok) {
+      throw new Error('Failed to create version')
+    }
+
+    const { version } = await res.json()
+    setVersions(prev => [...prev, version])
+    toast.success(`Created v${version.version} for ${data.role}`)
+  }
+
+  const handleDuplicate = (version: PromptVersion) => {
+    setDuplicateSource(version)
+    setEditorMode('duplicate')
+    setIsEditorOpen(true)
+  }
+
+  const handleNewVersion = () => {
+    setDuplicateSource(null)
+    setEditorMode('create')
+    setIsEditorOpen(true)
+  }
+
+  const roleLabel = ROLES.find(r => r.id === selectedRole)?.label || selectedRole
+  const modelLabel = selectedModel === 'default' ? '' : ` (${selectedModel})`
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center h-screen">
+        <Loader2 className="h-8 w-8 animate-spin text-[var(--text-muted)]" />
+      </div>
+    )
+  }
+
+  return (
+    <div className="h-[calc(100vh-4rem)] flex">
+      {/* Sidebar */}
+      <RoleSidebar
+        selectedRole={selectedRole}
+        selectedModel={selectedModel}
+        onSelectRole={setSelectedRole}
+        onSelectModel={setSelectedModel}
+        versions={versions}
+        onNewVersion={handleNewVersion}
+      />
+
+      {/* Main content */}
+      <div className="flex-1 flex flex-col min-w-0">
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-[var(--border)]">
+          <div className="flex items-center gap-3">
+            <FileText className="h-5 w-5 text-[var(--text-muted)]" />
+            <div>
+              <h1 className="text-lg font-semibold text-[var(--text-primary)]">
+                {roleLabel}{modelLabel}
+              </h1>
+              <p className="text-sm text-[var(--text-muted)]">
+                Version history and prompt templates
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {/* Version list */}
+        <div className="flex-1 overflow-y-auto p-6">
+          <VersionList
+            versions={versions}
+            selectedRole={selectedRole}
+            selectedModel={selectedModel}
+            onSetActive={handleSetActive}
+            onDuplicate={handleDuplicate}
+          />
+        </div>
+      </div>
+
+      {/* Editor dialog */}
+      <EditorDialog
+        isOpen={isEditorOpen}
+        onClose={() => setIsEditorOpen(false)}
+        onSave={handleCreateVersion}
+        initialRole={selectedRole}
+        initialModel={selectedModel}
+        initialContent={duplicateSource?.content || ''}
+        parentVersion={duplicateSource}
+        mode={editorMode}
+      />
+    </div>
+  )
+}

--- a/app/prompts/types.ts
+++ b/app/prompts/types.ts
@@ -1,0 +1,12 @@
+export interface PromptVersion {
+  id: string
+  role: string
+  model?: string
+  version: number
+  content: string
+  change_summary?: string
+  parent_version_id?: string
+  created_by: string
+  active: boolean
+  created_at: number
+}

--- a/components/layout/sidebar.tsx
+++ b/components/layout/sidebar.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link"
 import { usePathname } from "next/navigation"
-import { Home, Activity, Bot, Settings, Repeat } from "lucide-react"
+import { Home, Activity, Bot, Settings, Repeat, FileText } from "lucide-react"
 import { cn } from "@/lib/utils"
 
 const NAVIGATION_ITEMS = [
@@ -10,6 +10,7 @@ const NAVIGATION_ITEMS = [
   { id: "work-loop", label: "Work Loop", icon: Repeat, href: "/work-loop" },
   { id: "sessions", label: "Sessions", icon: Activity, href: "/sessions" },
   { id: "agents", label: "Agents", icon: Bot, href: "/agents" },
+  { id: "prompts", label: "Prompt Lab", icon: FileText, href: "/prompts" },
   { id: "settings", label: "Settings", icon: Settings, href: "/settings" },
 ]
 
@@ -26,6 +27,7 @@ export function Sidebar() {
     if (pathname.startsWith("/work-loop")) return "work-loop"
     if (pathname.startsWith("/sessions")) return "sessions"
     if (pathname.startsWith("/agents")) return "agents"
+    if (pathname.startsWith("/prompts")) return "prompts"
     if (pathname.startsWith("/settings")) return "settings"
     return "home"
   }

--- a/components/providers/index.tsx
+++ b/components/providers/index.tsx
@@ -5,6 +5,7 @@
  */
 
 import React from 'react';
+import { Toaster } from 'sonner';
 import { ConvexProviderWrapper } from '@/lib/convex/provider';
 
 interface ProvidersProps {
@@ -15,6 +16,16 @@ export function Providers({ children }: ProvidersProps) {
   return (
     <ConvexProviderWrapper>
       {children}
+      <Toaster 
+        position="bottom-right"
+        toastOptions={{
+          style: {
+            background: 'var(--bg-secondary)',
+            border: '1px solid var(--border)',
+            color: 'var(--text-primary)',
+          },
+        }}
+      />
     </ConvexProviderWrapper>
   );
 }

--- a/package.json
+++ b/package.json
@@ -17,10 +17,12 @@
   "dependencies": {
     "@hello-pangea/dnd": "^18.0.1",
     "@tanstack/react-table": "^8.21.3",
-    "convex": "^1.31.7",
+    "@types/diff": "^8.0.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "convex": "^1.31.7",
     "date-fns": "^4.1.0",
+    "diff": "^8.0.3",
     "lucide-react": "^0.563.0",
     "next": "16.1.6",
     "radix-ui": "^1.4.3",
@@ -29,6 +31,7 @@
     "react-markdown": "^10.1.0",
     "rehype-highlight": "^7.0.2",
     "remark-gfm": "^4.0.1",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.0",
     "ws": "^8.19.0",
     "zustand": "^5.0.11"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@tanstack/react-table':
         specifier: ^8.21.3
         version: 8.21.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@types/diff':
+        specifier: ^8.0.0
+        version: 8.0.0
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -26,6 +29,9 @@ importers:
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
+      diff:
+        specifier: ^8.0.3
+        version: 8.0.3
       lucide-react:
         specifier: ^0.563.0
         version: 0.563.0(react@19.2.3)
@@ -50,6 +56,9 @@ importers:
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
+      sonner:
+        specifier: ^2.0.7
+        version: 2.0.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       tailwind-merge:
         specifier: ^3.4.0
         version: 3.4.0
@@ -1895,6 +1904,10 @@ packages:
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
+  '@types/diff@8.0.0':
+    resolution: {integrity: sha512-o7jqJM04gfaYrdCecCVMbZhNdG6T1MHg/oQoRFdERLV+4d+V7FijhiEAbFu0Usww84Yijk9yH58U4Jk4HbtzZw==}
+    deprecated: This is a stub types definition. diff provides its own type definitions, so you do not need this installed.
+
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
 
@@ -2439,6 +2452,10 @@ packages:
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
+
+  diff@8.0.3:
+    resolution: {integrity: sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==}
+    engines: {node: '>=0.3.1'}
 
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
@@ -3710,6 +3727,12 @@ packages:
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  sonner@2.0.7:
+    resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -5722,6 +5745,10 @@ snapshots:
 
   '@types/deep-eql@4.0.2': {}
 
+  '@types/diff@8.0.0':
+    dependencies:
+      diff: 8.0.3
+
   '@types/estree-jsx@1.0.5':
     dependencies:
       '@types/estree': 1.0.8
@@ -6271,6 +6298,8 @@ snapshots:
   devlop@1.1.0:
     dependencies:
       dequal: 2.0.3
+
+  diff@8.0.3: {}
 
   doctrine@2.1.0:
     dependencies:
@@ -8109,6 +8138,11 @@ snapshots:
       side-channel-weakmap: 1.0.2
 
   siginfo@2.0.0: {}
+
+  sonner@2.0.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+    dependencies:
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
 
   source-map-js@1.2.1: {}
 


### PR DESCRIPTION
## Summary

Implements the Prompt Lab page for managing role prompt templates.

**Features:**
- Role sidebar listing all roles with version counts and model variants
- Version history (newest-first) with metadata
- Side-by-side diff view between any two versions
- Editor dialog for creating new versions
- Quick actions: set active version, duplicate to other models

**API routes:**
- `GET /api/prompts?role=dev` — list versions
- `GET /api/prompts/[id]` — get specific version
- `POST /api/prompts` — create new version
- `PATCH /api/prompts/[id]/activate` — set as active

**New dependencies:** `diff`, `sonner`

Closes #3386f273

**Ticket:** `3386f273`