### PR TITLE
feat: route PM clarifying questions to user via Ada in Discord

### DIFF
--- a/app/work-loop/components/status-badge.tsx
+++ b/app/work-loop/components/status-badge.tsx
@@ -36,6 +36,7 @@ interface PhaseBadgeProps {
 export function PhaseBadge({ phase }: PhaseBadgeProps) {
   const colors: Record<WorkLoopPhase, string> = {
     cleanup: "bg-orange-500/20 text-orange-600 border-orange-500/30",
+    notify: "bg-yellow-500/20 text-yellow-600 border-yellow-500/30",
     review: "bg-blue-500/20 text-blue-600 border-blue-500/30",
     work: "bg-green-500/20 text-green-600 border-green-500/30",
     analyze: "bg-purple-500/20 text-purple-600 border-purple-500/30",

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -214,6 +214,7 @@ export default defineSchema({
     blocking: v.boolean(),
     responded_at: v.optional(v.number()),
     response: v.optional(v.string()),
+    delivered_at: v.optional(v.number()), // When notification was sent to user
     created_at: v.number(),
   })
     .index("by_uuid", ["id"])
@@ -221,6 +222,7 @@ export default defineSchema({
     .index("by_kind", ["kind"])
     .index("by_blocking", ["blocking"])
     .index("by_responded", ["responded_at"])
+    .index("by_delivered", ["delivered_at"])
     .index("by_created", ["created_at"]),
 
   // Task Dependencies
@@ -242,6 +244,7 @@ export default defineSchema({
     cycle: v.number(),
     phase: v.union(
       v.literal("cleanup"),
+      v.literal("notify"),
       v.literal("review"),
       v.literal("work"),
       v.literal("analyze"),

--- a/convex/workLoop.ts
+++ b/convex/workLoop.ts
@@ -6,7 +6,7 @@ import { generateId } from './_helpers'
 // Types
 // ============================================
 
-type WorkLoopPhase = "cleanup" | "review" | "work" | "analyze" | "idle" | "error"
+type WorkLoopPhase = "cleanup" | "notify" | "review" | "work" | "analyze" | "idle" | "error"
 type WorkLoopStatus = "running" | "paused" | "stopped" | "error"
 
 // Convex document types
@@ -282,6 +282,7 @@ export const logRun = mutation({
     cycle: v.number(),
     phase: v.union(
       v.literal('cleanup'),
+      v.literal('notify'),
       v.literal('review'),
       v.literal('work'),
       v.literal('analyze'),

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -172,6 +172,7 @@ export interface Signal {
   blocking: number // SQLite boolean (1/0)
   responded_at: number | null
   response: string | null
+  delivered_at: number | null // When notification was sent to user
   created_at: number
 }
 

--- a/lib/types/work-loop.ts
+++ b/lib/types/work-loop.ts
@@ -1,6 +1,6 @@
 // Work Loop types for Convex integration
 
-export type WorkLoopPhase = "cleanup" | "review" | "work" | "analyze" | "idle" | "error"
+export type WorkLoopPhase = "cleanup" | "notify" | "review" | "work" | "analyze" | "idle" | "error"
 export type WorkLoopStatus = "running" | "paused" | "stopped" | "error"
 
 export interface WorkLoopState {

--- a/worker/logger.ts
+++ b/worker/logger.ts
@@ -12,7 +12,7 @@ import { api } from "../convex/_generated/api"
 // Types
 // ============================================
 
-type WorkLoopPhase = "cleanup" | "review" | "work" | "analyze" | "idle" | "error"
+type WorkLoopPhase = "cleanup" | "notify" | "review" | "work" | "analyze" | "idle" | "error"
 
 export interface LogRunParams {
   projectId: string
@@ -32,6 +32,7 @@ interface LogCycleCompleteParams {
   totalActions: number
   phases: {
     cleanup: boolean
+    notify: boolean
     review: boolean
     work: boolean
     analyze: boolean

--- a/worker/phases/notify.ts
+++ b/worker/phases/notify.ts
@@ -1,0 +1,209 @@
+/**
+ * Notification Phase
+ *
+ * Detects undelivered blocking PM signals and routes them to the user
+ * via the OpenClaw gateway (Discord). Marks signals as delivered after
+ * successful notification.
+ */
+
+import { ConvexHttpClient } from "convex/browser"
+import { api } from "../../convex/_generated/api"
+import { getGatewayClient } from "../gateway-client"
+import type { Signal, WorkLoopPhase } from "../../lib/types"
+
+// ============================================
+// Types
+// ============================================
+
+interface NotifyContext {
+  convex: ConvexHttpClient
+  cycle: number
+  projectId: string
+  log: (params: {
+    projectId: string
+    cycle: number
+    phase: WorkLoopPhase
+    action: string
+    taskId?: string
+    sessionKey?: string
+    details?: Record<string, unknown>
+    durationMs?: number
+  }) => Promise<void>
+}
+
+interface NotifyResult {
+  notifiedCount: number
+  errors: string[]
+}
+
+// ============================================
+// Constants
+// ============================================
+
+const DISCORD_SESSION_KEY = "agent:main:trap" // Main session for Discord notifications
+
+// ============================================
+// Notification Phase
+// ============================================
+
+/**
+ * Run the notification phase.
+ *
+ * Checks for undelivered blocking signals and sends them to the user
+ * via the OpenClaw gateway. Marks signals as delivered after sending.
+ */
+export async function runNotify(ctx: NotifyContext): Promise<NotifyResult> {
+  const startTime = Date.now()
+  const errors: string[] = []
+  let notifiedCount = 0
+
+  // Get undelivered blocking signals
+  const signals = await ctx.convex.query(api.signals.getUndeliveredBlocking, { limit: 20 })
+
+  if (signals.length === 0) {
+    return { notifiedCount: 0, errors: [] }
+  }
+
+  console.log(`[Notify] Found ${signals.length} undelivered blocking signal(s)`)
+
+  // Group signals by task for batched notifications
+  const signalsByTask = groupSignalsByTask(signals)
+
+  // Process each task's signals
+  for (const [taskId, taskSignals] of signalsByTask) {
+    try {
+      // Get task details
+      const taskResult = await ctx.convex.query(api.tasks.getById, { id: taskId })
+      if (!taskResult || !taskResult.task) {
+        errors.push(`Task not found: ${taskId}`)
+        continue
+      }
+      const task = taskResult.task
+
+      // Format and send notification
+      const message = formatNotificationMessage(task.title, task.id, taskSignals)
+      await sendDiscordNotification(message)
+
+      // Mark all signals for this task as delivered
+      for (const signal of taskSignals) {
+        try {
+          await ctx.convex.mutation(api.signals.markDelivered, { id: signal.id })
+        } catch (err) {
+          const errorMsg = err instanceof Error ? err.message : String(err)
+          errors.push(`Failed to mark signal ${signal.id} as delivered: ${errorMsg}`)
+        }
+      }
+
+      notifiedCount += taskSignals.length
+
+      // Log the notification
+      await ctx.log({
+        projectId: ctx.projectId,
+        cycle: ctx.cycle,
+        phase: "notify",
+        action: "signal_notified",
+        taskId: taskId,
+        details: {
+          signalCount: taskSignals.length,
+          signalIds: taskSignals.map((s) => s.id),
+        },
+      })
+    } catch (err) {
+      const errorMsg = err instanceof Error ? err.message : String(err)
+      errors.push(`Failed to process task ${taskId}: ${errorMsg}`)
+
+      await ctx.log({
+        projectId: ctx.projectId,
+        cycle: ctx.cycle,
+        phase: "notify",
+        action: "notify_failed",
+        taskId: taskId,
+        details: { error: errorMsg },
+      })
+    }
+  }
+
+  const durationMs = Date.now() - startTime
+  console.log(`[Notify] Completed in ${durationMs}ms, notified ${notifiedCount} signal(s)`)
+
+  return { notifiedCount, errors }
+}
+
+// ============================================
+// Helpers
+// ============================================
+
+/**
+ * Group signals by their task ID.
+ */
+function groupSignalsByTask(signals: Signal[]): Map<string, Signal[]> {
+  const grouped = new Map<string, Signal[]>()
+  for (const signal of signals) {
+    const existing = grouped.get(signal.task_id) ?? []
+    existing.push(signal)
+    grouped.set(signal.task_id, existing)
+  }
+  return grouped
+}
+
+/**
+ * Format a notification message for Discord.
+ */
+function formatNotificationMessage(taskTitle: string, taskId: string, signals: Signal[]): string {
+  const shortId = taskId.slice(0, 8)
+
+  // Extract questions from signal messages
+  const questions: string[] = []
+  for (const signal of signals) {
+    // Split message by newlines and filter out empty lines
+    const lines = signal.message
+      .split("\n")
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0)
+
+    // Add each non-empty line as a question
+    for (const line of lines) {
+      questions.push(line)
+    }
+  }
+
+  // Build the message
+  let message = `📋 **Issue \`${shortId}\`: ${taskTitle}**\n\n`
+  message += "The PM agent has some questions before this can be worked on:\n\n"
+
+  // Number the questions
+  questions.forEach((q, idx) => {
+    message += `${idx + 1}. ${q}\n`
+  })
+
+  message += "\nReply here or in Trap chat to answer."
+
+  return message
+}
+
+/**
+ * Send a notification message to Discord via the OpenClaw gateway.
+ */
+async function sendDiscordNotification(message: string): Promise<void> {
+  const gateway = getGatewayClient()
+
+  try {
+    // Connect to gateway if not already connected
+    await gateway.connect()
+
+    // Send message via sessions.send RPC
+    await gateway.request(
+      "sessions.send",
+      {
+        sessionKey: DISCORD_SESSION_KEY,
+        message: message,
+      },
+      30000 // 30 second timeout for sending
+    )
+
+    console.log(`[Notify] Sent notification to Discord session ${DISCORD_SESSION_KEY}`)
+  } catch (err) {
+    const errorMsg = err instanceof Error ? err.message : String(err)
+    throw new Error(`Failed to send Discord notification: ${errorMsg}`)
+  }
+}


### PR DESCRIPTION
Ticket: 325cce44-fbd6-4327-baba-1e84f8d57e29

## Summary
Wires the notification system so that when a PM agent creates a blocking signal (kind=question), the questions are delivered to the user via Discord.

## Changes
- Added \"delivered_at\" field to signals schema for tracking notification delivery
- Added \"getUndeliveredBlocking\" query to fetch pending PM signals  
- Added \"markDelivered\" mutation to track when signals are sent
- Created new \"notify\" work loop phase that:
  - Detects undelivered blocking signals
  - Groups signals by task for batched notifications
  - Formats messages with task title, short ID, and questions
  - Sends notifications to Discord via OpenClaw gateway (sessions.send RPC)
  - Marks signals as delivered after successful send
- Integrated notify phase into work loop (runs after cleanup, before review)
- Updated WorkLoopPhase type across codebase to include \"notify\"

## Testing
- Type check passes
- Lint passes (no new errors)

## Acceptance Criteria
- [x] Blocking PM signals automatically appear in Discord within one work loop cycle
- [x] Message includes task title, ID, and formatted questions
- [x] Signals are not re-sent on subsequent cycles (delivered_at tracking)
- [x] User can see which task the questions are about