### PR TITLE
feat: add work loop status indicator to project header

### DIFF
--- a/app/projects/[slug]/layout.tsx
+++ b/app/projects/[slug]/layout.tsx
@@ -8,6 +8,7 @@ import type { Project } from "@/lib/types"
 import { MobileProjectSwitcher } from "@/components/layout/mobile-project-switcher"
 import { DesktopProjectSwitcher } from "@/components/layout/desktop-project-switcher"
 import { useMobileDetection } from "@/components/board/use-mobile-detection"
+import { WorkLoopHeaderStatus } from "@/components/work-loop/work-loop-header-status"
 
 type LayoutProps = {
   children: React.ReactNode
@@ -80,32 +81,32 @@ export default function ProjectLayout({ children, params }: LayoutProps) {
         <div className="container mx-auto px-4 lg:px-6 max-w-7xl">
           {/* Mobile: Ultra-compact header */}
           {isMobile ? (
-            <div className="py-2">
+            <div className="py-2 space-y-2">
               {/* Single row: Back + Project + Tabs */}
               <div className="flex items-center gap-2">
-                <Link 
+                <Link
                   href="/"
                   className="p-1.5 text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors flex-shrink-0"
                   style={{ minWidth: "40px", minHeight: "40px" }}
                 >
                   <ArrowLeft className="h-4 w-4" />
                 </Link>
-                
+
                 {/* Compact project switcher */}
                 <div className="flex-shrink-0">
-                  <MobileProjectSwitcher 
+                  <MobileProjectSwitcher
                     currentProject={project}
                     projects={projects}
                   />
                 </div>
-                
+
                 {/* Compact tab navigation - hide Settings on mobile */}
                 <nav className="flex gap-1 overflow-x-auto scrollbar-hide flex-1 min-w-0">
                   {TABS.filter(tab => tab.id !== 'settings').map((tab) => {
                     const Icon = tab.icon
                     const isActive = activeTab === tab.id
                     const href = `/projects/${slug}${tab.href}`
-                    
+
                     return (
                       <Link
                         key={tab.id}
@@ -124,21 +125,37 @@ export default function ProjectLayout({ children, params }: LayoutProps) {
                   })}
                 </nav>
               </div>
+
+              {/* Work loop status row (mobile only, if enabled) */}
+              {project.work_loop_enabled === 1 && (
+                <div className="flex justify-end">
+                  <WorkLoopHeaderStatus
+                    projectId={project.id}
+                    workLoopEnabled={true}
+                  />
+                </div>
+              )}
             </div>
           ) : (
             /* Desktop: Original layout */
             <>
-              {/* Top row: back + project name */}
-              <div className="py-4 flex items-center gap-4">
-                <Link 
-                  href="/"
-                  className="text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors"
-                >
-                  <ArrowLeft className="h-5 w-5" />
-                </Link>
-                <DesktopProjectSwitcher 
-                  currentProject={project}
-                  projects={projects}
+              {/* Top row: back + project name + work loop status */}
+              <div className="py-4 flex items-center justify-between gap-4">
+                <div className="flex items-center gap-4">
+                  <Link
+                    href="/"
+                    className="text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors"
+                  >
+                    <ArrowLeft className="h-5 w-5" />
+                  </Link>
+                  <DesktopProjectSwitcher
+                    currentProject={project}
+                    projects={projects}
+                  />
+                </div>
+                <WorkLoopHeaderStatus
+                  projectId={project.id}
+                  workLoopEnabled={project.work_loop_enabled === 1}
                 />
               </div>
               

--- a/components/work-loop/work-loop-header-status.tsx
+++ b/components/work-loop/work-loop-header-status.tsx
@@ -1,0 +1,115 @@
+"use client"
+
+import { useState } from "react"
+import { Button } from "@/components/ui/button"
+import { useWorkLoopState } from "@/lib/hooks/use-work-loop"
+import { Pause, Play, RotateCw } from "lucide-react"
+import type { WorkLoopStatus } from "@/lib/types/work-loop"
+
+interface WorkLoopHeaderStatusProps {
+  projectId: string
+  workLoopEnabled: boolean
+}
+
+export function WorkLoopHeaderStatus({ projectId, workLoopEnabled }: WorkLoopHeaderStatusProps) {
+  const { state, isLoading } = useWorkLoopState(projectId)
+  const [isUpdating, setIsUpdating] = useState(false)
+
+  // Don't show if work loop is not enabled for this project
+  if (!workLoopEnabled) {
+    return null
+  }
+
+  const handleToggleStatus = async () => {
+    if (!state || isUpdating) return
+
+    setIsUpdating(true)
+    try {
+      const newStatus: WorkLoopStatus = state.status === "running" ? "paused" : "running"
+      const response = await fetch("/api/work-loop/state", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          projectId,
+          status: newStatus,
+        }),
+      })
+
+      if (!response.ok) {
+        throw new Error("Failed to update status")
+      }
+    } catch (error) {
+      console.error("Failed to toggle status:", error)
+    } finally {
+      setIsUpdating(false)
+    }
+  }
+
+  // Status colors
+  const statusColors: Record<WorkLoopStatus, string> = {
+    running: "bg-green-500",
+    paused: "bg-yellow-500",
+    stopped: "bg-gray-400",
+    error: "bg-red-500",
+  }
+
+  const isRunning = state?.status === "running"
+  const isPaused = state?.status === "paused"
+
+  return (
+    <div className="flex items-center gap-3">
+      {/* Status indicator */}
+      <div className="flex items-center gap-2">
+        <span
+          className={`inline-block h-2 w-2 rounded-full ${
+            isLoading || !state ? "bg-gray-300 animate-pulse" : statusColors[state.status]
+          }`}
+        />
+        <span className="text-sm text-[var(--text-secondary)]">
+          {isLoading || !state ? (
+            "Loading..."
+          ) : (
+            <>
+              <span className="capitalize">{state.status}</span>
+              {state.active_agents > 0 && (
+                <span className="ml-1 text-[var(--text-muted)]">
+                  ({state.active_agents} agent{state.active_agents !== 1 ? "s" : ""})
+                </span>
+              )}
+            </>
+          )}
+        </span>
+      </div>
+
+      {/* Pause/Resume button */}
+      {!isLoading && state && (
+        <Button
+          onClick={handleToggleStatus}
+          disabled={isUpdating}
+          variant={isRunning ? "outline" : "default"}
+          size="sm"
+          className="h-7 gap-1.5 px-2.5 text-xs"
+        >
+          {isUpdating ? (
+            <RotateCw className="h-3 w-3 animate-spin" />
+          ) : isRunning ? (
+            <>
+              <Pause className="h-3 w-3" />
+              <span>Pause</span>
+            </>
+          ) : isPaused ? (
+            <>
+              <Play className="h-3 w-3" />
+              <span>Resume</span>
+            </>
+          ) : (
+            <>
+              <Play className="h-3 w-3" />
+              <span>Start</span>
+            </>
+          )}
+        </Button>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
Add a work loop status indicator to the project header bar for quick visibility and control.

## Changes
- New `WorkLoopHeaderStatus` component showing:
  - Current loop state (Running/Paused/Stopped/Error) with color-coded indicator
  - Active agent count (e.g., "3 agents")
  - Pause/Resume toggle button
- Integrated into project header for both desktop and mobile views
- Only visible when work loop is enabled for the project
- Status updates reactively via Convex subscription (no refresh needed)

## Desktop Layout


## Mobile Layout
Work loop status appears below the tabs on mobile to save horizontal space.

## Testing
- [x] Type check passes
- [x] Lint passes
- [ ] Visual verification in browser (requires manual testing)

Ticket: 3f988637-0471-4cfb-a86b-47da21ed8ebd