### PR TITLE
feat: single source of truth for active agent count

### DIFF
--- a/app/work-loop/components/stats-panel.tsx
+++ b/app/work-loop/components/stats-panel.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { useWorkLoopState, useWorkLoopStats } from "@/lib/hooks/use-work-loop"
+import { useWorkLoopState, useWorkLoopStats, useActiveAgentCount } from "@/lib/hooks/use-work-loop"
 import { Activity, AlertCircle, Clock, Users } from "lucide-react"
 
 interface StatsPanelProps {
@@ -11,10 +11,12 @@ interface StatsPanelProps {
 export function StatsPanel({ projectId }: StatsPanelProps) {
   const { state, isLoading: stateLoading } = useWorkLoopState(projectId)
   const { stats, isLoading: statsLoading } = useWorkLoopStats(projectId)
+  const { count: activeAgentCount, isLoading: countLoading } = useActiveAgentCount(projectId)
 
-  if (stateLoading || statsLoading) {
+  if (stateLoading || statsLoading || countLoading) {
     return (
       <div className="space-y-4">
+        <StatsCardSkeleton />
         <StatsCardSkeleton />
         <StatsCardSkeleton />
         <StatsCardSkeleton />
@@ -95,7 +97,7 @@ export function StatsPanel({ projectId }: StatsPanelProps) {
         </CardHeader>
         <CardContent>
           <div className="text-2xl font-bold">
-            {state?.active_agents ?? 0}
+            {activeAgentCount}
             <span className="text-sm font-normal text-muted-foreground">
               {" "}/ {state?.max_agents ?? 0}
             </span>

--- a/components/work-loop/work-loop-header-status.tsx
+++ b/components/work-loop/work-loop-header-status.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react"
 import { Button } from "@/components/ui/button"
-import { useWorkLoopState } from "@/lib/hooks/use-work-loop"
+import { useWorkLoopState, useActiveAgentCount } from "@/lib/hooks/use-work-loop"
 import { Pause, Play, RotateCw } from "lucide-react"
 import type { WorkLoopStatus } from "@/lib/types/work-loop"
 
@@ -13,6 +13,7 @@ interface WorkLoopHeaderStatusProps {
 
 export function WorkLoopHeaderStatus({ projectId, workLoopEnabled }: WorkLoopHeaderStatusProps) {
   const { state, isLoading } = useWorkLoopState(projectId)
+  const { count: activeAgentCount, isLoading: countLoading } = useActiveAgentCount(projectId)
   const [isUpdating, setIsUpdating] = useState(false)
 
   // Don't show if work loop is not enabled for this project
@@ -71,9 +72,9 @@ export function WorkLoopHeaderStatus({ projectId, workLoopEnabled }: WorkLoopHea
           ) : (
             <>
               <span className="capitalize">{state.status}</span>
-              {state.active_agents > 0 && (
+              {activeAgentCount > 0 && !countLoading && (
                 <span className="ml-1 text-[var(--text-muted)]">
-                  ({state.active_agents} agent{state.active_agents !== 1 ? "s" : ""})
+                  ({activeAgentCount} agent{activeAgentCount !== 1 ? "s" : ""})
                 </span>
               )}
             </>

--- a/lib/hooks/use-work-loop.ts
+++ b/lib/hooks/use-work-loop.ts
@@ -133,3 +133,28 @@ export function useAgentHistory(
     error: null,
   }
 }
+
+/**
+ * Reactive Convex subscription for active agent count.
+ *
+ * Returns the count of currently active agents for a project.
+ * This is the single source of truth for active agent count.
+ */
+export function useActiveAgentCount(
+  projectId: string | null
+): {
+  count: number
+  isLoading: boolean
+  error: Error | null
+} {
+  const result = useQuery(
+    api.tasks.activeAgentCount,
+    projectId ? { projectId } : "skip"
+  )
+
+  return {
+    count: result ?? 0,
+    isLoading: result === undefined,
+    error: null,
+  }
+}


### PR DESCRIPTION
**Problem:**
Active agent count was derived from two independent sources that disagreed:
1. \workLoopState.active_agents\ — stale if loop restarts/crashes
2. \tasks.getWithActiveAgents\ — DB-derived truth

**Solution:**
- Created \tasks.activeAgentCount\ query (lightweight count only)
- Updated \projects.getAllWithStats\ to count from tasks instead of loopState
- Added \useActiveAgentCount\ hook
- Updated all UI components to use the new hook

**Files changed:**
- convex/tasks.ts — new activeAgentCount query
- convex/projects.ts — derive count from tasks
- lib/hooks/use-work-loop.ts — new hook
- components/work-loop/work-loop-header-status.tsx — use new hook
- app/work-loop/components/stats-panel.tsx — use new hook

Ticket: 502dc5f9-773c-4096-8678-d7803124b1fe