### PR TITLE
fix: typing indicator not clearing after agent response

### DIFF
--- a/app/projects/[slug]/chat/page.tsx
+++ b/app/projects/[slug]/chat/page.tsx
@@ -247,8 +247,8 @@ export default function ChatPage({ params }: PageProps) {
     // Save user message to Convex
     await sendMessageToDb(activeChat.id, messageContent, "dan")
 
-    // Show thinking indicator immediately (optimistic)
-    setTyping(activeChat.id, "ada", "thinking")
+    // Show thinking indicator immediately (optimistic - local + Convex)
+    void setTyping(activeChat.id, "ada", "thinking")
 
     // Build message for OpenClaw (include project context on first message)
     let openClawMessage = messageContent
@@ -263,7 +263,7 @@ export default function ChatPage({ params }: PageProps) {
     } catch (error) {
       console.error("[Chat] Failed to send to OpenClaw:", error)
       // Clear typing indicator on send failure
-      setTyping(activeChat.id, "ada", false)
+      void setTyping(activeChat.id, "ada", false)
     }
   }
 
@@ -275,7 +275,7 @@ export default function ChatPage({ params }: PageProps) {
     } catch (error) {
       console.error("[Chat] Failed to abort chat:", error)
     } finally {
-      setTyping(activeChat.id, "ada", false)
+      void setTyping(activeChat.id, "ada", false)
       await sendMessageToDb(activeChat.id, "_Response cancelled by user_", "system")
     }
   }


### PR DESCRIPTION
## Problem

After Ada replies in the chat UI, the typing indicator (thinking dots) reappears or stays active. This blocks the user from sending new messages without a full page refresh, because ChatInput checks isAssistantTyping and disables the send button.

## Root Cause

Two conflicting typing state systems were fighting each other:

1. **Zustand local state** (setTyping in chat-store.ts) — chat/page.tsx called setTyping optimistically when sending. This only updated the local zustand store, never Convex.

2. **Convex reactive state** — The trap-channel plugin sets/clears typing via POST /api/chats/[id]/typing which writes to Convex typingState table. The ConvexChatSync component subscribes to Convex typing state via syncTyping.

The conflict: zustand syncMessages tried to clear typing locally when a new message from Ada arrived, but the Convex typingState row may still exist (or be re-set by the plugin), so syncTyping immediately pushed the typing indicator back.

## Fix

Made typing state flow unidirectional through Convex:

1. **setTyping in zustand store now writes to Convex** (via the existing /api/chats/[id]/typing endpoint), not just local state. The Convex subscription (syncTyping) then reactively updates the UI.

2. **Removed the local-only typing manipulation** in syncMessages and receiveMessage — let Convex be the single source of truth.

3. **The trap-channel plugin already reliably clears typing** via clearTyping Convex mutation after writing Ada's response (in agent_end hook).

4. **Added a safety net**: clearStaleTyping mutation already exists (30s timeout). Added periodic cleanup in ConvexChatSync (runs every 30 seconds).

## Changes

- lib/stores/chat-store.ts — Modified setTyping to call Convex API, removed local typing manipulation from syncMessages/receiveMessage
- app/projects/[slug]/chat/page.tsx — Updated setTyping calls to use void prefix (fire-and-forget)
- components/chat/convex-sync.tsx — Added useMutation for clearStaleTyping + periodic cleanup interval

## Testing

- TypeScript compiles without errors
- Lint passes (44 pre-existing warnings, 0 new errors)

Ticket: 2b1f70a7-3f10-4c94-bd55-34c8f09e58e1