### PR TITLE
fix: use openclaw CLI for session status polling

### DIFF
--- a/app/api/sessions/status/route.ts
+++ b/app/api/sessions/status/route.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process"
 import { NextRequest, NextResponse } from "next/server"
 
 export interface SessionStatusInfo {
@@ -18,160 +19,170 @@ export interface SessionStatusInfo {
 }
 
 /**
+ * Raw session data from `openclaw sessions --json`.
+ */
+interface OpenClawSession {
+  key: string
+  kind: string
+  updatedAt: number
+  ageMs: number
+  sessionId: string
+  abortedLastRun: boolean
+  inputTokens: number
+  outputTokens: number
+  totalTokens: number
+  model: string
+  contextTokens: number
+}
+
+const IDLE_THRESHOLD_MS = 5 * 60 * 1000 // 5 minutes
+const STUCK_THRESHOLD_MS = 15 * 60 * 1000 // 15 minutes
+
+/**
+ * Fetch all active sessions from the OpenClaw CLI.
+ *
+ * Uses `openclaw sessions --json --active N` which reads the local sessions
+ * file. This is the same approach used by worker/sessions.ts and avoids the
+ * non-existent HTTP RPC endpoint that was causing "fetch failed" errors.
+ */
+function fetchOpenClawSessions(activeMinutes = 60): OpenClawSession[] {
+  try {
+    const result = execFileSync(
+      "openclaw",
+      ["sessions", "--json", "--active", String(activeMinutes)],
+      { encoding: "utf-8", timeout: 10_000 },
+    )
+    const data = JSON.parse(result) as { sessions?: OpenClawSession[] }
+    return data.sessions ?? []
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    console.warn(`[sessions/status] Failed to poll openclaw sessions: ${message}`)
+    return []
+  }
+}
+
+/**
+ * Derive status info from a raw OpenClaw session.
+ */
+function toStatusInfo(session: OpenClawSession): SessionStatusInfo {
+  const now = Date.now()
+  const lastActivityMs = session.updatedAt || now
+  const timeSinceActivity = now - lastActivityMs
+
+  const isActive = timeSinceActivity < IDLE_THRESHOLD_MS
+  const isIdle = timeSinceActivity >= IDLE_THRESHOLD_MS && timeSinceActivity < STUCK_THRESHOLD_MS
+  const isStuck = timeSinceActivity >= STUCK_THRESHOLD_MS
+
+  let status: SessionStatusInfo['status'] = 'idle'
+  if (isActive) status = 'running'
+  else if (isStuck) status = 'error'
+
+  const updatedAt = session.updatedAt
+    ? new Date(session.updatedAt).toISOString()
+    : undefined
+
+  return {
+    id: session.key,
+    status,
+    updatedAt,
+    model: session.model,
+    tokens: {
+      input: session.inputTokens || 0,
+      output: session.outputTokens || 0,
+      total: session.totalTokens || 0,
+    },
+    lastActivity: updatedAt,
+    isActive,
+    isIdle,
+    isStuck,
+  }
+}
+
+/**
  * POST /api/sessions/status
- * Get status for multiple session IDs
- * 
+ * Get status for multiple session IDs.
+ *
  * Body: { sessionIds: string[] }
  * Returns: { sessions: Record<string, SessionStatusInfo> }
  */
 export async function POST(request: NextRequest) {
   try {
     const { sessionIds } = await request.json()
-    
+
     if (!Array.isArray(sessionIds)) {
       return NextResponse.json(
         { error: "sessionIds must be an array" },
-        { status: 400 }
+        { status: 400 },
       )
     }
-    
-    // OpenClaw gateway HTTP endpoint
-    const openclawUrl = process.env.OPENCLAW_HTTP_URL || 'http://127.0.0.1:4440'
-    const openclawToken = process.env.OPENCLAW_TOKEN || process.env.NEXT_PUBLIC_OPENCLAW_TOKEN || ''
-    
+
+    // One CLI call to get all active sessions, then match locally
+    const allSessions = fetchOpenClawSessions(60)
+    const sessionsByKey = new Map(allSessions.map((s) => [s.key, s]))
+
     const sessions: Record<string, SessionStatusInfo> = {}
-    const now = Date.now()
-    const IDLE_THRESHOLD_MS = 5 * 60 * 1000 // 5 minutes
-    const STUCK_THRESHOLD_MS = 15 * 60 * 1000 // 15 minutes
-    
-    // Fetch session info for each session ID
+
     for (const sessionId of sessionIds) {
-      if (!sessionId || typeof sessionId !== 'string') {
+      if (!sessionId || typeof sessionId !== "string") {
         sessions[sessionId] = {
           id: sessionId,
-          status: 'not_found',
+          status: "not_found",
           isActive: false,
           isIdle: false,
-          isStuck: false
+          isStuck: false,
         }
         continue
       }
-      
-      try {
-        // Try to get session info via HTTP RPC to OpenClaw
-        const rpcRequest = {
-          type: 'req',
-          id: crypto.randomUUID(),
-          method: 'sessions.list',
-          params: { keys: [sessionId] }
-        }
-        
-        const httpResponse = await fetch(`${openclawUrl}/rpc`, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            'Authorization': openclawToken ? `Bearer ${openclawToken}` : ''
-          },
-          body: JSON.stringify(rpcRequest)
-        })
-        
-        if (!httpResponse.ok) {
-          throw new Error(`OpenClaw HTTP ${httpResponse.status}: ${httpResponse.statusText}`)
-        }
-        
-        const rpcResponse = await httpResponse.json()
-        if (!rpcResponse.ok || rpcResponse.error) {
-          throw new Error(rpcResponse.error?.message || 'OpenClaw RPC error')
-        }
-        
-        const sessionInfo = rpcResponse.payload?.sessions?.[0]
-        
-        if (!sessionInfo) {
-          sessions[sessionId] = {
-            id: sessionId,
-            status: 'not_found',
-            isActive: false,
-            isIdle: false,
-            isStuck: false
-          }
-          continue
-        }
-        
-        const updatedAt = sessionInfo.updatedAt
-        const lastActivityMs = updatedAt ? new Date(updatedAt).getTime() : now
-        const timeSinceActivity = now - lastActivityMs
-        
-        // Determine status based on activity
-        const isActive = timeSinceActivity < IDLE_THRESHOLD_MS
-        const isIdle = timeSinceActivity >= IDLE_THRESHOLD_MS && timeSinceActivity < STUCK_THRESHOLD_MS
-        const isStuck = timeSinceActivity >= STUCK_THRESHOLD_MS
-        
-        let status: SessionStatusInfo['status'] = 'idle'
-        if (isActive) status = 'running'
-        else if (isStuck) status = 'error' // Treat stuck as error state
-        
+
+      const match = sessionsByKey.get(sessionId)
+
+      if (!match) {
         sessions[sessionId] = {
           id: sessionId,
-          status,
-          updatedAt,
-          createdAt: sessionInfo.createdAt,
-          model: sessionInfo.model,
-          tokens: {
-            input: sessionInfo.inputTokens || 0,
-            output: sessionInfo.outputTokens || 0,
-            total: sessionInfo.totalTokens || 0
-          },
-          lastActivity: updatedAt,
-          isActive,
-          isIdle,
-          isStuck
-        }
-      } catch (error) {
-        console.error(`Failed to get status for session ${sessionId}:`, error)
-        sessions[sessionId] = {
-          id: sessionId,
-          status: 'error',
+          status: "not_found",
           isActive: false,
           isIdle: false,
-          isStuck: false
+          isStuck: false,
         }
+        continue
       }
+
+      sessions[sessionId] = toStatusInfo(match)
     }
-    
+
     return NextResponse.json({ sessions })
   } catch (error) {
     console.error("Failed to get session status:", error)
     return NextResponse.json(
       { error: "Failed to get session status", details: String(error) },
-      { status: 500 }
+      { status: 500 },
     )
   }
 }
 
 /**
  * GET /api/sessions/status?sessionId=xxx
- * Get status for a single session ID (for testing)
+ * Get status for a single session ID (for testing).
  */
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url)
-  const sessionId = searchParams.get('sessionId')
-  
+  const sessionId = searchParams.get("sessionId")
+
   if (!sessionId) {
     return NextResponse.json(
       { error: "sessionId parameter is required" },
-      { status: 400 }
+      { status: 400 },
     )
   }
-  
-  // Use the POST handler with a single session ID
+
   const mockRequest = {
-    json: async () => ({ sessionIds: [sessionId] })
+    json: async () => ({ sessionIds: [sessionId] }),
   } as NextRequest
-  
+
   const response = await POST(mockRequest)
   const data = await response.json()
-  
+
   return NextResponse.json({
-    session: data.sessions?.[sessionId] || null
+    session: data.sessions?.[sessionId] || null,
   })
 }


### PR DESCRIPTION
## Problem

The `/api/sessions/status` route was POSTing to `$OPENCLAW_HTTP_URL/rpc` — an endpoint that doesn't exist. OpenClaw exposes WebSocket RPC, not HTTP RPC. Every poll attempt resulted in:

```
Failed to get status for session workloop:dev:XXXX: TypeError: fetch failed
```

## Fix

Replaced the broken HTTP RPC approach with the `openclaw sessions --json --active 60` CLI, which is the same proven method used by `worker/sessions.ts` (`SessionsPoller`).

**Key changes:**
- Single CLI call per request (fetches all active sessions), then matches by key locally
- No per-session network requests
- Proper error handling with `execFileSync` + 10s timeout
- Extracted `fetchOpenClawSessions()` and `toStatusInfo()` helpers for clarity

## Verification

- `pnpm typecheck` passes
- `pnpm lint` passes (0 errors, pre-existing warnings only)

Ticket: 780b207a-bce2-4899-8836-e2a56dbafbc3