### PR TITLE
fix: stop 502 flood from RPC proxy — bridge through WS client

### DIFF
--- a/lib/openclaw/client.ts
+++ b/lib/openclaw/client.ts
@@ -194,7 +194,7 @@ class OpenClawClient {
       })
 
       const message = JSON.stringify({
-        jsonrpc: '2.0',
+        type: 'req',
         id,
         method,
         params: params || {}


### PR DESCRIPTION
## Problem

The chat tab continuously fires `POST /api/openclaw/rpc` requests that return 502 Bad Gateway, flooding the browser console.

## Root Cause

The RPC proxy route (`/api/openclaw/rpc`) was doing `fetch('http://gateway:18789/rpc')` — but the OpenClaw gateway has **no HTTP `/rpc` endpoint**. All RPC is WebSocket-only. Every single request returned 405 → proxy returned 502 → browser console spam.

Additionally, the WS client's `rpc()` method was sending `jsonrpc: '2.0'` format frames, but gateway protocol v3 expects `type: 'req'` — so even if the proxy used the WS client, the calls would have been silently dropped.

## Fixes

### 1. RPC proxy route → use WS client (`route.ts`)
Rewrote to bridge HTTP→WS via the existing `OpenClawClient` singleton instead of the non-existent HTTP endpoint.

### 2. WS client frame format (`client.ts`)
Fixed `rpc()` to send `{ type: 'req', id, method, params }` instead of `{ jsonrpc: '2.0', ... }`.

### 3. Polling components → use CLI-backed endpoint
Chat page, chat-header, and context-indicator were polling via `openclawRpc('sessions.list')` which went through the broken proxy. Switched to the working CLI-backed `/api/sessions/list` endpoint.

### 4. Exponential backoff (`rpc.ts`)
Replaced primitive "3 strikes wait 60s" with proper exponential backoff (5s→10s→20s→40s→60s cap). If the proxy is temporarily down, the client backs off gracefully instead of flooding.

## Files Changed
- `app/api/openclaw/rpc/route.ts` — proxy rewrite (HTTP→WS bridge)
- `lib/openclaw/client.ts` — fix frame format
- `lib/openclaw/rpc.ts` — exponential backoff
- `app/projects/[slug]/chat/page.tsx` — use CLI endpoint for session info
- `components/chat/chat-header.tsx` — use CLI endpoint
- `components/chat/context-indicator.tsx` — use CLI endpoint, reduce poll to 30s

## Verification
- `pnpm typecheck` passes
- `pnpm lint` — 0 errors (existing warnings only)

Ticket: 54432d88-aacb-4b42-9bda-c5965a2aca63