### PR TITLE
fix: restore thinking/typing indicator in chat UI

### DIFF
--- a/app/api/chats/[id]/typing/route.ts
+++ b/app/api/chats/[id]/typing/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from "next/server"
+import { getConvexClient } from "@/lib/convex/server"
+import { api } from "@/convex/_generated/api"
+
+type RouteParams = { params: Promise<{ id: string }> }
+
+// POST /api/chats/[id]/typing — Set or clear typing indicator
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  const { id } = await params
+  const body = await request.json()
+
+  const { typing, author = "ada", state = "thinking" } = body
+
+  if (typeof typing !== "boolean") {
+    return NextResponse.json(
+      { error: "typing (boolean) is required" },
+      { status: 400 }
+    )
+  }
+
+  const convex = getConvexClient()
+
+  // Verify chat exists
+  const chat = await convex.query(api.chats.getById, { id })
+  if (!chat) {
+    return NextResponse.json(
+      { error: "Chat not found" },
+      { status: 404 }
+    )
+  }
+
+  if (typing) {
+    const validState = state === "typing" ? "typing" as const : "thinking" as const
+    await convex.mutation(api.chats.setTyping, {
+      chat_id: id,
+      author,
+      state: validState,
+    })
+  } else {
+    await convex.mutation(api.chats.clearTyping, {
+      chat_id: id,
+      author,
+    })
+  }
+
+  return NextResponse.json({ ok: true })
+}

--- a/app/projects/[slug]/chat/page.tsx
+++ b/app/projects/[slug]/chat/page.tsx
@@ -358,6 +358,9 @@ export default function ChatPage({ params }: PageProps) {
     // Save user message to Convex
     await sendMessageToDb(activeChat.id, messageContent, "dan")
 
+    // Show thinking indicator immediately (optimistic)
+    setTyping(activeChat.id, "ada", "thinking")
+
     // Build message for OpenClaw (include project context on first message)
     let openClawMessage = messageContent
     if (isFirstMessage && projectContext) {
@@ -370,6 +373,8 @@ export default function ChatPage({ params }: PageProps) {
       await sendChatMessage(sessionKey, openClawMessage)
     } catch (error) {
       console.error("[Chat] Failed to send to OpenClaw:", error)
+      // Clear typing indicator on send failure
+      setTyping(activeChat.id, "ada", false)
     }
   }
 

--- a/plugins/trap-channel.ts
+++ b/plugins/trap-channel.ts
@@ -152,6 +152,18 @@ export default function register(api: OpenClawPluginApi) {
     } else {
       api.logger.warn(`Trap: failed to save response to chat ${chatId}: ${result.error}`);
     }
+
+    // Clear typing indicator after response is saved
+    const trapUrl = getTrapUrl(api);
+    try {
+      await fetch(`${trapUrl}/api/chats/${chatId}/typing`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ typing: false, author: "ada" }),
+      });
+    } catch (error) {
+      api.logger.warn(`Trap: failed to clear typing indicator for chat ${chatId}: ${error}`);
+    }
   });
 
   // =========================================================================


### PR DESCRIPTION
## Problem

The thinking/typing indicator no longer appears in the chat UI when waiting for a response. It used to show that the agent was processing, but it's gone now.

## Root Cause

Three issues combined to break the indicator:

1. **No optimistic indicator** — The frontend never set a typing state when sending a message, relying entirely on the backend path
2. **Missing API endpoint** — The trap-channel plugin's `sendTypingIndicator` POSTed to `/api/chats/[id]/typing` which didn't exist, so OpenClaw's typing signals were silently lost
3. **syncMessages didn't clear indicators** — When messages arrived via Convex reactive queries, typing indicators weren't cleared for authors with new messages

## Changes

### 1. Frontend optimistic indicator (`chat/page.tsx`)
- Sets Ada's 'thinking' state immediately when user sends a message
- Clears on send failure

### 2. New API endpoint (`/api/chats/[id]/typing/route.ts`)
- Accepts `POST { typing: bool, author: string, state?: string }`
- Calls Convex `setTyping`/`clearTyping` mutations
- This is the endpoint the trap-channel plugin was already trying to call

### 3. Backend safety net (`trap-channel.ts`)
- `agent_end` hook now explicitly clears the typing indicator after saving the response
- Ensures indicator is cleaned up even if the normal channel typing flow doesn't fire

### 4. Store fix (`chat-store.ts`)
- `syncMessages` now detects new messages from authors and clears their typing indicators
- The optimistic 'thinking' state disappears the moment Ada's response arrives via Convex

## Acceptance Criteria

- [x] Typing/thinking indicator displays in chat while waiting for agent response
- [x] Indicator disappears once the response arrives
- [x] Works for both streaming and non-streaming responses (indicator set optimistically, cleared on message arrival)

Ticket: ff51daac-71ae-4d33-be40-2a61a6860c1c