### PR TITLE
feat: filter system messages from chat view

### DIFF
--- a/components/chat/chat-thread.tsx
+++ b/components/chat/chat-thread.tsx
@@ -252,9 +252,12 @@ export function ChatThread({
     )
   }
 
+  // Filter out system messages (e.g., "Response cancelled by user", "Session reset...")
+  const visibleMessages = messages.filter((msg) => msg.author !== "system")
+
   // Group consecutive messages by same author
   const groupedMessages: { author: string; messages: ChatMessage[] }[] = []
-  messages.forEach((msg) => {
+  visibleMessages.forEach((msg) => {
     const lastGroup = groupedMessages[groupedMessages.length - 1]
     if (lastGroup && lastGroup.author === msg.author) {
       lastGroup.messages.push(msg)


### PR DESCRIPTION
## Summary

Filters out system messages (e.g., "Response cancelled by user", "Session reset...") from the chat thread to reduce visual clutter.

## Changes

- Modified `components/chat/chat-thread.tsx` to filter out messages with `author === "system"` before grouping and rendering
- System messages are still preserved in the database but not displayed in the UI

## Testing

- TypeScript compiles without errors
- Lint passes

## Ticket

Ticket: 855cb524-5253-41ef-802d-2e676e6c87b6