### PR TITLE
fix: clear stale agent fields on task status transition

### DIFF
--- a/convex/tasks.ts
+++ b/convex/tasks.ts
@@ -543,6 +543,14 @@ export const move = mutation({
       position: newPosition,
       updated_at: now,
       completed_at: wasCompleted ? now : existing.completed_at,
+      // Clear stale agent fields when status changes —
+      // new agent (if any) will write its own info after spawn
+      agent_session_key: undefined,
+      agent_model: undefined,
+      agent_started_at: undefined,
+      agent_last_active_at: undefined,
+      agent_tokens_in: undefined,
+      agent_tokens_out: undefined,
     })
 
     const updated = await ctx.db.get(existing._id)


### PR DESCRIPTION
## Problem

When a task moves between columns (e.g. `in_progress` → `in_review`), agent tracking fields (`agent_session_key`, `agent_model`, timestamps, token counts) remained on the task record. This caused:

1. **Stale last-token counter** — card shows ever-growing time-since-last-token from the dead agent
2. **Wrong model displayed** — shows dev agent's model on in_review cards
3. **No reviewer agent info** — review phase didn't write its agent fields after spawn

## Fix

### 1. Clear agent fields on status transition (`convex/tasks.ts`)
The `move` mutation now sets all `agent_*` fields to `undefined` when the status changes. The new agent (if any) writes its own info after spawn.

### 2. Write reviewer agent info after spawn (`worker/phases/review.ts`)
After spawning a reviewer via `agents.spawn()`, we now write the reviewer's session key, model, and timestamps to the task — same pattern the work phase already uses.

## Verification
- `pnpm typecheck` ✅
- `pnpm lint` ✅ (0 errors, all warnings pre-existing)

Ticket: 258e8d0d-0c23-4d16-9fe5-b9fc511618cf