### PR TITLE
feat: dev agents post progress comments at key milestones

### DIFF
--- a/app/api/tasks/[id]/route.ts
+++ b/app/api/tasks/[id]/route.ts
@@ -45,6 +45,8 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
     tags,
     session_id,
     prompt_version_id,
+    branch,
+    pr_number,
   } = body
 
   try {
@@ -66,6 +68,8 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
       if (tags !== undefined) otherUpdates.tags = tags ? (typeof tags === "string" ? tags : JSON.stringify(tags)) : undefined
       if (session_id !== undefined) otherUpdates.session_id = session_id || undefined
       if (prompt_version_id !== undefined) otherUpdates.prompt_version_id = prompt_version_id || undefined
+      if (branch !== undefined) otherUpdates.branch = branch || undefined
+      if (pr_number !== undefined) otherUpdates.pr_number = pr_number || undefined
 
       if (Object.keys(otherUpdates).length > 0) {
         const task = await convex.mutation(api.tasks.update, { id, ...otherUpdates })
@@ -86,6 +90,8 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
     if (tags !== undefined) updates.tags = tags ? (typeof tags === "string" ? tags : JSON.stringify(tags)) : undefined
     if (session_id !== undefined) updates.session_id = session_id || undefined
     if (prompt_version_id !== undefined) updates.prompt_version_id = prompt_version_id || undefined
+    if (branch !== undefined) updates.branch = branch || undefined
+    if (pr_number !== undefined) updates.pr_number = pr_number || undefined
 
     const task = await convex.mutation(api.tasks.update, {
       id,

--- a/worker/prompts.ts
+++ b/worker/prompts.ts
@@ -229,6 +229,9 @@ cd ${params.worktreeDir}
 
 # Record the branch name on the task
 curl -X PATCH http://localhost:3002/api/tasks/${params.taskId} -H 'Content-Type: application/json' -d '{"branch": "${branchName}"}'
+
+# Post progress comment
+ curl -X POST http://localhost:3002/api/tasks/${params.taskId}/comments -H 'Content-Type: application/json' -d '{"content": "Started work. Branch: \`${branchName}\`, worktree: \`${params.worktreeDir}\`"}'
 \`\`\`
 
 **After implementation, push and create PR:**
@@ -244,14 +247,24 @@ Create the PR and capture the PR number:
 # Create PR and extract the PR number from the URL
 PR_URL=$(gh pr create --title "<title>" --body "Ticket: ${params.taskId}")
 PR_NUMBER=$(echo "$PR_URL" | grep -oE '[0-9]+$')
+PR_TITLE="<title>"
 
 # Record the PR number on the task
 curl -X PATCH http://localhost:3002/api/tasks/${params.taskId} -H 'Content-Type: application/json' -d "{\"pr_number\": $PR_NUMBER}"
+
+# Post progress comment
+curl -X POST http://localhost:3002/api/tasks/${params.taskId}/comments -H 'Content-Type: application/json' -d "{\"content\": \"Implementation complete. PR #$PR_NUMBER opened: $PR_TITLE\"}"
 \`\`\`
 
 Then update ticket to in_review:
 \`\`\`bash
 curl -X PATCH http://localhost:3002/api/tasks/${params.taskId} -H 'Content-Type: application/json' -d '{"status": "in_review"}'
+\`\`\`
+
+**If you encounter blockers:**
+\`\`\`bash
+# Post a comment about any issues during implementation
+curl -X POST http://localhost:3002/api/tasks/${params.taskId}/comments -H 'Content-Type: application/json' -d '{"content": "Blocker: <description of issue>"}'
 \`\`\``
 }
 


### PR DESCRIPTION
Ticket: 32942a47-cd31-4da8-a262-613864effabb

## Summary
Dev agents now post progress comments at key milestones:

1. **Work started** — After creating worktree and recording branch
2. **PR created** — After opening PR with number and title
3. **Blockers** — Template provided for any issues during implementation

## Changes
- Updated buildDevInstructions() in worker/prompts.ts
- Added curl commands to post comments via POST /api/tasks/{id}/comments
- Comments are concise, one-line per milestone
- QA/research comment behavior unchanged

## Testing
- Typecheck passes
- Lint passes (only pre-existing warnings)