### PR TITLE
fix: pause button on /work-loop crashes with TypeError

### DIFF
--- a/app/api/work-loop/state/route.ts
+++ b/app/api/work-loop/state/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server"
-import { fetchMutation } from "convex/nextjs"
+import { getConvexClient } from "@/lib/convex/server"
 import { api } from "@/convex/_generated/api"
 
 // PATCH /api/work-loop/state — Update work loop state
@@ -24,7 +24,8 @@ export async function PATCH(request: NextRequest) {
 
     // Upsert the state with provided values
     // Convex will handle creating new or updating existing
-    const updatedState = await fetchMutation(api.workLoop.upsertState, {
+    const convex = getConvexClient()
+    const updatedState = await convex.mutation(api.workLoop.upsertState, {
       project_id: projectId,
       status,
       current_phase,


### PR DESCRIPTION
## Problem
The pause/resume button on the /work-loop page was failing with:
- `TypeError: Failed to fetch` in the browser console
- `ERR_CONNECTION_REFUSED` on `/api/work-loop/state`
- Page redirecting to home page

## Root Cause
The API route was using `fetchMutation` from `convex/nextjs`, which is a **client-side** helper that requires `NEXT_PUBLIC_CONVEX_URL`. This environment variable isn't available in API route context, causing the mutation to fail.

## Fix
Changed to use `getConvexClient()` from `@/lib/convex/server` which uses `ConvexHttpClient" with the server-side `CONVEX_URL` environment variable.

## Verification
- API endpoint now returns 200 with correct state
- Pause/resume toggle works correctly

Ticket: 036547c6-880f-47c3-9c0c-2217842d58d7