### PR TITLE
Deprecate old cron-based work loop and gate script

### DIFF
--- a/docs/cron-deprecation.md
+++ b/docs/cron-deprecation.md
@@ -1,0 +1,35 @@
+# Cron-Based Work Loop — Deprecated
+
+The old cron-based work loop system has been replaced by the persistent worker (`worker/`).
+
+## What Changed
+
+| Component | Old (cron-based) | New (persistent worker) |
+|-----------|-------------------|------------------------|
+| Scheduling | OpenClaw cron job every 30s | Persistent Node.js process |
+| Gate script | `~/bin/trap-gate.sh` | `worker/loop.ts` with phases |
+| Agent spawn | Cron script resolver → sub-agent | `GatewayRpcClient` → real sessions |
+| Worktree cleanup | `~/bin/trap-worktree-cleanup.sh` | `worker/phases/cleanup.ts` |
+| Review routing | Gate script section 3 | `worker/phases/review.ts` |
+
+## Archived Files
+
+- `~/bin/archive/trap-gate.sh.deprecated` — original gate script
+- `~/bin/archive/trap-worktree-cleanup.sh.deprecated` — original cleanup script
+
+Stub scripts remain at the old paths with deprecation notices, so any accidental invocation returns a no-op.
+
+## Cron Jobs Removed
+
+- `trap-work-loop` (ID `a4512186-e8a2-468b-b0ff-c5525469a628`) — deleted from OpenClaw cron
+- No `trap-qa-loop` job existed
+
+## Why
+
+The cron-based system had limitations:
+- 30s polling interval meant slow response to new work
+- Script resolver was fragile (shell script parsing JSON, race conditions)
+- No persistent state between runs
+- Each run was an isolated sub-agent with no context
+
+The persistent worker maintains WebSocket connection to OpenClaw gateway, tracks agent lifecycle, and responds to work immediately.


### PR DESCRIPTION
## Summary

Deprecates the old cron-based work loop system now that the persistent worker is running.

### Changes

**Archived (not deleted):**
- `~/bin/trap-gate.sh` → `~/bin/archive/trap-gate.sh.deprecated`
- `~/bin/trap-worktree-cleanup.sh` → `~/bin/archive/trap-worktree-cleanup.sh.deprecated`
- Stub scripts left at old paths with deprecation notices

**Removed:**
- `trap-work-loop` cron job deleted from OpenClaw (was already disabled)

**Added:**
- `docs/cron-deprecation.md` — documents old → new migration

**Updated:**
- MEMORY.md references updated from 'gate script' to 'persistent worker'

### Acceptance Criteria
- [x] No cron jobs fire for trap work/review/cleanup
- [x] Gate script is archived (not deleted)
- [x] Old system won't interfere with new worker
- [x] Documentation updated

Ticket: 9dd50a56-26cb-4755-96e4-35393aaf9eac