### PR TITLE
feat: group work loop activity by cycle for readability

### DIFF
--- a/app/work-loop/components/activity-log.tsx
+++ b/app/work-loop/components/activity-log.tsx
@@ -1,26 +1,128 @@
 "use client"
 
+import { useState, useMemo } from "react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table"
 import { useWorkLoopRuns } from "@/lib/hooks/use-work-loop"
 import { PhaseBadge } from "./status-badge"
 import Link from "next/link"
 import { formatDistanceToNow } from "@/lib/utils"
+import { ChevronRight, ChevronDown } from "lucide-react"
+import type { WorkLoopRun } from "@/lib/types/work-loop"
 
 interface ActivityLogProps {
   projectId: string
   projectSlug: string
 }
 
+interface CycleGroup {
+  cycle: number
+  runs: WorkLoopRun[]
+  firstRunAt: number
+  lastRunAt: number
+  totalDurationMs: number
+  meaningfulActionCount: number
+  hasSpawns: boolean
+  hasClaims: boolean
+  hasErrors: boolean
+}
+
+// Actions that don't count as "meaningful" for action count
+const NOISE_ACTIONS = new Set([
+  "phase_start",
+  "phase_complete",
+  "phase_failed",
+  "tasks_found",
+  "ready_tasks_found",
+  "no_claimable_tasks",
+  "capacity_check",
+])
+
+// Actions that indicate something important happened
+const SPAWN_ACTIONS = new Set(["agent_spawned", "reviewer_spawned", "spawn_failed"])
+const CLAIM_ACTIONS = new Set(["task_claimed", "dependency_blocked"])
+const ERROR_ACTIONS = new Set(["spawn_failed", "phase_failed", "error"])
+
 export function ActivityLog({ projectId, projectSlug }: ActivityLogProps) {
-  const { runs, isLoading } = useWorkLoopRuns(projectId, 50)
+  const { runs, isLoading } = useWorkLoopRuns(projectId, 100)
+
+  // Group runs by cycle and compute metadata
+  const cycles = useMemo((): CycleGroup[] => {
+    if (!runs || runs.length === 0) return []
+
+    const groups = new Map<number, WorkLoopRun[]>()
+
+    // Group runs by cycle
+    for (const run of runs) {
+      const existing = groups.get(run.cycle) ?? []
+      existing.push(run)
+      groups.set(run.cycle, existing)
+    }
+
+    // Convert to cycle groups with metadata
+    const cycleGroups: CycleGroup[] = []
+    for (const [cycle, cycleRuns] of groups) {
+      // Sort runs by created_at
+      cycleRuns.sort((a, b) => b.created_at - a.created_at)
+
+      const firstRun = cycleRuns[cycleRuns.length - 1]
+      const lastRun = cycleRuns[0]
+
+      // Count meaningful actions (excluding noise)
+      const meaningfulActionCount = cycleRuns.filter(
+        (r) => !NOISE_ACTIONS.has(r.action)
+      ).length
+
+      // Check for important actions
+      const hasSpawns = cycleRuns.some((r) => SPAWN_ACTIONS.has(r.action))
+      const hasClaims = cycleRuns.some((r) => CLAIM_ACTIONS.has(r.action))
+      const hasErrors = cycleRuns.some((r) => ERROR_ACTIONS.has(r.action) || r.phase === "error")
+
+      // Calculate total duration from individual action durations
+      const totalDurationMs = cycleRuns.reduce((sum, r) => sum + (r.duration_ms ?? 0), 0)
+
+      cycleGroups.push({
+        cycle,
+        runs: cycleRuns,
+        firstRunAt: firstRun?.created_at ?? 0,
+        lastRunAt: lastRun?.created_at ?? 0,
+        totalDurationMs,
+        meaningfulActionCount,
+        hasSpawns,
+        hasClaims,
+        hasErrors,
+      })
+    }
+
+    // Sort by cycle number descending (newest first)
+    return cycleGroups.sort((a, b) => b.cycle - a.cycle)
+  }, [runs])
+
+  // Compute which cycles should be expanded by default (those with activity)
+  const defaultExpandedCycles = useMemo(() => {
+    const toExpand = new Set<number>()
+    for (const cycle of cycles) {
+      // Expand if has spawns, claims, errors, or meaningful actions
+      if (cycle.hasSpawns || cycle.hasClaims || cycle.hasErrors || cycle.meaningfulActionCount > 0) {
+        toExpand.add(cycle.cycle)
+      }
+    }
+    return toExpand
+  }, [cycles])
+
+  // Use state for expanded cycles, initialized from defaults
+  const [expandedCycles, setExpandedCycles] = useState<Set<number>>(defaultExpandedCycles)
+
+  const toggleCycle = (cycle: number) => {
+    setExpandedCycles((prev) => {
+      const next = new Set(prev)
+      if (next.has(cycle)) {
+        next.delete(cycle)
+      } else {
+        next.add(cycle)
+      }
+      return next
+    })
+  }
 
   if (isLoading) {
     return (
@@ -35,11 +137,7 @@ export function ActivityLog({ projectId, projectSlug }: ActivityLogProps) {
     )
   }
 
-  // Filter out noisy phase lifecycle entries that don't carry useful info
-  const NOISE_ACTIONS = new Set(["phase_start", "phase_complete", "phase_failed"])
-  const filteredRuns = runs?.filter((r) => !NOISE_ACTIONS.has(r.action)) ?? null
-
-  if (!filteredRuns || filteredRuns.length === 0) {
+  if (!cycles || cycles.length === 0) {
     return (
       <Card>
         <CardHeader>
@@ -60,57 +158,144 @@ export function ActivityLog({ projectId, projectSlug }: ActivityLogProps) {
         <CardTitle className="text-lg">Recent Activity</CardTitle>
       </CardHeader>
       <CardContent>
-        <div className="rounded-md border">
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>Time</TableHead>
-                <TableHead>Phase</TableHead>
-                <TableHead>Action</TableHead>
-                <TableHead>Task</TableHead>
-                <TableHead className="text-right">Duration</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {filteredRuns.map((run) => (
-                <TableRow key={run.id}>
-                  <TableCell className="text-muted-foreground whitespace-nowrap">
-                    {formatTimeAgo(run.created_at)}
-                  </TableCell>
-                  <TableCell>
-                    <PhaseBadge phase={run.phase} />
-                  </TableCell>
-                  <TableCell className="font-medium">
-                    {formatAction(run.action, run.details)}
-                  </TableCell>
-                  <TableCell>
-                    {run.task_id ? (
-                      <Link
-                        href={`/projects/${projectSlug}/board?task=${run.task_id}`}
-                        className="text-sm hover:underline text-primary"
-                      >
-                        View task
-                      </Link>
-                    ) : (
-                      <span className="text-sm text-muted-foreground">—</span>
-                    )}
-                  </TableCell>
-                  <TableCell className="text-right">
-                    {run.duration_ms ? (
-                      <span className="text-sm text-muted-foreground">
-                        {formatDuration(run.duration_ms)}
-                      </span>
-                    ) : (
-                      <span className="text-sm text-muted-foreground">—</span>
-                    )}
-                  </TableCell>
-                </TableRow>
-              ))}
-            </TableBody>
-          </Table>
+        <div className="space-y-2">
+          {cycles.map((cycle) => (
+            <CycleRow
+              key={cycle.cycle}
+              cycle={cycle}
+              projectSlug={projectSlug}
+              isExpanded={expandedCycles.has(cycle.cycle)}
+              onToggle={() => toggleCycle(cycle.cycle)}
+            />
+          ))}
         </div>
       </CardContent>
     </Card>
+  )
+}
+
+interface CycleRowProps {
+  cycle: CycleGroup
+  projectSlug: string
+  isExpanded: boolean
+  onToggle: () => void
+}
+
+function CycleRow({ cycle, projectSlug, isExpanded, onToggle }: CycleRowProps) {
+  return (
+    <div className="rounded-md border">
+      {/* Cycle Summary Row */}
+      <button
+        onClick={onToggle}
+        className="w-full flex items-center gap-3 px-4 py-3 hover:bg-muted/50 transition-colors text-left"
+      >
+        {isExpanded ? (
+          <ChevronDown className="h-4 w-4 text-muted-foreground flex-shrink-0" />
+        ) : (
+          <ChevronRight className="h-4 w-4 text-muted-foreground flex-shrink-0" />
+        )}
+
+        <div className="flex-1 flex items-center gap-4 min-w-0">
+          <span className="font-semibold whitespace-nowrap">
+            Cycle {cycle.cycle}
+          </span>
+
+          <span className="text-sm text-muted-foreground whitespace-nowrap">
+            {formatTimeAgo(cycle.firstRunAt)}
+          </span>
+
+          {/* Action count badge */}
+          <span
+            className={`text-xs px-2 py-0.5 rounded-full whitespace-nowrap ${
+              cycle.meaningfulActionCount > 0
+                ? "bg-primary/10 text-primary"
+                : "bg-muted text-muted-foreground"
+            }`}
+          >
+            {cycle.meaningfulActionCount} action
+            {cycle.meaningfulActionCount !== 1 ? "s" : ""}
+          </span>
+
+          {/* Duration */}
+          <span className="text-sm text-muted-foreground whitespace-nowrap">
+            {formatDuration(cycle.totalDurationMs)}
+          </span>
+
+          {/* Indicators for important events */}
+          <div className="flex items-center gap-2 ml-auto">
+            {cycle.hasErrors && (
+              <span className="text-xs px-2 py-0.5 rounded-full bg-red-100 text-red-700">
+                error
+              </span>
+            )}
+            {cycle.hasSpawns && (
+              <span className="text-xs px-2 py-0.5 rounded-full bg-green-100 text-green-700">
+                spawn
+              </span>
+            )}
+            {cycle.hasClaims && (
+              <span className="text-xs px-2 py-0.5 rounded-full bg-blue-100 text-blue-700">
+                claim
+              </span>
+            )}
+          </div>
+        </div>
+      </button>
+
+      {/* Expanded Detail Rows */}
+      {isExpanded && (
+        <div className="border-t">
+          {cycle.runs.map((run) => (
+            <RunRow key={run.id} run={run} projectSlug={projectSlug} />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+interface RunRowProps {
+  run: WorkLoopRun
+  projectSlug: string
+}
+
+function RunRow({ run, projectSlug }: RunRowProps) {
+  return (
+    <div className="flex items-center gap-3 px-4 py-2 hover:bg-muted/30 text-sm border-b last:border-b-0">
+      {/* Indent to align with cycle chevron */}
+      <div className="w-4 flex-shrink-0" />
+
+      {/* Phase badge */}
+      <div className="w-20 flex-shrink-0">
+        <PhaseBadge phase={run.phase} />
+      </div>
+
+      {/* Action */}
+      <div className="flex-1 min-w-0 truncate">
+        <span className="text-muted-foreground">
+          {formatAction(run.action, run.details)}
+        </span>
+      </div>
+
+      {/* Task link */}
+      <div className="w-20 flex-shrink-0 text-right">
+        {run.task_id ? (
+          <Link
+            href={`/projects/${projectSlug}/board?task=${run.task_id}`}
+            className="text-xs hover:underline text-primary"
+          >
+            View task
+          </Link>
+        ) : (
+          <span className="text-xs text-muted-foreground">—</span>
+        )}
+      </div>
+
+      {/* Duration */}
+      <div className="w-16 flex-shrink-0 text-right text-muted-foreground">
+        {run.duration_ms ? formatDuration(run.duration_ms) : "—"}
+      </div>
+    </div>
   )
 }
 
@@ -160,6 +345,7 @@ function formatTimeAgo(timestamp: number): string {
 }
 
 function formatDuration(ms: number): string {
+  if (ms === 0) return "—"
   const seconds = Math.round(ms / 1000)
   if (seconds < 60) return `${seconds}s`
   const minutes = Math.floor(seconds / 60)


### PR DESCRIPTION
Ticket: 4290fdbb-0995-45d9-bf01-28f245170241

## Summary
Groups the work loop Recent Activity table by cycle number with collapsible rows.

## Changes
- Groups activity log entries by cycle number
- Adds summary row showing cycle #, time ago, action count, duration, and event badges
- Cycles are collapsible/expandable with chevron indicator
- Auto-expands cycles with spawns, claims, or errors
- Shows phase badges, action details, and task links when expanded
- Filters out noisy actions (tasks_found, phase_start, etc.) from action count

## Before
Flat chronological list of every action - hard to parse with 5-8 actions per 30s cycle.

## After
Grouped by cycle with expandable sections. Important activity (spawns, claims, errors) is visible at a glance.

## Testing
- [x] Type check passes
- [x] Lint passes
- [x] Build succeeds