### PR TITLE
feat: add Work Loop tab to project page

### DIFF
--- a/app/projects/[slug]/layout.tsx
+++ b/app/projects/[slug]/layout.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState, use } from "react"
 import Link from "next/link"
 import { usePathname } from "next/navigation"
-import { ArrowLeft, LayoutGrid, MessageSquare, Activity, Settings } from "lucide-react"
+import { ArrowLeft, LayoutGrid, MessageSquare, Activity, Settings, RefreshCw } from "lucide-react"
 import type { Project } from "@/lib/types"
 import { MobileProjectSwitcher } from "@/components/layout/mobile-project-switcher"
 import { DesktopProjectSwitcher } from "@/components/layout/desktop-project-switcher"
@@ -19,6 +19,7 @@ const TABS = [
   { id: "chat", label: "Chat", icon: MessageSquare, href: "/chat" },
   { id: "board", label: "Board", icon: LayoutGrid, href: "/board" },
   { id: "sessions", label: "Sessions", icon: Activity, href: "/sessions" },
+  { id: "work-loop", label: "Work Loop", icon: RefreshCw, href: "/work-loop" },
   { id: "settings", label: "Settings", icon: Settings, href: "/settings" },
 ]
 
@@ -61,6 +62,7 @@ export default function ProjectLayout({ children, params }: LayoutProps) {
     if (path === "" || path.startsWith("/chat")) return "chat"
     if (path.startsWith("/board")) return "board"
     if (path.startsWith("/sessions")) return "sessions"
+    if (path.startsWith("/work-loop")) return "work-loop"
     if (path.startsWith("/settings")) return "settings"
     return "chat"
   }

--- a/app/projects/[slug]/work-loop/page.tsx
+++ b/app/projects/[slug]/work-loop/page.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+/**
+ * Project Work Loop Page
+ * Shows work loop activity log filtered to the current project
+ */
+
+import { use, useEffect, useState } from 'react';
+import dynamic from 'next/dynamic';
+import { Skeleton } from '@/components/ui/skeleton';
+import { RefreshCw } from 'lucide-react';
+
+interface PageProps {
+  params: Promise<{ slug: string }>;
+}
+
+// Dynamically import ActivityLog to avoid SSR issues with Convex
+const ActivityLog = dynamic(
+  () => import('@/app/work-loop/components/activity-log').then(mod => ({ default: mod.ActivityLog })),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="space-y-4">
+        <Skeleton className="h-8 w-48" />
+        <Skeleton className="h-64" />
+      </div>
+    ),
+  }
+);
+
+interface ProjectInfo {
+  id: string;
+  slug: string;
+  name: string;
+}
+
+export default function ProjectWorkLoopPage({ params }: PageProps) {
+  const { slug } = use(params);
+  const [project, setProject] = useState<ProjectInfo | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    async function fetchProject() {
+      try {
+        const response = await fetch(`/api/projects/${slug}`);
+        if (response.ok) {
+          const data = await response.json();
+          setProject(data.project);
+        }
+      } catch (error) {
+        console.error('[ProjectWorkLoopPage] Failed to fetch project:', error);
+      } finally {
+        setIsLoading(false);
+      }
+    }
+    fetchProject();
+  }, [slug]);
+
+  if (isLoading) {
+    return (
+      <div className="container mx-auto py-8 px-4">
+        <div className="space-y-6">
+          <div className="flex items-center gap-3">
+            <RefreshCw className="h-6 w-6 text-muted-foreground" />
+            <Skeleton className="h-8 w-48" />
+          </div>
+          <Skeleton className="h-64" />
+        </div>
+      </div>
+    );
+  }
+
+  if (!project) {
+    return (
+      <div className="container mx-auto py-8 px-4">
+        <div className="text-center">
+          <h1 className="text-2xl font-bold text-red-600">Project Not Found</h1>
+          <p className="text-muted-foreground mt-2">
+            Could not find project with slug: {slug}
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto py-8 px-4">
+      <div className="space-y-6">
+        <div className="flex items-center gap-3">
+          <RefreshCw className="h-6 w-6 text-primary" />
+          <h1 className="text-2xl font-bold">Work Loop Activity</h1>
+        </div>
+        <p className="text-muted-foreground">
+          Recent work loop cycles and actions for the {project.name} project
+        </p>
+        <ActivityLog projectId={project.id} projectSlug={slug} />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Add a "Work Loop" tab to the project detail page that shows the same work loop log as the home page, but filtered to the current project.

## Changes
- Added Work Loop tab to project layout alongside existing tabs (Chat, Board, Sessions, Settings)
- Created new /projects/[slug]/work-loop page that reuses the ActivityLog component
- ActivityLog displays work loop cycles and actions filtered to the current project
- Uses dynamic import to avoid SSR issues with Convex

## Ticket
e46d6373-6007-41cd-985a-27787fcb63a7

## QA Notes
- Navigate to any project page
- Verify the "Work Loop" tab appears in the tab navigation
- Click the tab to see work loop activity filtered to that project