### PR TITLE
fix: correct max_agents display in work loop sidebar

### DIFF
--- a/worker/loop.ts
+++ b/worker/loop.ts
@@ -226,7 +226,7 @@ async function runProjectCycle(
     current_phase: "cleanup",
     current_cycle: cycle,
     active_agents: agentManager.activeCount(project.id),
-    max_agents: project.work_loop_max_agents ?? 2,
+    max_agents: project.work_loop_max_agents ?? config.maxAgentsPerProject,
     last_cycle_at: cycleStart,
   })
 
@@ -259,7 +259,7 @@ async function runProjectCycle(
     current_phase: "review",
     current_cycle: cycle,
     active_agents: agentManager.activeCount(project.id),
-    max_agents: project.work_loop_max_agents ?? 2,
+    max_agents: project.work_loop_max_agents ?? config.maxAgentsPerProject,
   })
 
   // Phase 2: Review
@@ -287,7 +287,7 @@ async function runProjectCycle(
     current_phase: "work",
     current_cycle: cycle,
     active_agents: agentManager.activeCount(project.id),
-    max_agents: project.work_loop_max_agents ?? 2,
+    max_agents: project.work_loop_max_agents ?? config.maxAgentsPerProject,
   })
 
   // Phase 3: Work
@@ -320,7 +320,7 @@ async function runProjectCycle(
     current_phase: "analyze",
     current_cycle: cycle,
     active_agents: agentManager.activeCount(project.id),
-    max_agents: project.work_loop_max_agents ?? 2,
+    max_agents: project.work_loop_max_agents ?? config.maxAgentsPerProject,
   })
 
   // Phase 4: Analyze
@@ -370,7 +370,7 @@ async function runProjectCycle(
     current_phase: "idle",
     current_cycle: cycle,
     active_agents: agentManager.activeCount(project.id),
-    max_agents: project.work_loop_max_agents ?? 2,
+    max_agents: project.work_loop_max_agents ?? config.maxAgentsPerProject,
     last_cycle_at: Date.now(),
   })
 }
@@ -500,7 +500,7 @@ async function runLoop(): Promise<void> {
         current_phase: currentPhase,
         current_cycle: cycle,
         active_agents: agentManager.activeCount(project.id),
-        max_agents: project.work_loop_max_agents ?? 2,
+        max_agents: project.work_loop_max_agents ?? config.maxAgentsPerProject,
         last_cycle_at: Date.now(),
       })
     }


### PR DESCRIPTION
## Bug
The right sidebar on /work-loop shows Active Agents as 3/2. The denominator was hardcoded to 2 instead of reading from the WORK_LOOP_MAX_AGENTS_PER_PROJECT environment variable.

## Fix
Changed all instances of `project.work_loop_max_agents ?? 2` to `project.work_loop_max_agents ?? config.maxAgentsPerProject` in worker/loop.ts.

Now the display will correctly show the configured limit (e.g., 3/3 or 3/5) instead of always defaulting to 2.

## Changes
- worker/loop.ts: Use config.maxAgentsPerProject as fallback instead of hardcoded 2

Ticket: 0d56fddf-4f52-48f1-8312-c7dd2330ec90