### PR TITLE
fix: prevent visual duplication on board, settings, and modal pages

### DIFF
--- a/app/projects/[slug]/layout.tsx
+++ b/app/projects/[slug]/layout.tsx
@@ -191,8 +191,8 @@ export default function ProjectLayout({ children, params }: LayoutProps) {
       </header>
       
       {/* Content */}
-      <main className={`px-4 py-6 ${
-        activeTab === "board" 
+      <main className={`px-4 py-6 overflow-x-hidden ${
+        activeTab === "board"
           ? "w-full lg:px-6" // Full width on desktop with larger padding
           : "container mx-auto max-w-7xl" // Keep constraint for other pages
       }`}>

--- a/components/board/board.tsx
+++ b/components/board/board.tsx
@@ -394,26 +394,30 @@ export function Board({ projectId, onTaskClick, onAddTask }: BoardProps) {
             />
           ))}
         </div>
-        {/* Desktop: grid layout */}
-        <div className="hidden lg:grid w-full gap-4 pb-4" style={{
-          gridTemplateColumns: `repeat(${visibleColumns.length}, minmax(280px, 1fr))`
-        }}>
-          {visibleColumns.map((col) => (
-            <Column
-              key={col.status}
-              status={col.status}
-              title={col.title}
-              color={col.color}
-              tasks={getTasksForColumn(col.status)}
-              onTaskClick={onTaskClick}
-              onAddTask={() => onAddTask(col.status)}
-              showAddButton={col.showAdd}
-              projectId={projectId}
-              totalCount={totalCounts[col.status]}
-              hasMore={hasMore[col.status]}
-              onLoadMore={() => loadMore(col.status)}
-            />
-          ))}
+        {/* Desktop: grid layout with horizontal scroll */}
+        <div className="hidden lg:block overflow-x-auto pb-4">
+          <div className="flex gap-4" style={{
+            width: 'max-content',
+            minWidth: '100%'
+          }}>
+            {visibleColumns.map((col) => (
+              <div key={col.status} style={{ width: '280px', flexShrink: 0 }}>
+                <Column
+                  status={col.status}
+                  title={col.title}
+                  color={col.color}
+                  tasks={getTasksForColumn(col.status)}
+                  onTaskClick={onTaskClick}
+                  onAddTask={() => onAddTask(col.status)}
+                  showAddButton={col.showAdd}
+                  projectId={projectId}
+                  totalCount={totalCounts[col.status]}
+                  hasMore={hasMore[col.status]}
+                  onLoadMore={() => loadMore(col.status)}
+                />
+              </div>
+            ))}
+          </div>
         </div>
       </DragDropContext>
     </div>


### PR DESCRIPTION
Ticket: 34931c78-2e8f-4b88-a811-f6665f814e3c

## Problem
On the Board page, Settings page, and task detail modals, the entire content area was visually rendering 3-4+ copies stacked vertically. The DOM only contained 1 instance of each element, so this was a CSS/paint issue, not DOM duplication.

## Root Cause
The board layout used \"w-full lg:px-6\" without overflow containment. Combined with \"sticky\" header positioning and \"min-h-screen\" on the parent, the browser painted content repeatedly across the oversized scroll area when board columns pushed the body width beyond the viewport.

## Solution
- Added \"overflow-x-hidden\" to the main layout container in \"layout.tsx\"
- Changed desktop board layout from CSS grid to flexbox with \"overflow-x-auto\" container
- Board columns now scroll horizontally instead of expanding page width

## Testing
- [x] TypeScript compiles
- [x] Lint passes
- [ ] Visual QA needed: Verify board renders once at 1920x1080 and 1366x768
- [ ] Verify no horizontal scroll on body element