### PR TITLE
fix: migrate task dependencies from REST to Convex reactive queries

### DIFF
--- a/components/board/task-card.tsx
+++ b/components/board/task-card.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from "react"
 import { Draggable } from "@hello-pangea/dnd"
 import { Link2, Lock } from "lucide-react"
 import type { Task } from "@/lib/types"
-import { useDependencies } from "@/lib/hooks/use-dependencies"
+import { useConvexDependencies } from "@/lib/hooks/use-convex-dependencies"
 import { formatCompactTime } from "@/lib/utils"
 import { AgentStatus, OrphanedTaskWarning } from "@/components/agents/agent-status"
 import { TaskCardMenu } from "./task-card-menu"
@@ -79,8 +79,8 @@ export function TaskCard({ task, index, onClick, isMobile = false, projectId, co
     return () => clearInterval(interval)
   }, [])
 
-  // Get dependency info
-  const { dependencies } = useDependencies(task.id)
+  // Get dependency info (using reactive Convex query instead of REST)
+  const { dependencies } = useConvexDependencies(task.id)
   const dependsOnCount = dependencies.depends_on.length
   const blocksCount = dependencies.blocks.length
   const incompleteDeps = dependencies.depends_on.filter(d => d.status !== 'done')

--- a/lib/hooks/use-convex-dependencies.ts
+++ b/lib/hooks/use-convex-dependencies.ts
@@ -1,0 +1,41 @@
+"use client"
+
+import { useQuery } from "convex/react"
+import { api } from "@/convex/_generated/api"
+import type { TaskDependencySummary, TaskSummary } from "@/lib/types"
+
+interface DependenciesData {
+  depends_on: TaskDependencySummary[]
+  blocks: TaskSummary[]
+}
+
+interface UseConvexDependenciesReturn {
+  dependencies: DependenciesData
+  loading: boolean
+  error: string | null
+}
+
+/**
+ * Reactive Convex hook for fetching task dependencies.
+ * 
+ * Replaces the REST-based useDependencies hook with reactive Convex queries.
+ * Updates automatically when dependencies change in the database.
+ * 
+ * @param taskId - The task ID to fetch dependencies for
+ * @returns Object with depends_on and blocks arrays, loading state, and error
+ */
+export function useConvexDependencies(taskId: string | null): UseConvexDependenciesReturn {
+  const result = useQuery(
+    api.taskDependencies.getDependencySummary,
+    taskId ? { taskId } : "skip"
+  )
+
+  return {
+    dependencies: {
+      depends_on: result?.depends_on ?? [],
+      blocks: result?.blocks ?? [],
+    },
+    loading: result === undefined,
+    error: null,
+  }
+}


### PR DESCRIPTION
Ticket: 5df28758-1118-48c7-baf5-c0756f3f2b4b

Migrates task dependency fetching from REST API calls to Convex reactive queries, eliminating excessive HTTP requests on the board page.

Changes:
- Added getDependencySummary query to convex/taskDependencies.ts
- Created useConvexDependencies hook for reactive dependency data
- Updated task-card.tsx to use the new Convex-based hook

Before: Every task card made an individual HTTP GET request to /api/tasks/{id}/dependencies
After: Dependencies fetched through Convex reactive queries with real-time updates