### PR TITLE
fix: gracefully handle RPC unavailability in session detail page

### DIFF
--- a/app/sessions/[id]/page.tsx
+++ b/app/sessions/[id]/page.tsx
@@ -443,7 +443,10 @@ export default function SessionDetailPage() {
                 ))}
                 {sessionPreview.messages.length === 0 && (
                   <div className="text-center text-muted-foreground py-8">
-                    No messages in this session yet.
+                    <p className="mb-2">No messages available.</p>
+                    <p className="text-sm opacity-70">
+                      Conversation history requires OpenClaw RPC connection. Session metadata is still available.
+                    </p>
                   </div>
                 )}
               </div>


### PR DESCRIPTION
Ticket: b8651df0-a3af-4081-b6f0-4bd1d80e497d

## Problem
When OpenClaw WebSocket is disconnected, the `/api/openclaw/rpc` endpoint returns 502 errors. The session detail page was calling `sessions.preview` via RPC on page load, causing 5 simultaneous 502 errors to appear in the browser console.

## Solution
Modified `getSessionPreview()` to gracefully handle RPC failures:
- Always fetches session metadata from CLI-backed `/api/sessions/list` (works without WebSocket)
- Attempts to fetch message history via RPC, but catches failures gracefully
- Returns session metadata with empty messages array when RPC is unavailable
- Updated UI to explain when messages can't be loaded due to RPC issues

This follows the same pattern as the previous fix for ticket #54432d88.

## Changes
- `lib/openclaw/api.ts`: Modified `getSessionPreview()` to catch RPC errors and return fallback data
- `app/sessions/[id]/page.tsx`: Updated empty messages state with more informative message