### PR TITLE
feat: WebSocket real-time updates for Kanban board

### DIFF
--- a/app/api/tasks/reorder/route.ts
+++ b/app/api/tasks/reorder/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server"
 import { getConvexClient } from "@/lib/convex/server"
 import { api } from "@/convex/_generated/api"
+import { broadcastMessage } from "@/lib/websocket/server"
 
 // POST /api/tasks/reorder — Reorder tasks within a column
 export async function POST(request: NextRequest) {
@@ -27,6 +28,15 @@ export async function POST(request: NextRequest) {
     const task = await convex.mutation(api.tasks.reorder, {
       id: task_id,
       newPosition: new_index,
+    })
+
+    // Broadcast WebSocket event for real-time board updates
+    broadcastMessage({
+      type: "task_moved",
+      taskId: task.id,
+      status: task.status,
+      position: task.position,
+      task,
     })
 
     return NextResponse.json({ success: true, task })

--- a/app/api/tasks/route.ts
+++ b/app/api/tasks/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server"
 import { getConvexClient } from "@/lib/convex/server"
 import { api } from "@/convex/_generated/api"
+import { broadcastMessage } from "@/lib/websocket/server"
 
 // GET /api/tasks?projectId=xxx&status=xxx&limit=n — List with filters
 export async function GET(request: NextRequest) {
@@ -81,6 +82,9 @@ export async function POST(request: NextRequest) {
       tags: tags ? (typeof tags === "string" ? tags : JSON.stringify(tags)) : undefined,
       role: role || undefined,
     })
+
+    // Broadcast WebSocket event for real-time board updates
+    broadcastMessage({ type: "task_created", task })
 
     return NextResponse.json({ task }, { status: 201 })
   } catch (error) {

--- a/components/board/column.tsx
+++ b/components/board/column.tsx
@@ -19,6 +19,7 @@ interface ColumnProps {
   totalCount?: number
   hasMore?: boolean
   onLoadMore?: () => void
+  recentChanges?: Map<string, { type: 'created' | 'updated' | 'moved' | 'deleted'; timestamp: number }>
 }
 
 export function Column({
@@ -34,6 +35,7 @@ export function Column({
   totalCount,
   hasMore,
   onLoadMore,
+  recentChanges,
 }: ColumnProps) {
   // Use totalCount if provided, otherwise fall back to tasks.length
   const displayCount = totalCount !== undefined ? totalCount : tasks.length
@@ -81,6 +83,7 @@ export function Column({
                 isMobile={isMobile}
                 projectId={projectId}
                 columnTasks={tasks}
+                recentChange={recentChanges?.get(task.id)}
               />
             ))}
             {provided.placeholder}

--- a/components/board/mobile-board.tsx
+++ b/components/board/mobile-board.tsx
@@ -25,6 +25,7 @@ interface MobileBoardProps {
   totalCounts?: Record<TaskStatus, number>
   hasMore?: Record<TaskStatus, boolean>
   onLoadMore?: (status: TaskStatus) => void
+  recentChanges?: Map<string, { type: 'created' | 'updated' | 'moved' | 'deleted'; timestamp: number }>
 }
 
 export function MobileBoard({
@@ -39,6 +40,7 @@ export function MobileBoard({
   totalCounts,
   hasMore,
   onLoadMore,
+  recentChanges,
 }: MobileBoardProps) {
   const [activeColumnIndex, setActiveColumnIndex] = useState(0)
   const activeColumn = columns[activeColumnIndex]
@@ -285,6 +287,7 @@ export function MobileBoard({
             totalCount={totalCounts?.[activeColumn.status]}
             hasMore={hasMore?.[activeColumn.status]}
             onLoadMore={onLoadMore ? () => onLoadMore(activeColumn.status) : undefined}
+            recentChanges={recentChanges}
           />
         </div>
       </DragDropContext>

--- a/lib/websocket/client.ts
+++ b/lib/websocket/client.ts
@@ -6,7 +6,7 @@ export type BoardMessage =
   | { type: "task_created"; task: unknown }
   | { type: "task_updated"; task: unknown }
   | { type: "task_deleted"; taskId: string }
-  | { type: "task_moved"; taskId: string; status: string; position: number }
+  | { type: "task_moved"; taskId: string; status: string; position: number; task?: unknown }
   | { type: "connected"; timestamp: number }
   | { type: "pong" }
 

--- a/lib/websocket/server.ts
+++ b/lib/websocket/server.ts
@@ -12,7 +12,7 @@ export type BoardMessage =
   | { type: "task_created"; task: unknown }
   | { type: "task_updated"; task: unknown }
   | { type: "task_deleted"; taskId: string }
-  | { type: "task_moved"; taskId: string; status: string; position: number }
+  | { type: "task_moved"; taskId: string; status: string; position: number; task?: unknown }
   | { type: "ping" }
   | { type: "pong" }
 


### PR DESCRIPTION
Ticket: 7171e289-f513-4c5d-a556-6f68e9a0733e

Summary:
- Broadcast WebSocket events from task CRUD + reorder APIs
- Board subscribes via useBoardWebSocket and highlights recent changes
- Connection status indicator (Live/Offline)