### PR TITLE
fix: analyze phase to include tasks without prompt_version_id

### DIFF
--- a/worker/phases/analyze.ts
+++ b/worker/phases/analyze.ts
@@ -142,13 +142,8 @@ async function processTask(ctx: AnalyzeContext, task: Task): Promise<TaskProcess
     }
   }
 
-  const promptVersionId = taskDetails.task.prompt_version_id
-  if (!promptVersionId) {
-    return {
-      spawned: false,
-      details: { reason: "no_prompt_version_id", taskId: task.id },
-    }
-  }
+  // Use prompt_version_id if available, otherwise "legacy" for older tasks
+  const promptVersionId = taskDetails.task.prompt_version_id ?? "legacy"
 
   // Build analyzer prompt
   const prompt = buildAnalyzerPrompt({


### PR DESCRIPTION
## Problem
The /prompts/metrics page showed "No metrics data yet" despite 197+ completed tasks. The analyze phase was not generating any taskAnalyses records.

## Root Cause
The \"getUnanalyzed\" query in convex/tasks.ts was filtering for tasks with \"prompt_version_id\" set. However, most completed tasks were created before prompt tracking was implemented, so they had null prompt_version_id and were excluded from analysis.

Additionally, only 25% of done tasks were being sampled, further limiting metrics population.

## Changes
- **convex/tasks.ts**: 
  - Removed the \"prompt_version_id\" filter from getUnanalyzed query
  - Now includes all done/ready/backlog tasks (not just those with tracking enabled)
  - Removed 25% sampling for done tasks to populate metrics faster
  
- **worker/phases/analyze.ts**:
  - Removed early return when \"prompt_version_id\" is missing
  - Uses \"legacy\" placeholder for tasks without prompt_version_id
  - Allows analysis of older tasks pre-dating prompt tracking

## Acceptance Criteria
- [x] Analyze phase produces taskAnalyses records for completed tasks
- [x] Metrics page will display aggregated data as analyses are created

Ticket: 23c8f592-d070-4544-94ec-3ffa8e95fd98