### PR TITLE
feat: redesign project list with ticket stats, agents, and work loop status

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -284,3 +284,9 @@
 .hljs-regexp {
   color: #ffcc99;
 }
+
+/* Live indicator pulse */
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,22 +1,18 @@
 "use client"
 
-import { useEffect } from "react"
-import { useProjectStore } from "@/lib/stores/project-store"
-import { ProjectCard } from "@/components/projects/project-card"
+import { useQuery } from "convex/react"
+import { api } from "@/convex/_generated/api"
+import { ProjectListRow } from "@/components/projects/project-list-row"
 import { CreateProjectModal } from "@/components/projects/create-project-modal"
 import { Skeleton } from "@/components/ui/skeleton"
 
 export default function Home() {
-  const { projects, loading, error, fetchProjects } = useProjectStore()
-
-  useEffect(() => {
-    fetchProjects()
-  }, [fetchProjects])
+  const projects = useQuery(api.projects.getAllWithStats, {})
 
   return (
-    <div className="container mx-auto py-12 px-4 max-w-6xl">
+    <div className="container mx-auto py-12 px-4 max-w-5xl">
       {/* Header */}
-      <div className="flex items-center justify-between mb-8">
+      <div className="flex items-center justify-between mb-6">
         <div>
           <h1 className="text-3xl font-bold text-[var(--text-primary)]">
             Projects
@@ -30,48 +26,53 @@ export default function Home() {
         </div>
       </div>
 
-        {/* Error state */}
-        {error && (
-          <div className="text-sm text-red-500 bg-red-500/10 border border-red-500/20 rounded px-4 py-3 mb-6">
-            {error}
-          </div>
-        )}
-
-        {/* Loading state */}
-        {loading && projects.length === 0 && (
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-            {[1, 2, 3].map((i) => (
-              <div key={i} className="bg-[var(--bg-secondary)] border border-[var(--border)] rounded-lg overflow-hidden">
-                <Skeleton className="h-1 w-full" />
-                <div className="p-4 space-y-3">
-                  <Skeleton className="h-5 w-1/2" />
-                  <Skeleton className="h-4 w-3/4" />
-                  <Skeleton className="h-6 w-16" />
-                </div>
+      {/* Loading state */}
+      {projects === undefined && (
+        <div className="border border-[var(--border)] rounded-lg overflow-hidden">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="flex items-center gap-4 px-4 py-3 border-b border-[var(--border)] last:border-b-0">
+              <Skeleton className="w-2.5 h-2.5 rounded-full" />
+              <div className="flex-1 space-y-1.5">
+                <Skeleton className="h-4 w-40" />
+                <Skeleton className="h-3 w-60" />
               </div>
-            ))}
-          </div>
-        )}
+              <Skeleton className="h-4 w-32 hidden md:block" />
+              <Skeleton className="h-5 w-16 hidden lg:block" />
+            </div>
+          ))}
+        </div>
+      )}
 
-        {/* Empty state */}
-        {!loading && projects.length === 0 && (
-          <div className="text-center py-16">
-            <div className="text-6xl mb-4">📋</div>
-            <h2 className="text-xl font-semibold text-[var(--text-primary)] mb-2">
-              No projects yet
-            </h2>
-            <p className="text-[var(--text-secondary)] mb-6">
-              Create your first project to start organizing work.
-            </p>
-            <CreateProjectModal />
-          </div>
-        )}
+      {/* Empty state */}
+      {projects !== undefined && projects.length === 0 && (
+        <div className="text-center py-16">
+          <div className="text-6xl mb-4">📋</div>
+          <h2 className="text-xl font-semibold text-[var(--text-primary)] mb-2">
+            No projects yet
+          </h2>
+          <p className="text-[var(--text-secondary)] mb-6">
+            Create your first project to start organizing work.
+          </p>
+          <CreateProjectModal />
+        </div>
+      )}
 
-      {/* Project grid */}
-      {projects.length > 0 && (
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+      {/* Project list */}
+      {projects !== undefined && projects.length > 0 && (
+        <div className="border border-[var(--border)] rounded-lg overflow-hidden">
+          {/* Column headers */}
+          <div className="flex items-center gap-4 px-4 py-2 bg-[var(--bg-secondary)] border-b border-[var(--border)] text-xs font-medium text-[var(--text-muted)] uppercase tracking-wider">
+            <div className="flex-1">Project</div>
+            <div className="hidden md:block" style={{ minWidth: "180px" }}>Tickets</div>
+            <div className="flex md:hidden">Tasks</div>
+            <div className="hidden sm:block" style={{ minWidth: "90px" }}>Agents</div>
+            <div className="hidden lg:block" style={{ minWidth: "90px" }}>Loop</div>
+            <div className="hidden lg:block" style={{ minWidth: "70px" }}>Activity</div>
+            <div style={{ width: "56px" }} />
+          </div>
+
           {projects.map((project) => (
-            <ProjectCard key={project.id} project={project} />
+            <ProjectListRow key={project.id} project={project} />
           ))}
         </div>
       )}

--- a/components/projects/project-list-row.tsx
+++ b/components/projects/project-list-row.tsx
@@ -1,0 +1,191 @@
+"use client"
+
+import Link from "next/link"
+import { Settings, LayoutGrid } from "lucide-react"
+
+interface ProjectStats {
+  id: string
+  slug: string
+  name: string
+  description: string | null
+  color: string
+  task_count: number
+  status_counts: {
+    backlog: number
+    ready: number
+    in_progress: number
+    in_review: number
+    done: number
+  }
+  active_agents: number
+  work_loop_status: string
+  last_activity: number
+}
+
+interface ProjectListRowProps {
+  project: ProjectStats
+}
+
+function StatusCount({ count, label, color }: { count: number; label: string; color: string }) {
+  if (count === 0) {
+    return (
+      <span className="text-xs text-[var(--text-muted)] tabular-nums" title={label}>
+        {count}
+      </span>
+    )
+  }
+  return (
+    <span className="text-xs font-medium tabular-nums" style={{ color }} title={label}>
+      {count}
+    </span>
+  )
+}
+
+function WorkLoopBadge({ status }: { status: string }) {
+  const configs: Record<string, { label: string; bg: string; text: string; dot?: string }> = {
+    running: { label: "Running", bg: "rgba(34, 197, 94, 0.1)", text: "var(--accent-green)", dot: "var(--accent-green)" },
+    paused: { label: "Paused", bg: "rgba(234, 179, 8, 0.1)", text: "var(--accent-yellow)" },
+    stopped: { label: "Stopped", bg: "rgba(161, 161, 170, 0.1)", text: "var(--text-muted)" },
+    error: { label: "Error", bg: "rgba(239, 68, 68, 0.1)", text: "var(--accent-red)" },
+    disabled: { label: "Disabled", bg: "transparent", text: "var(--text-muted)" },
+  }
+  const cfg = configs[status] ?? configs.disabled
+
+  return (
+    <span
+      className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-xs font-medium"
+      style={{ backgroundColor: cfg.bg, color: cfg.text }}
+    >
+      {cfg.dot && (
+        <span
+          className="inline-block w-1.5 h-1.5 rounded-full"
+          style={{
+            backgroundColor: cfg.dot,
+            animation: status === "running" ? "pulse 2s ease-in-out infinite" : undefined,
+          }}
+        />
+      )}
+      {cfg.label}
+    </span>
+  )
+}
+
+function ActiveAgentsBadge({ count }: { count: number }) {
+  if (count === 0) return null
+
+  return (
+    <span
+      className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-xs font-medium"
+      style={{ backgroundColor: "rgba(59, 130, 246, 0.1)", color: "var(--accent-blue)" }}
+    >
+      <span
+        className="inline-block w-1.5 h-1.5 rounded-full"
+        style={{
+          backgroundColor: "var(--accent-blue)",
+          animation: "pulse 2s ease-in-out infinite",
+        }}
+      />
+      {count} agent{count !== 1 ? "s" : ""}
+    </span>
+  )
+}
+
+function timeAgo(timestamp: number): string {
+  const seconds = Math.floor((Date.now() - timestamp) / 1000)
+  if (seconds < 60) return "just now"
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) return `${minutes}m ago`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.floor(hours / 24)
+  if (days < 30) return `${days}d ago`
+  return new Date(timestamp).toLocaleDateString()
+}
+
+export function ProjectListRow({ project }: ProjectListRowProps) {
+  const { status_counts: sc } = project
+
+  return (
+    <div className="group flex items-center gap-4 px-4 py-3 border-b border-[var(--border)] hover:bg-[var(--bg-secondary)] transition-colors">
+      {/* Color indicator + Name */}
+      <div className="flex items-center gap-3 min-w-0 flex-1">
+        <div
+          className="w-2.5 h-2.5 rounded-full flex-shrink-0"
+          style={{ backgroundColor: project.color }}
+        />
+        <div className="min-w-0">
+          <Link
+            href={`/projects/${project.slug}`}
+            className="font-medium text-[var(--text-primary)] hover:text-[var(--accent-blue)] transition-colors truncate block"
+          >
+            {project.name}
+          </Link>
+          {project.description && (
+            <p className="text-xs text-[var(--text-muted)] truncate mt-0.5 hidden sm:block">
+              {project.description}
+            </p>
+          )}
+        </div>
+      </div>
+
+      {/* Ticket counts — desktop */}
+      <div className="hidden md:flex items-center gap-3 text-xs flex-shrink-0" style={{ minWidth: "180px" }}>
+        <span className="flex items-center gap-1" title="Ready">
+          <span className="w-2 h-2 rounded-sm flex-shrink-0" style={{ backgroundColor: "var(--accent-blue)" }} />
+          <StatusCount count={sc.ready} label="Ready" color="var(--accent-blue)" />
+        </span>
+        <span className="flex items-center gap-1" title="In Progress">
+          <span className="w-2 h-2 rounded-sm flex-shrink-0" style={{ backgroundColor: "var(--accent-yellow)" }} />
+          <StatusCount count={sc.in_progress} label="In Progress" color="var(--accent-yellow)" />
+        </span>
+        <span className="flex items-center gap-1" title="In Review">
+          <span className="w-2 h-2 rounded-sm flex-shrink-0" style={{ backgroundColor: "#a78bfa" }} />
+          <StatusCount count={sc.in_review} label="In Review" color="#a78bfa" />
+        </span>
+        <span className="flex items-center gap-1" title="Done">
+          <span className="w-2 h-2 rounded-sm flex-shrink-0" style={{ backgroundColor: "var(--accent-green)" }} />
+          <StatusCount count={sc.done} label="Done" color="var(--accent-green)" />
+        </span>
+      </div>
+
+      {/* Ticket counts — mobile compact */}
+      <div className="flex md:hidden items-center gap-1.5 text-xs flex-shrink-0">
+        <span className="text-[var(--text-muted)]">{project.task_count}</span>
+        <span className="text-[var(--text-muted)]">tasks</span>
+      </div>
+
+      {/* Active agents */}
+      <div className="hidden sm:flex items-center flex-shrink-0" style={{ minWidth: "90px" }}>
+        <ActiveAgentsBadge count={project.active_agents} />
+      </div>
+
+      {/* Work loop status */}
+      <div className="hidden lg:flex items-center flex-shrink-0" style={{ minWidth: "90px" }}>
+        <WorkLoopBadge status={project.work_loop_status} />
+      </div>
+
+      {/* Last activity */}
+      <div className="hidden lg:block text-xs text-[var(--text-muted)] flex-shrink-0 tabular-nums" style={{ minWidth: "70px" }}>
+        {timeAgo(project.last_activity)}
+      </div>
+
+      {/* Quick actions */}
+      <div className="flex items-center gap-1 flex-shrink-0 opacity-0 group-hover:opacity-100 transition-opacity">
+        <Link
+          href={`/projects/${project.slug}/board`}
+          className="p-1.5 rounded hover:bg-[var(--bg-tertiary)] text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors"
+          title="Board"
+        >
+          <LayoutGrid className="w-3.5 h-3.5" />
+        </Link>
+        <Link
+          href={`/projects/${project.slug}/settings`}
+          className="p-1.5 rounded hover:bg-[var(--bg-tertiary)] text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors"
+          title="Settings"
+        >
+          <Settings className="w-3.5 h-3.5" />
+        </Link>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Switch project dashboard from grid cards to a dense, scannable list layout (think GitHub repo list / Linear).

## Changes

**New Convex query** — `projects.getAllWithStats`
- Returns task counts broken down by status (backlog/ready/in_progress/in_review/done)
- Includes work loop state (status + active agents) per project
- Tracks last activity timestamp across project and task updates
- Single reactive query replaces the old Zustand + REST API pattern

**New component** — `ProjectListRow`
- Color indicator + project name/description
- Status-colored ticket count chips (blue=ready, yellow=in-progress, purple=in-review, green=done)
- Active agents badge with pulse animation when > 0
- Work loop status badge (running/paused/stopped/disabled)
- Relative timestamp for last activity
- Quick-link icons to board and settings (visible on hover)
- Responsive: full columns on desktop, compact task count on mobile

**Updated** — `app/page.tsx`
- Direct Convex `useQuery` for real-time reactive updates
- List layout with column headers
- Loading skeleton matches list shape

**CSS** — Added `@keyframes pulse` for live indicator animation

## Ticket
`c6937067-93d7-4ede-bdb7-ec82eed2ba08`