### PR TITLE
fix: sessions page showing 0 sessions due to Convex filter bug

### DIFF
--- a/convex/tasks.ts
+++ b/convex/tasks.ts
@@ -410,7 +410,7 @@ export const getWithActiveAgents = query({
     const tasks = await ctx.db
       .query('tasks')
       .withIndex('by_project', (q) => q.eq('project_id', args.projectId))
-      .filter((q) => q.neq('agent_session_key', undefined))
+      .filter((q) => q.neq('agent_session_key', null))
       .collect()
 
     // Filter to only include agents that are still active
@@ -445,7 +445,7 @@ export const activeAgentCount = query({
     const tasks = await ctx.db
       .query('tasks')
       .withIndex('by_project', (q) => q.eq('project_id', args.projectId))
-      .filter((q) => q.neq('agent_session_key', undefined))
+      .filter((q) => q.neq('agent_session_key', null))
       .collect()
 
     // Count only agents that are still active
@@ -534,7 +534,7 @@ export const getAgentSessions = query({
     const tasks = await ctx.db
       .query('tasks')
       .withIndex('by_project', (q) => q.eq('project_id', args.projectId))
-      .filter((q) => q.neq('agent_session_key', undefined))
+      .filter((q) => q.neq('agent_session_key', null))
       .collect()
 
     // Sort by most recently active first
@@ -596,7 +596,7 @@ export const getAllAgentSessions = query({
   handler: async (ctx, args): Promise<AgentSession[]> => {
     const tasks = await ctx.db
       .query('tasks')
-      .filter((q) => q.neq('agent_session_key', undefined))
+      .filter((q) => q.neq('agent_session_key', null))
       .collect()
 
     // Sort by most recently active first
@@ -657,7 +657,7 @@ export const getAgentHistory = query({
     const tasks = await ctx.db
       .query('tasks')
       .withIndex('by_project', (q) => q.eq('project_id', args.projectId))
-      .filter((q) => q.neq('agent_started_at', undefined))
+      .filter((q) => q.neq('agent_started_at', null))
       .collect()
 
     // Sort by most recently started first


### PR DESCRIPTION
**Ticket:** 4297d796-8047-49e3-8831-f472e4c9c996

**Problem:**
Both the global /sessions page and project-specific /projects/{slug}/sessions page showed 0 Project Sessions, 0 Running, 0 Total Tokens — even while the work loop was actively spawning and running agents.

**Root Cause:**
The Convex queries for agent sessions were using `q.neq('field', undefined)` which doesn't work because Convex stores unset optional fields as `null` (or omits them), not `undefined`. This caused all session queries to return empty results.

**Fix:**
Changed filters from `q.neq('field', undefined)` to `q.neq('field', null)` in:
- `getWithActiveAgents`
- `activeAgentCount`
- `getAgentSessions`
- `getAllAgentSessions`
- `getAgentHistory`

**Verification:**
Confirmed via API that tasks exist with `agent_session_key` set (e.g., task `4297d796` has a session key), and the Convex query should now correctly return them.

Typecheck and lint pass.