### PR TITLE
fix: chat layout radio shows wrong initial state

### DIFF
--- a/app/projects/[slug]/settings/page.tsx
+++ b/app/projects/[slug]/settings/page.tsx
@@ -16,7 +16,7 @@ export default function SettingsPage({ params }: PageProps) {
   const [project, setProject] = useState<Project | null>(null)
   const [loading, setLoading] = useState(true)
   const [saving, setSaving] = useState(false)
-  const [chatLayout, setChatLayout] = useState<'slack' | 'imessage'>('slack')
+  const [chatLayout, setChatLayout] = useState<'slack' | 'imessage' | null>(null)
   
   // Codebase configuration state
   const [localPath, setLocalPath] = useState<string>('')
@@ -37,7 +37,7 @@ export default function SettingsPage({ params }: PageProps) {
         if (response.ok) {
           const data = await response.json()
           setProject(data.project)
-          setChatLayout(data.project.chat_layout || 'slack')
+          setChatLayout(data.project.chat_layout)
           setLocalPath(data.project.local_path || '')
           setGithubRepo(data.project.github_repo || '')
           setWorkLoopEnabled(Boolean(data.project.work_loop_enabled))
@@ -196,7 +196,7 @@ export default function SettingsPage({ params }: PageProps) {
     )
   }
 
-  const hasChanges = chatLayout !== project.chat_layout ||
+  const hasChanges = (chatLayout !== null && chatLayout !== project.chat_layout) ||
     localPath !== (project.local_path || '') ||
     githubRepo !== (project.github_repo || '') ||
     workLoopEnabled !== Boolean(project.work_loop_enabled)


### PR DESCRIPTION
Ticket: 8369c2a5-8831-4d75-bbf1-74976c8b9d71

## Problem
The chat layout radio buttons in project settings were initialized with a hardcoded 'slack' value. This caused the UI to briefly show the wrong selection before the actual project data loaded from the API.

## Solution
- Initialize `chatLayout` state to `null` instead of hardcoded 'slack'
- Update `hasChanges` check to handle null state properly
- Remove unnecessary fallback when setting state from API response

This ensures the radio buttons accurately reflect the saved preference from the database.

## Testing
- [x] TypeScript compiles (`pnpm typecheck`)
- [x] Lint passes (`pnpm lint`)
- [ ] Browser QA recommended: Verify radio shows correct initial state for projects with both 'slack' and 'imessage' layouts