### PR TITLE
feat: add timestamps to work loop dashboard

### DIFF
--- a/app/work-loop/components/active-agents.tsx
+++ b/app/work-loop/components/active-agents.tsx
@@ -2,10 +2,12 @@
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { useActiveAgentTasks } from "@/lib/hooks/use-work-loop"
 import { Cpu, Clock, Terminal, ExternalLink } from "lucide-react"
 import Link from "next/link"
 import { useMemo } from "react"
+import { formatTimestamp } from "@/lib/utils"
 
 interface ActiveAgentsProps {
   projectId: string
@@ -25,7 +27,9 @@ export function ActiveAgents({ projectId, projectSlug }: ActiveAgentsProps) {
       role: task.role ?? "dev",
       model: task.agent_model ?? "unknown",
       duration: formatDuration(task.agent_started_at),
+      durationTimestamp: task.agent_started_at,
       lastActivity: formatLastActivity(task.agent_last_active_at),
+      lastActivityTimestamp: task.agent_last_active_at,
     }))
   }, [tasks])
 
@@ -93,7 +97,9 @@ interface AgentCardProps {
     role: string
     model: string
     duration: string
+    durationTimestamp: number | null
     lastActivity: string
+    lastActivityTimestamp: number | null
   }
   projectSlug: string
 }
@@ -136,14 +142,28 @@ function AgentCard({ agent, projectSlug }: AgentCardProps) {
       </div>
 
       <div className="flex items-center gap-4 text-xs text-muted-foreground">
-        <span className="flex items-center gap-1">
-          <Clock className="h-3 w-3" />
-          {agent.duration}
-        </span>
-        <span className="flex items-center gap-1">
-          <Terminal className="h-3 w-3" />
-          {agent.lastActivity}
-        </span>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className="flex items-center gap-1 cursor-help">
+              <Clock className="h-3 w-3" />
+              {agent.duration}
+            </span>
+          </TooltipTrigger>
+          <TooltipContent>
+            Started: {agent.durationTimestamp ? formatTimestamp(agent.durationTimestamp) : "Unknown"}
+          </TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className="flex items-center gap-1 cursor-help">
+              <Terminal className="h-3 w-3" />
+              {agent.lastActivity}
+            </span>
+          </TooltipTrigger>
+          <TooltipContent>
+            Last activity: {agent.lastActivityTimestamp ? formatTimestamp(agent.lastActivityTimestamp) : "Unknown"}
+          </TooltipContent>
+        </Tooltip>
       </div>
     </div>
   )

--- a/app/work-loop/components/activity-log.tsx
+++ b/app/work-loop/components/activity-log.tsx
@@ -2,10 +2,11 @@
 
 import { useState, useMemo } from "react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { useWorkLoopRuns } from "@/lib/hooks/use-work-loop"
 import { PhaseBadge } from "./status-badge"
 import Link from "next/link"
-import { formatDistanceToNow } from "@/lib/utils"
+import { formatDistanceToNow, formatTimestamp } from "@/lib/utils"
 import { ChevronRight, ChevronDown } from "lucide-react"
 import type { WorkLoopRun } from "@/lib/types/work-loop"
 
@@ -200,9 +201,14 @@ function CycleRow({ cycle, projectSlug, isExpanded, onToggle }: CycleRowProps) {
             Cycle {cycle.cycle}
           </span>
 
-          <span className="text-sm text-muted-foreground whitespace-nowrap">
-            {formatTimeAgo(cycle.firstRunAt)}
-          </span>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span className="text-sm text-muted-foreground whitespace-nowrap cursor-help">
+                {formatTimeAgo(cycle.firstRunAt)}
+              </span>
+            </TooltipTrigger>
+            <TooltipContent>{formatTimestamp(cycle.firstRunAt)}</TooltipContent>
+          </Tooltip>
 
           {/* Action count badge */}
           <span
@@ -275,6 +281,11 @@ function RunRow({ run, projectSlug }: RunRowProps) {
         <span className="text-muted-foreground">
           {formatAction(run.action, run.details)}
         </span>
+      </div>
+
+      {/* Timestamp */}
+      <div className="w-24 flex-shrink-0 text-right text-muted-foreground text-xs">
+        {formatTimestamp(run.created_at)}
       </div>
 
       {/* Task link */}

--- a/app/work-loop/components/stats-panel.tsx
+++ b/app/work-loop/components/stats-panel.tsx
@@ -1,8 +1,10 @@
 "use client"
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { useWorkLoopState, useWorkLoopStats, useActiveAgentCount } from "@/lib/hooks/use-work-loop"
 import { Activity, AlertCircle, Clock, Users } from "lucide-react"
+import { formatTimestamp } from "@/lib/utils"
 
 interface StatsPanelProps {
   projectId: string
@@ -59,6 +61,29 @@ export function StatsPanel({ projectId }: StatsPanelProps) {
           <div className="text-2xl font-bold">{state?.current_cycle ?? 0}</div>
         </CardContent>
       </Card>
+
+      {state?.last_cycle_at && (
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium flex items-center gap-2">
+              <Clock className="h-4 w-4 text-muted-foreground" />
+              Last Cycle
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <div className="text-2xl font-bold cursor-help">
+                  {formatTimestamp(state.last_cycle_at)}
+                </div>
+              </TooltipTrigger>
+              <TooltipContent>
+                {new Date(state.last_cycle_at).toLocaleString()}
+              </TooltipContent>
+            </Tooltip>
+          </CardContent>
+        </Card>
+      )}
 
       <Card>
         <CardHeader className="pb-2">

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -66,3 +66,40 @@ export function formatDistanceToNow(timestamp: number, options?: FormatDistanceO
 
   return result
 }
+
+/**
+ * Format a timestamp as a concise absolute time
+ * - Today: "10:32 PM"
+ * - This year: "Feb 6 10:32 PM"
+ * - Different year: "Feb 6, 2025 10:32 PM"
+ */
+export function formatTimestamp(timestamp: number): string {
+  const date = new Date(timestamp)
+  const now = new Date()
+  const isToday = date.toDateString() === now.toDateString()
+  const isThisYear = date.getFullYear() === now.getFullYear()
+
+  const timeOptions: Intl.DateTimeFormatOptions = {
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: true,
+  }
+
+  if (isToday) {
+    return date.toLocaleTimeString(undefined, timeOptions)
+  }
+
+  const dateTimeOptions: Intl.DateTimeFormatOptions = {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: true,
+  }
+
+  if (!isThisYear) {
+    dateTimeOptions.year = "numeric"
+  }
+
+  return date.toLocaleString(undefined, dateTimeOptions)
+}


### PR DESCRIPTION
Ticket: 7b6a1e00-45f8-4924-8182-1b00d65a4424

## Changes

- **Cycle summary rows**: Show absolute timestamp in tooltip on hover (e.g. "5 minutes ago" hover shows "10:32 PM")
- **Run rows**: Added timestamp column showing when each action occurred using "run.created_at"
- **Active agents panel**: Tooltips on "Started" and "Last Activity" columns show absolute timestamps
- **Stats panel**: Added "Last Cycle" card showing when the last work loop cycle ran

## Technical Details

- Added "formatTimestamp()" helper to lib/utils.ts for concise absolute timestamps:
  - Today: "10:32 PM"
  - This year: "Feb 6 10:32 PM"
  - Different year: "Feb 6, 2025 10:32 PM"

## Testing

- pnpm typecheck: ✓ passes
- pnpm lint: ✓ passes (warnings only, pre-existing)