### PR TITLE
fix: sessions tab status accuracy and browser freeze

### DIFF
--- a/app/api/sessions/status/route.ts
+++ b/app/api/sessions/status/route.ts
@@ -36,7 +36,7 @@ interface OpenClawSession {
 }
 
 const IDLE_THRESHOLD_MS = 5 * 60 * 1000 // 5 minutes
-const STUCK_THRESHOLD_MS = 15 * 60 * 1000 // 15 minutes
+const COMPLETED_THRESHOLD_MS = 15 * 60 * 1000 // 15 minutes
 
 /**
  * Fetch all active sessions from the OpenClaw CLI.
@@ -70,12 +70,12 @@ function toStatusInfo(session: OpenClawSession): SessionStatusInfo {
   const timeSinceActivity = now - lastActivityMs
 
   const isActive = timeSinceActivity < IDLE_THRESHOLD_MS
-  const isIdle = timeSinceActivity >= IDLE_THRESHOLD_MS && timeSinceActivity < STUCK_THRESHOLD_MS
-  const isStuck = timeSinceActivity >= STUCK_THRESHOLD_MS
+  const isIdle = timeSinceActivity >= IDLE_THRESHOLD_MS && timeSinceActivity < COMPLETED_THRESHOLD_MS
+  const isStuck = timeSinceActivity >= COMPLETED_THRESHOLD_MS
 
   let status: SessionStatusInfo['status'] = 'idle'
   if (isActive) status = 'running'
-  else if (isStuck) status = 'error'
+  else if (isStuck) status = 'completed'
 
   const updatedAt = session.updatedAt
     ? new Date(session.updatedAt).toISOString()

--- a/components/sessions/session-row.tsx
+++ b/components/sessions/session-row.tsx
@@ -50,8 +50,11 @@ const statusConfig: Record<SessionStatus, { label: string; variant: 'default' | 
 };
 
 function formatDuration(startTime: string, endTime?: string): string {
+  // Without a true createdAt, we can't compute meaningful duration.
+  // Show "—" for sessions without a completion time instead of live-ticking.
+  if (!endTime) return '—';
   const start = new Date(startTime);
-  const end = endTime ? new Date(endTime) : new Date();
+  const end = new Date(endTime);
   const diffMs = end.getTime() - start.getTime();
   
   const minutes = Math.floor(diffMs / 60000);

--- a/lib/hooks/use-openclaw-http.ts
+++ b/lib/hooks/use-openclaw-http.ts
@@ -25,7 +25,7 @@ export { openclawApi };
 /**
  * Hook for session list with auto-refresh
  */
-export function useSessionList(refreshIntervalMs = 10000) {
+export function useSessionList(refreshIntervalMs = 30000) {
   const [sessions, setSessions] = useState<Session[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);

--- a/lib/openclaw/api.ts
+++ b/lib/openclaw/api.ts
@@ -28,7 +28,7 @@ export type { GatewayStatus } from './rpc';
  * Works from both client and server contexts.
  */
 async function fetchSessionsFromApi(params?: SessionListParams): Promise<SessionListResponse> {
-  const limit = params?.limit ?? 100;
+  const limit = params?.limit ?? 50;
   const activeMinutes = 60;
   const url = `/api/sessions/list?activeMinutes=${activeMinutes}&limit=${limit}`;
 


### PR DESCRIPTION
## Problem

Two bugs on the Sessions tab:

1. **All sessions show as alive** — every session displays as 'Working' with a ticking timer, regardless of actual state
2. **Tab freezes the browser** — excessive polling, per-render Date() computations, and Convex subscription thrashing cause the tab to become unresponsive

## Root Causes

### Status always shows 'Working'
- API returned `error` for sessions >15min old, which the UI mapped to 'Stuck' (red) — but never returned `completed`
- `createdAt` was set to `updatedAt` in the API response, making every session look freshly started
- `formatDuration()` used `new Date()` as the end time when `completedAt` was missing, causing all durations to tick upward indefinitely

### Browser freeze
- Polling every 10 seconds, each poll spawning a child process (`execFileSync` → `openclaw sessions --json`)
- Session limit of 100 with no cap
- `sessionIds` array reference changed on every poll (new array), causing Convex `useTasksBySessionIds` to re-subscribe on every cycle
- Every poll replaced the entire Zustand sessions array, triggering full component tree re-renders

## Fix

### Status accuracy
- API now returns `running` (<5min), `idle` (5-15min), `completed` (>15min) instead of `running`/`idle`/`error`
- `completedAt` is set for completed sessions so the UI shows static duration
- Status endpoint updated to match the same thresholds

### Performance
- Reduced poll interval from 10s → 30s
- Reduced default session limit from 100 → 50 (server cap: 200)
- Removed per-render `new Date()` calls from `formatDuration` in both session-table and session-row
- Stabilized Convex subscription by memoizing `sessionIds` with joined key comparison (reference only changes when actual IDs change)

## Files Changed
- `app/api/sessions/list/route.ts` — correct status derivation, add completedAt, lower default limit
- `app/api/sessions/status/route.ts` — align thresholds with list endpoint
- `components/sessions/session-table.tsx` — static duration computation, no live ticking
- `components/sessions/session-row.tsx` — static duration, no live ticking
- `components/sessions/sessions-list.tsx` — 30s polling, stable sessionIds memo
- `lib/hooks/use-openclaw-http.ts` — 30s default refresh interval
- `lib/openclaw/api.ts` — default limit 50

Ticket: 259cb9d6-c3a2-463a-92ba-033d0400d508