### PR TITLE
fix: disable Link prefetch to fix 10-15s navigation delays

### DIFF
--- a/components/layout/desktop-project-switcher.tsx
+++ b/components/layout/desktop-project-switcher.tsx
@@ -64,6 +64,7 @@ export function DesktopProjectSwitcher({ currentProject, projects = [] }: Deskto
           <div className="p-1">
             <Link
               href="/"
+              prefetch={false}
               onClick={handleClose}
               className="flex items-center gap-3 px-3 py-2 text-sm font-medium text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-tertiary)] rounded-md transition-colors"
             >
@@ -81,6 +82,7 @@ export function DesktopProjectSwitcher({ currentProject, projects = [] }: Deskto
                   <Link
                     key={project.slug}
                     href={`/projects/${project.slug}/chat`}
+                    prefetch={false}
                     onClick={handleClose}
                     className={cn(
                       "flex items-center gap-3 px-3 py-2 text-sm font-medium rounded-md transition-colors",

--- a/components/layout/mobile-bottom-nav.tsx
+++ b/components/layout/mobile-bottom-nav.tsx
@@ -42,6 +42,7 @@ export function MobileBottomNav() {
             <Link
               key={item.id}
               href={item.href}
+              prefetch={false}
               className={cn(
                 "flex flex-col items-center gap-1 px-3 py-2 text-xs font-medium rounded-lg transition-colors",
                 "touch-manipulation min-w-0 flex-1 max-w-20",

--- a/components/layout/mobile-nav.tsx
+++ b/components/layout/mobile-nav.tsx
@@ -88,7 +88,7 @@ export function MobileNav({ isOpen, onToggle, onClose }: MobileNavProps) {
       >
         {/* Header */}
         <div className="p-6 pt-20 border-b border-[var(--border)]">
-          <Link href="/" className="flex items-center gap-3" onClick={onClose}>
+          <Link href="/" prefetch={false} className="flex items-center gap-3" onClick={onClose}>
             <div className="text-2xl">🦞</div>
             <div>
               <h1 className="text-lg font-bold text-[var(--text-primary)]">
@@ -112,6 +112,7 @@ export function MobileNav({ isOpen, onToggle, onClose }: MobileNavProps) {
                 <li key={item.id}>
                   <Link
                     href={item.href}
+                    prefetch={false}
                     onClick={onClose}
                     className={cn(
                       "flex items-center gap-3 px-4 py-3 text-sm font-medium rounded-lg transition-colors",

--- a/components/layout/mobile-project-switcher.tsx
+++ b/components/layout/mobile-project-switcher.tsx
@@ -68,6 +68,7 @@ export function MobileProjectSwitcher({ currentProject, projects = [] }: MobileP
               <div className="p-2">
                 <Link
                   href="/"
+                  prefetch={false}
                   onClick={handleClose}
                   className="flex items-center gap-3 px-3 py-3 text-sm font-medium text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-tertiary)] rounded-lg transition-colors"
                   style={{ minHeight: "44px" }}
@@ -83,6 +84,7 @@ export function MobileProjectSwitcher({ currentProject, projects = [] }: MobileP
                     <Link
                       key={project.slug}
                       href={`/projects/${project.slug}`}
+                      prefetch={false}
                       onClick={handleClose}
                       className={cn(
                         "flex items-center gap-3 px-3 py-3 text-sm font-medium rounded-lg transition-colors",

--- a/components/layout/sidebar.tsx
+++ b/components/layout/sidebar.tsx
@@ -37,7 +37,7 @@ export function Sidebar() {
     <div className="hidden lg:block fixed left-0 top-0 z-40 h-screen w-64 bg-[var(--bg-secondary)] border-r border-[var(--border)]">
       {/* Header */}
       <div className="p-6 border-b border-[var(--border)]">
-        <Link href="/" className="flex items-center gap-3">
+        <Link href="/" prefetch={false} className="flex items-center gap-3">
           <div className="text-2xl">🦞</div>
           <div>
             <h1 className="text-lg font-bold text-[var(--text-primary)]">
@@ -61,6 +61,7 @@ export function Sidebar() {
               <li key={item.id}>
                 <Link
                   href={item.href}
+                  prefetch={false}
                   className={cn(
                     "flex items-center gap-3 px-3 py-2 text-sm font-medium rounded-lg transition-colors",
                     isActive

--- a/components/projects/project-card.tsx
+++ b/components/projects/project-card.tsx
@@ -11,6 +11,7 @@ export function ProjectCard({ project }: ProjectCardProps) {
   return (
     <Link 
       href={`/projects/${project.slug}`}
+      prefetch={false}
       className="group block"
     >
       <div className="bg-[var(--bg-secondary)] border border-[var(--border)] rounded-lg overflow-hidden transition-all duration-150 hover:shadow-lg hover:-translate-y-0.5">

--- a/components/projects/project-list-row.tsx
+++ b/components/projects/project-list-row.tsx
@@ -116,6 +116,7 @@ export function ProjectListRow({ project }: ProjectListRowProps) {
         <div className="min-w-0">
           <Link
             href={`/projects/${project.slug}`}
+            prefetch={false}
             className="font-medium text-[var(--text-primary)] hover:text-[var(--accent-blue)] transition-colors truncate block"
           >
             {project.name}
@@ -173,6 +174,7 @@ export function ProjectListRow({ project }: ProjectListRowProps) {
       <div className="flex items-center gap-1 flex-shrink-0 opacity-0 group-hover:opacity-100 transition-opacity">
         <Link
           href={`/projects/${project.slug}/board`}
+          prefetch={false}
           className="p-1.5 rounded hover:bg-[var(--bg-tertiary)] text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors"
           title="Board"
         >
@@ -180,6 +182,7 @@ export function ProjectListRow({ project }: ProjectListRowProps) {
         </Link>
         <Link
           href={`/projects/${project.slug}/settings`}
+          prefetch={false}
           className="p-1.5 rounded hover:bg-[var(--bg-tertiary)] text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors"
           title="Settings"
         >


### PR DESCRIPTION
## Summary

Fixes extremely slow client-side navigation (10-15s transitions) by disabling Next.js 16's aggressive Link prefetching.

## Problem

- 86 RSC prefetch requests were firing on mount
- Navigation between top-level pages took 10-22 seconds
- Server responded in <5ms, but React reconciliation blocked rendering

## Solution

Added `prefetch={false}` to all navigation Links:

| Component | Links Updated |
|-----------|--------------|
| sidebar.tsx | 7 (logo + 6 nav items) |
| mobile-nav.tsx | 7 (logo + 6 nav items) |
| mobile-bottom-nav.tsx | 5 |
| desktop-project-switcher.tsx | 2 |
| mobile-project-switcher.tsx | 2 |
| project-list-row.tsx | 3 |
| project-card.tsx | 1 |

## Acceptance Criteria

- [x] TypeScript compiles
- [x] Lint passes (44 pre-existing warnings)
- [x] Navigation Links have prefetch disabled

**Needs browser QA to verify navigation speed improvement**

Ticket: bdd073ee-f129-4ef8-837c-9f5ab8cdffaa