### PR TITLE
feat: restore reasonable stale agent thresholds after JSONL integration

### DIFF
--- a/worker/config.ts
+++ b/worker/config.ts
@@ -14,7 +14,7 @@ export interface WorkLoopConfig {
   maxAgentsPerProject: number
   /** Max concurrent agents globally — default 5 */
   maxAgentsGlobal: number
-  /** How long before in_progress is considered "stalled" — default 60 minutes */
+  /** How long before in_progress is considered "stalled" — default 15 minutes */
   staleTaskMinutes: number
   /** How long before in_review without PR is stalled — default 30 minutes */
   staleReviewMinutes: number
@@ -28,8 +28,8 @@ const DEFAULT_CONFIG: WorkLoopConfig = {
   cycleIntervalMs: 30000,
   maxAgentsPerProject: 2,
   maxAgentsGlobal: 5,
-  staleTaskMinutes: 5,
-  staleReviewMinutes: 5,
+  staleTaskMinutes: 15,
+  staleReviewMinutes: 30,
 }
 
 /**


### PR DESCRIPTION
## Summary

Restores reasonable stale agent reaper thresholds now that JSONL-based session file detection is in place.

## Changes

- Removed `WORK_LOOP_STALE_TASK_MINUTES` and `WORK_LOOP_STALE_REVIEW_MINUTES` overrides from `.env.local` (were temporarily set to 20min)
- Updated default thresholds in `worker/config.ts`:
  - `staleTaskMinutes`: 5 → 15 minutes
  - `staleReviewMinutes`: 5 → 30 minutes

## Why

The previous aggressive 5-minute defaults were causing active agents to be falsely killed. With the new JSONL file-based detection (file mtime + stopReason), we can safely use longer thresholds without missing actually-stuck agents.

## Acceptance Criteria

- [x] Stale env overrides removed from `.env.local`
- [x] Defaults in config.ts are reasonable (15min tasks, 30min reviews)
- [x] Active agents with recent file mtime won't be reaped
- [x] Finished agents (stopReason: stop) get reaped promptly
- [x] Actually-stuck agents (no file writes for 15+ min) get reaped

Ticket: 1d0e998f-ff73-47c4-90ce-9da8e4a25a7b