### PR TITLE
fix: prevent chat sidebar layout shift with skeleton states

### DIFF
--- a/app/projects/[slug]/chat/page.tsx
+++ b/app/projects/[slug]/chat/page.tsx
@@ -471,15 +471,13 @@ export default function ChatPage({ params }: PageProps) {
       <ConvexChatSync chatId={activeChat?.id ?? null} projectId={projectId} />
 
       <div className="flex h-[calc(100vh-140px)] bg-[var(--bg-primary)] rounded-lg border border-[var(--border)] overflow-hidden min-w-0 max-w-full">
-        {projectId && (
-          <ChatSidebar
-            projectId={projectId}
-            projectSlug={slug}
-            isOpen={isMobile ? sidebarOpen : true}
-            onClose={() => setSidebarOpen(false)}
-            isMobile={isMobile}
-          />
-        )}
+        <ChatSidebar
+          projectId={projectId}
+          projectSlug={slug}
+          isOpen={isMobile ? sidebarOpen : true}
+          onClose={() => setSidebarOpen(false)}
+          isMobile={isMobile}
+        />
 
         <div className="flex-1 flex flex-col min-w-0 max-w-full overflow-hidden">
           {activeChat ? (


### PR DESCRIPTION
## Summary
Fixes the chat page sidebar layout shift that occurred when the sidebar would pop in after data loaded.

## Changes
- Always render ChatSidebar component (removed conditional on projectId)
- Make projectId prop nullable in ChatSidebar interface
- Add skeleton loading states for:
  - Chat list section
  - Work Queue sections (In Progress, In Review)
- Disable New Chat/New Issue buttons when projectId is null
- Guard NewIssueDialog behind projectId check

## Before
Sidebar area was empty on initial load, causing a visible layout shift when the sidebar appeared after project data loaded.

## After
Sidebar area is immediately visible with skeleton placeholders, maintaining layout stability. No content jump when data arrives.

## Testing
- [x] Type checks pass
- [x] Lint checks pass
- [x] Pre-commit hooks pass

Ticket: b89ffe8e-16e1-429c-a400-4a51b25f7be2