### PR TITLE
feat: PM triage phase for sparse issues with clarifying questions

### DIFF
--- a/worker/phases/work.ts
+++ b/worker/phases/work.ts
@@ -157,6 +157,49 @@ async function loadSoulTemplate(role: string): Promise<string> {
 }
 
 // ============================================
+// Image URL Extraction
+// ============================================
+
+/**
+ * Extract image URLs from task description
+ * Looks for markdown image syntax: ![alt](url) or ![](url)
+ * Also detects data URLs and HTTP/HTTPS image URLs
+ */
+function extractImageUrls(description: string | null): string[] {
+  if (!description) return []
+
+  const urls: string[] = []
+
+  // Markdown image syntax: ![alt](url)
+  const markdownRegex = /!\[([^\]]*)\]\(([^)]+)\)/g
+  let match
+  while ((match = markdownRegex.exec(description)) !== null) {
+    const url = match[2]
+    if (url.startsWith('http') || url.startsWith('data:')) {
+      urls.push(url)
+    }
+  }
+
+  // Plain image URLs (http/https)
+  const urlRegex = /(https?:\/\/[^\s\"<>]+\.(?:png|jpg|jpeg|gif|webp|svg))/gi
+  while ((match = urlRegex.exec(description)) !== null) {
+    if (!urls.includes(match[1])) {
+      urls.push(match[1])
+    }
+  }
+
+  // Data URLs
+  const dataUrlRegex = /(data:image\/[^;]+;base64,[a-zA-Z0-9+/=]+)/g
+  while ((match = dataUrlRegex.exec(description)) !== null) {
+    if (!urls.includes(match[1])) {
+      urls.push(match[1])
+    }
+  }
+
+  return urls
+}
+
+// ============================================
 // Main Work Phase
 // ============================================
 
@@ -289,6 +332,9 @@ export async function runWork(ctx: WorkContext): Promise<WorkPhaseResult> {
     const repoDir = project?.local_path ?? "/home/dan/src/trap"
     const worktreeDir = `/home/dan/src/trap-worktrees/fix/${task.id.slice(0, 8)}`
 
+    // Extract image URLs for PM triage tasks
+    const imageUrls = role === "pm" ? extractImageUrls(task.description) : undefined
+
     const prompt = buildPrompt({
       role,
       taskId: task.id,
@@ -298,6 +344,7 @@ export async function runWork(ctx: WorkContext): Promise<WorkPhaseResult> {
       projectId,
       repoDir,
       worktreeDir,
+      imageUrls,
     })
 
     // --- 5. Spawn agent via gateway RPC ---


### PR DESCRIPTION
Ticket: 088322ef-6a97-4493-b3a1-b42a25dd8f3f

## Summary

Adds PM triage capability to the work loop. When a task has 

## Changes

- **work.ts**: Extract image URLs from task descriptions for PM analysis
- **prompts.ts**: Add PM triage instructions with two paths:
  1. Flesh out clear issues → update description, change role to dev
  2. Create blocking signals for unclear issues → ask clarifying questions
- **pm.md role template**: Add triage mode instructions and decision criteria

## How it works

1. PM agent picks up role=pm tasks from ready column
2. Analyzes title, description, and any attached images
3. Decision:
   - **Clear enough**: Writes full description with Summary, Implementation, Files, Acceptance Criteria sections; changes role to dev
   - **Needs clarification**: Creates blocking signal (kind=question) with specific questions; marks done (signal remains as blocker)

## Acceptance Criteria

- [x] PM agent automatically picks up role=pm tasks from ready
- [x] Well-defined issues get fleshed out and re-roled to dev
- [x] Unclear issues generate specific clarifying questions via signals
- [x] PM uses sonnet model (already configured)