### PR TITLE
fix: board renders as kanban grid at desktop viewports

### DIFF
--- a/components/board/board.tsx
+++ b/components/board/board.tsx
@@ -370,7 +370,24 @@ export function Board({ projectId, onTaskClick, onAddTask }: BoardProps) {
 
       {/* Board Columns */}
       <DragDropContext onDragEnd={handleDragEnd}>
-        <div className="flex gap-4 overflow-x-auto pb-4 lg:grid lg:overflow-visible" style={{
+        {/* Mobile: horizontal scroll flex layout */}
+        <div className="flex lg:hidden gap-4 overflow-x-auto pb-4">
+          {visibleColumns.map((col) => (
+            <Column
+              key={col.status}
+              status={col.status}
+              title={col.title}
+              color={col.color}
+              tasks={getTasksForColumn(col.status)}
+              onTaskClick={onTaskClick}
+              onAddTask={() => onAddTask(col.status)}
+              showAddButton={col.showAdd}
+              isMobile={true}
+            />
+          ))}
+        </div>
+        {/* Desktop: grid layout */}
+        <div className="hidden lg:grid gap-4 pb-4" style={{
           gridTemplateColumns: `repeat(${visibleColumns.length}, minmax(280px, 1fr))`
         }}>
           {visibleColumns.map((col) => (


### PR DESCRIPTION
Ticket: 160060ee-2aa1-4baa-8936-fd58bf471fcf

## Problem
The board page rendered all columns stacked vertically (like a list) instead of side-by-side kanban columns, even at 1920x1080 viewport.

## Solution
Split the board layout into two separate containers:
- **Mobile** (<1024px): Horizontal scroll flex layout ()
- **Desktop** (≥1024px): Grid layout with equal columns ()

## Changes
- Mobile container uses  with  for horizontal scrolling
- Desktop container uses CSS Grid with 
- Each column maintains minimum 280px width as specified

## Acceptance Criteria
- [x] Board displays as horizontal kanban columns at desktop widths (>= 1024px)
- [x] Columns scroll horizontally on smaller screens
- [x] Each column is at least 280px wide