### PR TITLE
feat: escape key dismisses any open modal

### DIFF
--- a/components/board/dependency-picker.tsx
+++ b/components/board/dependency-picker.tsx
@@ -77,6 +77,21 @@ export function DependencyPicker({
     }
   }, [open])
 
+  // Handle Escape key to close picker
+  useEffect(() => {
+    if (!open) return
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        onOpenChange(false)
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [open, onOpenChange])
+
   // Filter tasks: same project, exclude self, exclude existing deps, match search
   const filteredTasks = useMemo(() => {
     if (!task) return []

--- a/components/board/task-modal.tsx
+++ b/components/board/task-modal.tsx
@@ -91,11 +91,18 @@ export function TaskModal({ task, open, onOpenChange, onDelete }: TaskModalProps
   const dependsOn = dependencies.depends_on
   const blocks = dependencies.blocks
 
-  // Keyboard shortcut for dependency picker
+  // Keyboard shortcut for dependency picker and Escape to close modal
   useEffect(() => {
     if (!open || !task) return
 
     const handleKeyDown = (e: KeyboardEvent) => {
+      // Escape key to close modal (unless dependency picker is open)
+      if (e.key === 'Escape' && !pickerOpen) {
+        e.preventDefault()
+        onOpenChange(false)
+        return
+      }
+
       // 'd' key to open dependency picker (when not typing in an input)
       if (e.key === 'd' && !e.ctrlKey && !e.metaKey && !e.altKey) {
         const target = e.target as HTMLElement
@@ -109,7 +116,7 @@ export function TaskModal({ task, open, onOpenChange, onDelete }: TaskModalProps
 
     window.addEventListener('keydown', handleKeyDown)
     return () => window.removeEventListener('keydown', handleKeyDown)
-  }, [open, task, pickerOpen])
+  }, [open, task, pickerOpen, onOpenChange])
 
   // Load task data when modal opens
   useEffect(() => {

--- a/components/chat/new-issue-dialog.tsx
+++ b/components/chat/new-issue-dialog.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useRef, useCallback } from "react"
+import { useState, useRef, useCallback, useEffect } from "react"
 import { X, Send, ImageIcon, Loader2 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -243,6 +243,21 @@ export function NewIssueDialog({
       setIsSubmitting(false)
     }
   }
+
+  // Handle Escape key to close dialog
+  useEffect(() => {
+    if (!open) return
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        handleClose()
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [open, handleClose])
 
   if (!open) return null
 


### PR DESCRIPTION
Ticket: c13c26d3-966a-4589-8d0d-7dbde449251b

## Summary
Adds Escape key handling to close modals that were missing this standard UX behavior.

## Changes
- **TaskModal**: Added Escape key handler to close the modal (when dependency picker is not open)
- **DependencyPicker**: Added Escape key handler to close the picker
- **NewIssueDialog**: Added Escape key handler to close the dialog

## Notes
- Dialog-based modals (CreateProjectModal, CreateTaskModal, EditorDialog, ABStartDialog) already handle Escape via Radix UI's built-in behavior
- Custom modals (TaskModal, DependencyPicker, NewIssueDialog) required explicit keydown listeners
- If multiple modals are stacked (e.g., TaskModal + DependencyPicker), Escape closes the topmost one first