### PR TITLE
fix: explicitly set model for dev/qa roles to prevent Opus fallback

### DIFF
--- a/worker/phases/work.ts
+++ b/worker/phases/work.ts
@@ -58,19 +58,21 @@ function sortTasks(tasks: Task[]): Task[] {
 // Role → Model Mapping
 // ============================================
 
-const ROLE_MODEL_MAP: Record<string, string | undefined> = {
+const ROLE_MODEL_MAP: Record<string, string> = {
   pm: "sonnet",
   research: "sonnet",
   reviewer: "sonnet",
-  dev: undefined,  // use default
-  qa: undefined,   // use default
+  dev: "moonshot/kimi-for-coding",
+  qa: "moonshot/kimi-for-coding",
 }
 
 /**
- * Get the model override for a role
+ * Get the model for a role.
+ * Every role must have an explicit model to avoid falling back to the
+ * gateway default (which may be an expensive model like Opus).
  */
-function getModelForRole(role: string): string | undefined {
-  return ROLE_MODEL_MAP[role] ?? undefined
+function getModelForRole(role: string): string {
+  return ROLE_MODEL_MAP[role] ?? ROLE_MODEL_MAP.dev
 }
 
 // ============================================


### PR DESCRIPTION
## Problem

Dev and QA agents were running on `claude-opus-4-6` instead of `moonshot/kimi-for-coding`, burning expensive Opus tokens on work that should be free/cheap.

## Root Cause

`ROLE_MODEL_MAP` had `undefined` for dev/qa roles:

```ts
const ROLE_MODEL_MAP = {
  pm: "sonnet",
  reviewer: "sonnet",
  dev: undefined,  // ← no model override
  qa: undefined,   // ← no model override
}
```

When `getModelForRole` returned `undefined`, the `ChildManager.spawn` method skipped the `--model` flag entirely, so `openclaw chat` used the gateway default model — which is Opus.

## Fix

- Set dev/qa explicitly to `moonshot/kimi-for-coding`
- Changed `ROLE_MODEL_MAP` type from `Record<string, string | undefined>` to `Record<string, string>` — missing models are now a type error
- `getModelForRole` always returns a string, falling back to the dev model for unknown roles

## Verification

- `pnpm typecheck` ✅
- `pnpm lint` ✅ (0 errors, 43 pre-existing warnings)

Ticket: 1ab76f36-985d-4035-acfa-8a1f08ddfafc