### PR TITLE
fix: work loop dashboard showing 0s due to project ID mismatch

### DIFF
--- a/convex/workLoop.ts
+++ b/convex/workLoop.ts
@@ -145,6 +145,7 @@ export const listRuns = query({
         .withIndex('by_project_created', (q) =>
           q.eq('project_id', args.projectId).lt('created_at', args.before!)
         )
+        .order("desc")
         .take(limit)
     } else {
       runs = await ctx.db
@@ -152,13 +153,11 @@ export const listRuns = query({
         .withIndex('by_project_created', (q) =>
           q.eq('project_id', args.projectId)
         )
+        .order("desc")
         .take(limit)
     }
 
-    // Sort by created_at descending (newest first)
-    return runs
-      .sort((a, b) => b.created_at - a.created_at)
-      .map((r) => toWorkLoopRun(r as WorkLoopRunDoc))
+    return runs.map((r) => toWorkLoopRun(r as WorkLoopRunDoc))
   },
 })
 
@@ -169,7 +168,8 @@ export const getStats = query({
   args: { projectId: v.string() },
   handler: async (ctx, args): Promise<WorkLoopStats> => {
     const now = Date.now()
-    const startOfDay = new Date(now).setHours(0, 0, 0, 0)
+    const d = new Date(now)
+    const startOfDay = Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate())
 
     // Get today's runs for this project
     const runs = await ctx.db

--- a/worker/phases/analyze.ts
+++ b/worker/phases/analyze.ts
@@ -44,14 +44,6 @@ interface AnalyzeResult {
 export async function runAnalyze(ctx: AnalyzeContext): Promise<AnalyzeResult> {
   const { convex, children, config, cycle, projectId, log } = ctx
 
-  // Log phase start
-  await log({
-    projectId,
-    cycle,
-    phase: "analyze",
-    action: "phase_start",
-  })
-
   let spawnedCount = 0
   let skippedCount = 0
 

--- a/worker/phases/review.ts
+++ b/worker/phases/review.ts
@@ -66,14 +66,6 @@ interface PRInfo {
 export async function runReview(ctx: ReviewContext): Promise<ReviewResult> {
   const { convex, children, config, cycle, projectId } = ctx
 
-  // Log phase start
-  await ctx.log({
-    projectId,
-    cycle,
-    phase: "review",
-    action: "phase_start",
-  })
-
   let spawnedCount = 0
   let skippedCount = 0
 


### PR DESCRIPTION
## Summary

The work loop dashboard showed 0 for everything (tasks today, cycles, active agents, recent activity) despite the loop running correctly and logging data to Convex.

## Root Cause

The dashboard hardcoded `DEFAULT_PROJECT_ID = 'trap'` — a slug — but all Convex queries filter by the UUID `project_id`. Since no data matched the slug `'trap'`, every query returned empty results.

Meanwhile, the actual loop was running fine, cycling every 30s, finding 4 ready tasks (all dependency-blocked), and logging all of this to Convex under the correct UUID `da46e964-...`.

## Fixes

1. **Project ID resolution** — Dashboard now queries `projects.getAll` and finds the first project with `work_loop_enabled=true`, using its real UUID for all subsequent queries. Shows a helpful empty state if no projects have the loop enabled.

2. **`listRuns` ordering** — The query was doing `.take(limit)` on an ascending index then sorting descending in JS — returning the *oldest* 50 runs instead of the newest. Fixed to use `.order('desc')` before `.take()`.

3. **`getStats` UTC** — `startOfDay` was calculated with local-timezone `setHours()` instead of UTC `Date.UTC()`.

4. **Duplicate phase_start logging** — Both `runPhase()` wrapper in loop.ts and the individual phase functions (review, analyze) were logging `phase_start`. Removed the inner duplicates.

5. **Activity log UX** — Filters out noisy `phase_start`/`phase_complete` entries and formats action strings with human-readable context from the details JSON (e.g., `blocked: Metrics dashboard UI on /prompts/metrics page` instead of raw `dependency_blocked`).

## What's NOT broken

The work loop orchestrator itself is working correctly:
- Connects to Convex, polls enabled projects
- Runs all 4 phases per cycle (cleanup → review → work → analyze)
- Finds ready tasks and checks dependencies
- Logs everything to `workLoopRuns` table
- All 4 current ready tasks are properly identified as dependency-blocked

Ticket: 3320344c-7edb-423c-b298-17bf79b46561