### PR TITLE
fix: block rendering until Convex client is initialized

### DIFF
--- a/lib/convex/provider.tsx
+++ b/lib/convex/provider.tsx
@@ -39,9 +39,9 @@ export function ConvexProviderWrapper({ children }: ConvexProviderWrapperProps) 
     }
   }, [])
 
-  // If no Convex URL is configured, just render children without provider
+  // Block rendering until Convex client is initialized
   if (!client) {
-    return <>{children}</>
+    return null
   }
 
   return <ConvexProvider client={client}>{children}</ConvexProvider>


### PR DESCRIPTION
Fix: Home page crashes with useQuery outside ConvexProvider error

Changes:
- Return null instead of children in ConvexProviderWrapper when client is not yet initialized
- This prevents child components from rendering before the Convex React context is available

Ticket: c1b944ca-6aeb-4252-94fb-34b29cf3c8fa