### PR TITLE
feat: repurpose Agents page to show work-loop agent analytics

### DIFF
--- a/lib/hooks/use-work-loop.ts
+++ b/lib/hooks/use-work-loop.ts
@@ -108,3 +108,28 @@ export function useActiveAgentTasks(
     error: null,
   }
 }
+
+/**
+ * Reactive Convex subscription for agent activity history.
+ *
+ * Returns all tasks that have been worked on by agents (have agent_started_at),
+ * sorted by most recently started first. Used by the Agents page.
+ */
+export function useAgentHistory(
+  projectId: string | null
+): {
+  tasks: Task[] | null
+  isLoading: boolean
+  error: Error | null
+} {
+  const result = useQuery(
+    api.tasks.getAgentHistory,
+    projectId ? { projectId } : "skip"
+  )
+
+  return {
+    tasks: result ?? null,
+    isLoading: result === undefined,
+    error: null,
+  }
+}


### PR DESCRIPTION
## Summary

The Agents page was showing 0 agents because it was designed for persistent named agents via OpenClaw RPC. The current architecture uses ephemeral role-based agents spawned by the work loop.

## Changes

- Added `getAgentHistory` Convex query to fetch tasks with agent activity
- Added `useAgentHistory` hook for reactive agent history data  
- Rewrote Agents page to show agent analytics grouped by role:
  - Total tasks, active agents, roles, and tokens
  - Per-role cards with token counts, avg duration, and models used
  - Color-coded roles matching Work Loop styling
  - Link to Work Loop for active agent details

## Screenshots

Visit `/agents` to see the new agent analytics dashboard.

## Ticket

Ticket: 84c99cca-08d0-4563-845c-f3d20d1ed64d

## Acceptance Criteria

- [x] Shows useful agent data (not 0 agents)
- [x] Shows work loop agent sessions grouped by role