### PR TITLE
feat: add SessionsPoller for OpenClaw sessions API polling

### DIFF
--- a/worker/sessions.ts
+++ b/worker/sessions.ts
@@ -1,0 +1,106 @@
+import { execFileSync } from "node:child_process"
+
+/**
+ * Session information from the OpenClaw sessions API
+ */
+export interface SessionInfo {
+  /** Session key (unique identifier) */
+  key: string
+  /** Session kind (e.g., "agent") */
+  kind: string
+  /** Unix timestamp of last update (milliseconds) */
+  updatedAt: number
+  /** Age of the session in milliseconds */
+  ageMs: number
+  /** Session ID (short identifier) */
+  sessionId: string
+  /** Whether the session aborted on the last run */
+  abortedLastRun: boolean
+  /** Input tokens consumed */
+  inputTokens: number
+  /** Output tokens consumed */
+  outputTokens: number
+  /** Total tokens consumed */
+  totalTokens: number
+  /** Model being used */
+  model: string
+  /** Context window tokens */
+  contextTokens: number
+}
+
+/**
+ * Polls the OpenClaw sessions API to get status info about running agent sessions.
+ *
+ * The orchestrator uses this to check session health, token usage, and activity.
+ */
+export class SessionsPoller {
+  /**
+   * Poll all active sessions from OpenClaw CLI.
+   *
+   * Executes `openclaw sessions --json --active N` and parses the result.
+   * Returns empty array on any error (CLI failure, JSON parse error).
+   *
+   * @param activeMinutes - Number of minutes to look back for active sessions (default: 30)
+   * @returns Array of session info objects
+   */
+  async poll(activeMinutes = 30): Promise<SessionInfo[]> {
+    try {
+      const result = execFileSync("openclaw", ["sessions", "--json", "--active", String(activeMinutes)], {
+        encoding: "utf-8",
+        timeout: 10_000,
+      })
+
+      const data = JSON.parse(result) as { sessions?: SessionInfo[] }
+      return data.sessions ?? []
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      console.warn(`[SessionsPoller] Failed to poll sessions: ${message}`)
+      return []
+    }
+  }
+
+  /**
+   * Find sessions matching a set of session keys.
+   *
+   * Polls for active sessions and returns a map of matching sessions by their keys.
+   *
+   * @param keys - Array of session keys to look for
+   * @param activeMinutes - Number of minutes to look back (default: 30)
+   * @returns Map of session key to session info
+   */
+  async findByKeys(keys: string[], activeMinutes?: number): Promise<Map<string, SessionInfo>> {
+    const sessions = await this.poll(activeMinutes)
+    const keySet = new Set(keys)
+    const result = new Map<string, SessionInfo>()
+
+    for (const session of sessions) {
+      if (keySet.has(session.key)) {
+        result.set(session.key, session)
+      }
+    }
+
+    return result
+  }
+
+  /**
+   * Check if a specific session is still active.
+   *
+   * Polls for active sessions and checks if the given session key is present.
+   *
+   * @param sessionKey - The session key to check
+   * @param activeMinutes - Number of minutes to look back (default: 30)
+   * @returns True if the session is active, false otherwise
+   */
+  async isActive(sessionKey: string, activeMinutes?: number): Promise<boolean> {
+    const sessions = await this.poll(activeMinutes)
+    return sessions.some((session) => session.key === sessionKey)
+  }
+}
+
+/**
+ * Default singleton instance for convenience.
+ *
+ * Use this for the global sessions poller, or create new SessionsPoller
+ * instances for isolated testing.
+ */
+export const sessionsPoller = new SessionsPoller()


### PR DESCRIPTION
## Summary

Adds a SessionsPoller module to poll the OpenClaw sessions API for monitoring running agent sessions.

## Changes

- Created `worker/sessions.ts` with SessionsPoller class
- Implements `poll()` to call `openclaw sessions --json --active N`
- Implements `findByKeys()` to filter sessions by key
- Implements `isActive()` to check if a specific session is active
- Exports singleton `sessionsPoller` for convenience
- Handles CLI errors and JSON parse errors gracefully (returns empty array, logs warning)

## Acceptance Criteria

- [x] SessionsPoller class exported from worker/sessions.ts
- [x] poll() calls openclaw sessions --json --active N and parses result
- [x] findByKeys() filters poll results to match given session keys
- [x] Handles CLI errors gracefully (returns empty array, logs warning)
- [x] Handles JSON parse errors gracefully
- [x] pnpm typecheck passes
- [x] pnpm lint passes

Ticket: 8e12871e-6ec9-4693-aa6a-2f1a7c33eb68