### PR TITLE
fix: prevent chat messages from overflowing and pushing sidebar

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -176,8 +176,6 @@
   
   /* Ensure code blocks are properly contained */
   .markdown-content pre {
-    word-wrap: break-word;
-    white-space: pre-wrap;
     max-width: 100%;
     min-width: 0;
     overflow-x: auto;

--- a/components/chat/message-bubble.tsx
+++ b/components/chat/message-bubble.tsx
@@ -222,7 +222,7 @@ export function MessageBubble({
       {!showAuthor && <div className="w-8 flex-shrink-0" />}
       
       {/* Message content */}
-      <div className={`flex-1 max-w-[90%] md:max-w-[80%] min-w-0 overflow-hidden ${isOwnMessage ? "text-right" : ""}`}>
+      <div className={`flex-1 max-w-[90%] md:max-w-[80%] min-w-0 w-0 overflow-hidden ${isOwnMessage ? "text-right" : ""}`}>
         {/* Author + time + actions */}
         {showAuthor && (
           <div className={`flex items-center gap-2 mb-1 ${isOwnMessage ? "flex-row-reverse" : ""}`}>
@@ -244,16 +244,16 @@ export function MessageBubble({
         )}
         
         {/* Bubble */}
-        <div 
-          className={`inline-block px-3 md:px-4 py-2 md:py-3 rounded-2xl text-base leading-relaxed font-medium chat-text overflow-hidden max-w-full ${
+        <div
+          className={`block w-full px-3 md:px-4 py-2 md:py-3 rounded-2xl text-base leading-relaxed font-medium chat-text overflow-hidden min-w-0 ${
             isOwnMessage
               ? "bg-[var(--accent-blue)] text-white rounded-br-md"
               : "bg-[var(--bg-tertiary)] text-[var(--text-primary)] rounded-bl-md"
           }`}
         >
-          <MarkdownContent 
+          <MarkdownContent
             content={message.content}
-            className="break-words"
+            className="break-words min-w-0"
           />
         </div>
       </div>


### PR DESCRIPTION
**Problem:**
Long chat messages (especially code blocks with long lines) were causing the chat area to expand beyond its container, pushing the sidebar to the left and getting cut off.

**Root Cause:**
The message bubble used \"inline-block\" which expands to fit content rather than respecting parent width constraints. Combined with flex layout, this allowed wide content to force expansion.

**Fix:**
- Changed message bubble from \"inline-block\" to \"block w-full\" with proper width constraints
- Added \"w-0\" to flex-1 message container to prevent expansion from wide content (flex-1 + w-0 = take available space but start at 0)
- Removed \"white-space: pre-wrap\" from code blocks to enable horizontal scrolling instead of forced wrapping
- Added \"min-w-0\" throughout the component chain to ensure proper flex constraints

**Testing:**
- TypeScript compiles cleanly
- Lint passes (pre-existing warnings only)
- Needs browser QA to verify code blocks scroll horizontally instead of expanding

Ticket: 5902106e-5f86-44d1-b34a-d9d69f3ef911