### PR TITLE
fix: ConvexProvider null guard comment improvement

### DIFF
--- a/lib/convex/provider.tsx
+++ b/lib/convex/provider.tsx
@@ -39,7 +39,8 @@ export function ConvexProviderWrapper({ children }: ConvexProviderWrapperProps) 
     }
   }, [])
 
-  // Block rendering until Convex client is initialized
+  // Wait for client to initialize — rendering children without the provider
+  // would crash any component that calls useQuery/useMutation
   if (!client) {
     return null
   }


### PR DESCRIPTION
Improve the comment explaining why we return null when the Convex client is not yet initialized.

**Fix:**
- Updated comment to clearly explain that rendering children without the provider would crash components using useQuery/useMutation

**Changes:**
- lib/convex/provider.tsx: Enhanced comment for the client null check

Ticket: a445dd5f-b8a4-4e42-97e6-faae60d7d811