### PR TITLE
fix: task detail modal description fills full height

### DIFF
--- a/components/board/task-modal.tsx
+++ b/components/board/task-modal.tsx
@@ -403,16 +403,16 @@ export function TaskModal({ task, open, onOpenChange, onDelete }: TaskModalProps
               </div>
 
               <div className="flex-1 overflow-y-auto p-4">
-                <div className="flex gap-8">
+                <div className="flex gap-8 h-full">
                   {/* Main content */}
-                  <div className="flex-1 min-h-0">
+                  <div className="flex-1 min-h-0 flex flex-col">
                     {/* Description Tab */}
-                    <TabsContent value="description" className="mt-0">
+                    <TabsContent value="description" className="mt-0 flex-1 flex flex-col">
                       <textarea
                         value={description}
                         onChange={(e) => setDescription(e.target.value)}
                         placeholder="Add a description..."
-                        className="w-full min-h-[400px] bg-[var(--bg-primary)] border border-[var(--border)] rounded-lg px-3 py-2 text-sm text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus:outline-none focus:border-[var(--accent-blue)] resize-y"
+                        className="w-full flex-1 min-h-[200px] bg-[var(--bg-primary)] border border-[var(--border)] rounded-lg px-3 py-2 text-sm text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus:outline-none focus:border-[var(--accent-blue)] resize-y"
                       />
                     </TabsContent>
 


### PR DESCRIPTION
## Summary
Makes the description textarea in the task detail modal fill the full available vertical space.

## Changes
- Added \"h-full\" to the flex container for the main content area
- Made TabsContent use \"flex-1 flex flex-col\" to fill available space  
- Changed textarea from fixed \"min-h-[400px]\" to \"flex-1 min-h-[200px]\"
- Textarea now dynamically expands to fill modal height while maintaining minimum usable height

## Testing
- [x] Typecheck passes
- [x] Lint passes
- [ ] Visual verification in browser

Ticket: e26c61ab-e5ac-462b-9c9a-f91586b147b4