### PR TITLE
feat: consolidate WebSocket onto port 3002

### DIFF
--- a/app/api/ws/route.ts
+++ b/app/api/ws/route.ts
@@ -1,0 +1,105 @@
+import { broadcastMessage } from "@/lib/websocket/server"
+import { type NextRequest } from "next/server"
+
+// Force Node.js runtime for WebSocket support
+export const runtime = "nodejs"
+export const dynamic = "force-dynamic"
+export const preferredRegion = "home"
+
+/**
+ * WebSocket upgrade handler for Next.js App Router.
+ *
+ * This route handles both:
+ * 1. GET requests for WebSocket upgrade (ws://host/api/ws)
+ * 2. POST requests for broadcasting messages via HTTP
+ *
+ * Note: WebSocket upgrade in Next.js App Router requires Node.js runtime
+ * and access to the underlying HTTP server socket.
+ */
+export async function GET(request: NextRequest) {
+  // Check if this is a WebSocket upgrade request
+  const upgrade = request.headers.get("upgrade")
+
+  if (upgrade?.toLowerCase() !== "websocket") {
+    return new Response(
+      JSON.stringify({
+        status: "WebSocket endpoint",
+        url: "/api/ws",
+        protocol: "ws/wss",
+        message: "Use WebSocket connection to this endpoint for real-time updates",
+      }),
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }
+    )
+  }
+
+  // For WebSocket upgrade, we need to access the underlying Node.js HTTP request
+  // This requires Node.js runtime and is handled through the upgrade mechanism
+  // The actual upgrade happens when the client sends the proper WebSocket handshake
+
+  // Return 426 Upgrade Required to trigger the WebSocket handshake
+  return new Response(
+    JSON.stringify({
+      error: "Use WebSocket protocol",
+      message: "This endpoint requires a WebSocket connection",
+    }),
+    {
+      status: 426,
+      headers: {
+        "Content-Type": "application/json",
+        Upgrade: "websocket",
+      },
+    }
+  )
+}
+
+/**
+ * POST handler for broadcasting messages via HTTP.
+ * Used by other API routes to notify WebSocket clients of changes.
+ *
+ * Example body: { type: "task_updated", task: { ... } }
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json()
+
+    // Validate message has required type field
+    if (!body.type) {
+      return Response.json(
+        { error: "Message must have a 'type' field" },
+        { status: 400 }
+      )
+    }
+
+    // Broadcast to all connected clients
+    const sent = broadcastMessage(body)
+
+    return Response.json({
+      success: true,
+      clientsNotified: sent,
+      timestamp: Date.now(),
+    })
+  } catch (error) {
+    console.error("[WebSocket] Broadcast failed:", error)
+    return Response.json(
+      { error: "Failed to broadcast message" },
+      { status: 500 }
+    )
+  }
+}
+
+/**
+ * GET handler for status (non-upgrade requests).
+ * Returns information about the WebSocket server status.
+ */
+export async function HEAD() {
+  return new Response(null, {
+    status: 200,
+    headers: {
+      "Content-Type": "application/json",
+      "X-WebSocket-Supported": "true",
+    },
+  })
+}

--- a/lib/websocket/client.ts
+++ b/lib/websocket/client.ts
@@ -1,0 +1,173 @@
+"use client"
+
+import { useEffect, useRef, useCallback, useState } from "react"
+
+export type BoardMessage =
+  | { type: "task_created"; task: unknown }
+  | { type: "task_updated"; task: unknown }
+  | { type: "task_deleted"; taskId: string }
+  | { type: "task_moved"; taskId: string; status: string; position: number }
+  | { type: "connected"; timestamp: number }
+  | { type: "pong" }
+
+export type MessageHandler = (message: BoardMessage) => void
+
+/**
+ * Get the WebSocket URL based on the current window location.
+ * Uses the same host/port as the Next.js app.
+ */
+export function getWebSocketUrl(): string {
+  if (typeof window === "undefined") {
+    return ""
+  }
+
+  const protocol = window.location.protocol === "https:" ? "wss:" : "ws:"
+  return `${protocol}//${window.location.host}/api/ws`
+}
+
+/**
+ * Hook for managing a WebSocket connection to the board updates endpoint.
+ *
+ * @param projectId - Optional project ID to filter updates
+ * @returns Connection state and send function
+ */
+export function useBoardWebSocket(projectId?: string) {
+  const [isConnected, setIsConnected] = useState(false)
+  const [error, setError] = useState<Error | null>(null)
+  const wsRef = useRef<WebSocket | null>(null)
+  const handlersRef = useRef<Set<MessageHandler>>(new Set())
+  const reconnectTimeoutRef = useRef<NodeJS.Timeout | null>(null)
+  const pingIntervalRef = useRef<NodeJS.Timeout | null>(null)
+
+  // Register a message handler
+  const onMessage = useCallback((handler: MessageHandler) => {
+    handlersRef.current.add(handler)
+    return () => {
+      handlersRef.current.delete(handler)
+    }
+  }, [])
+
+  // Send a message to the server
+  const send = useCallback((message: Omit<BoardMessage, "timestamp">) => {
+    if (wsRef.current?.readyState === WebSocket.OPEN) {
+      wsRef.current.send(JSON.stringify(message))
+      return true
+    }
+    return false
+  }, [])
+
+  // Connect to WebSocket
+  useEffect(() => {
+    let isActive = true
+
+    const connect = () => {
+      if (!isActive) return
+
+      try {
+        const url = getWebSocketUrl()
+        if (!url) {
+          setError(new Error("WebSocket URL not available"))
+          return
+        }
+
+        console.log("[BoardWebSocket] Connecting to", url)
+        const ws = new WebSocket(url)
+        wsRef.current = ws
+
+        ws.onopen = () => {
+          if (!isActive) {
+            ws.close()
+            return
+          }
+          console.log("[BoardWebSocket] Connected")
+          setIsConnected(true)
+          setError(null)
+
+          // Start ping interval to keep connection alive
+          pingIntervalRef.current = setInterval(() => {
+            if (ws.readyState === WebSocket.OPEN) {
+              ws.send(JSON.stringify({ type: "ping" }))
+            }
+          }, 30000) // Ping every 30 seconds
+        }
+
+        ws.onmessage = (event) => {
+          try {
+            const message = JSON.parse(event.data) as BoardMessage
+
+            // Notify all registered handlers
+            for (const handler of handlersRef.current) {
+              try {
+                handler(message)
+              } catch (handlerError) {
+                console.error("[BoardWebSocket] Handler error:", handlerError)
+              }
+            }
+          } catch (parseError) {
+            console.error("[BoardWebSocket] Failed to parse message:", parseError)
+          }
+        }
+
+        ws.onerror = (event) => {
+          console.error("[BoardWebSocket] Error:", event)
+          setError(new Error("WebSocket connection error"))
+        }
+
+        ws.onclose = () => {
+          console.log("[BoardWebSocket] Disconnected")
+          setIsConnected(false)
+          wsRef.current = null
+
+          // Clear intervals
+          if (pingIntervalRef.current) {
+            clearInterval(pingIntervalRef.current)
+            pingIntervalRef.current = null
+          }
+
+          // Attempt reconnection after delay
+          if (isActive) {
+            reconnectTimeoutRef.current = setTimeout(() => {
+              console.log("[BoardWebSocket] Attempting reconnection...")
+              connect()
+            }, 5000)
+          }
+        }
+      } catch (connectError) {
+        console.error("[BoardSocket] Connection failed:", connectError)
+        setError(connectError instanceof Error ? connectError : new Error("Connection failed"))
+
+        // Attempt reconnection after delay
+        if (isActive) {
+          reconnectTimeoutRef.current = setTimeout(connect, 5000)
+        }
+      }
+    }
+
+    connect()
+
+    // Cleanup on unmount
+    return () => {
+      isActive = false
+
+      if (reconnectTimeoutRef.current) {
+        clearTimeout(reconnectTimeoutRef.current)
+      }
+
+      if (pingIntervalRef.current) {
+        clearInterval(pingIntervalRef.current)
+      }
+
+      if (wsRef.current) {
+        wsRef.current.close()
+        wsRef.current = null
+      }
+    }
+  }, [projectId])
+
+  return {
+    isConnected,
+    error,
+    onMessage,
+    send,
+  }
+}

--- a/lib/websocket/index.ts
+++ b/lib/websocket/index.ts
@@ -1,0 +1,2 @@
+// WebSocket client exports
+export { useBoardWebSocket, getWebSocketUrl, type BoardMessage, type MessageHandler } from "./client"

--- a/lib/websocket/server.ts
+++ b/lib/websocket/server.ts
@@ -1,0 +1,125 @@
+"use server"
+
+import { WebSocketServer, WebSocket } from "ws"
+import { IncomingMessage } from "http"
+import type { Duplex } from "stream"
+
+// Store for all connected clients
+const clients = new Set<WebSocket>()
+
+// Message types for board updates
+export type BoardMessage =
+  | { type: "task_created"; task: unknown }
+  | { type: "task_updated"; task: unknown }
+  | { type: "task_deleted"; taskId: string }
+  | { type: "task_moved"; taskId: string; status: string; position: number }
+  | { type: "ping" }
+  | { type: "pong" }
+
+let wss: WebSocketServer | null = null
+
+/**
+ * Initialize the WebSocket server by attaching to an existing HTTP server.
+ * This is called from the Next.js route handler when an upgrade request comes in.
+ */
+export function initWebSocketServer() {
+  if (wss) {
+    return wss
+  }
+
+  // Create WebSocket server without its own HTTP server
+  // We'll handle the upgrade manually in the route handler
+  wss = new WebSocketServer({ noServer: true })
+
+  wss.on("connection", (ws: WebSocket, req: IncomingMessage) => {
+    const clientIp = req.socket.remoteAddress
+    console.log(`[WebSocket] Client connected from ${clientIp}`)
+
+    clients.add(ws)
+
+    // Send welcome message
+    ws.send(JSON.stringify({ type: "connected", timestamp: Date.now() }))
+
+    ws.on("message", (data: Buffer) => {
+      try {
+        const message = JSON.parse(data.toString()) as BoardMessage
+
+        // Handle ping/pong for keepalive
+        if (message.type === "ping") {
+          ws.send(JSON.stringify({ type: "pong" }))
+          return
+        }
+
+        console.log("[WebSocket] Received:", message.type)
+      } catch (error) {
+        console.error("[WebSocket] Invalid message:", error)
+      }
+    })
+
+    ws.on("close", () => {
+      console.log("[WebSocket] Client disconnected")
+      clients.delete(ws)
+    })
+
+    ws.on("error", (error) => {
+      console.error("[WebSocket] Client error:", error)
+      clients.delete(ws)
+    })
+  })
+
+  wss.on("error", (error) => {
+    console.error("[WebSocket] Server error:", error)
+  })
+
+  console.log("[WebSocket] Server initialized")
+  return wss
+}
+
+/**
+ * Handle HTTP upgrade request for WebSocket.
+ * This is called from the route handler to upgrade the connection.
+ */
+export function handleWebSocketUpgrade(
+  request: IncomingMessage,
+  socket: Duplex,
+  head: Buffer
+) {
+  const server = initWebSocketServer()
+
+  server.handleUpgrade(request, socket, head, (ws) => {
+    server.emit("connection", ws, request)
+  })
+}
+
+/**
+ * Broadcast a message to all connected clients.
+ * Used by API routes to notify clients of changes.
+ */
+export function broadcastMessage(message: BoardMessage) {
+  const messageStr = JSON.stringify(message)
+  let sent = 0
+
+  for (const client of clients) {
+    if (client.readyState === WebSocket.OPEN) {
+      client.send(messageStr)
+      sent++
+    }
+  }
+
+  console.log(`[WebSocket] Broadcast ${message.type} to ${sent} clients`)
+  return sent
+}
+
+/**
+ * Get the number of connected clients.
+ */
+export function getConnectedClientCount(): number {
+  return clients.size
+}
+
+/**
+ * Check if the WebSocket server is initialized.
+ */
+export function isWebSocketServerInitialized(): boolean {
+  return wss !== null
+}

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "dev": "volta run node ./node_modules/next/dist/bin/next dev -p 3002",
     "build": "next build",
     "start": "next start",
+    "start:ws": "tsx server.ts",
     "lint": "eslint",
     "typecheck": "tsc --noEmit",
     "test": "vitest",

--- a/server.ts
+++ b/server.ts
@@ -1,0 +1,70 @@
+/**
+ * Custom Next.js server with WebSocket support.
+ *
+ * This server wraps the Next.js request handler and adds WebSocket
+ * upgrade handling on the same port (3002).
+ *
+ * Usage:
+ *   node server.ts        # Production
+ *   pnpm dev              # Development (uses next dev with custom server)
+ *
+ * Note: In development, we use a separate approach via middleware
+ * since Next.js dev server doesn't easily support custom upgrades.
+ */
+
+import { createServer } from "http"
+import { parse } from "url"
+import next from "next"
+import { handleWebSocketUpgrade } from "./lib/websocket/server"
+
+const dev = process.env.NODE_ENV !== "production"
+const hostname = process.env.HOSTNAME || "0.0.0.0"
+const port = parseInt(process.env.PORT || "3002", 10)
+
+const app = next({ dev, hostname, port })
+const handle = app.getRequestHandler()
+
+app.prepare().then(() => {
+  const server = createServer(async (req, res) => {
+    try {
+      const parsedUrl = parse(req.url || "/", true)
+      await handle(req, res, parsedUrl)
+    } catch (err) {
+      console.error("Error handling request:", err)
+      res.statusCode = 500
+      res.end("Internal Server Error")
+    }
+  })
+
+  // Handle WebSocket upgrade requests
+  server.on("upgrade", (request, socket, head) => {
+    const { pathname } = parse(request.url || "/", false)
+
+    // Only handle WebSocket upgrades for /api/ws
+    if (pathname === "/api/ws") {
+      console.log("[Server] WebSocket upgrade request")
+      handleWebSocketUpgrade(request, socket, head)
+    } else {
+      // Reject other upgrade requests
+      socket.destroy()
+    }
+  })
+
+  server.listen(port, hostname, () => {
+    console.log(
+      `> Ready on http://${hostname}:${port} (WebSocket on ws://${hostname}:${port}/api/ws)`
+    )
+  })
+
+  // Graceful shutdown
+  const shutdown = () => {
+    console.log("\n> Shutting down gracefully...")
+    server.close(() => {
+      console.log("> Server closed")
+      process.exit(0)
+    })
+  }
+
+  process.on("SIGTERM", shutdown)
+  process.on("SIGINT", shutdown)
+})


### PR DESCRIPTION
## Summary

Fixes board WebSocket connection errors by consolidating the WebSocket server onto the same port as Next.js (3002) instead of a separate port 3003.

## Changes

- **lib/websocket/server.ts** - WebSocket server with upgrade handling
- **lib/websocket/client.ts** - React hook `useBoardWebSocket` for client connections  
- **lib/websocket/index.ts** - Barrel exports
- **app/api/ws/route.ts** - HTTP endpoint for broadcasting messages
- **server.ts** - Custom Next.js server with WebSocket upgrade support
- **package.json** - Added "start:ws" script

## How it works

1. The custom server wraps Next.js and handles WebSocket upgrades on `/api/ws`
2. Client connects to `ws://${window.location.host}/api/ws` (same origin)
3. API routes can broadcast messages via POST to `/api/ws`
4. Automatic reconnection with 5s delay and 30s ping/pong keepalive

## Usage

```bash
# Production with WebSocket support
pnpm build
pnpm start:ws  # Uses server.ts on port 3002

# Development (standard Next.js dev server - no WebSocket)
pnpm dev
```

## Ticket

Ticket: 2967392a-96bb-4821-b67e-749d62a35671

## Checklist

- [x] TypeScript compiles
- [x] Lint passes
- [x] Pre-commit hooks pass