### PR TITLE
fix: add project prompt-lab placeholder page

### DIFF
--- a/app/projects/[slug]/prompt-lab/page.tsx
+++ b/app/projects/[slug]/prompt-lab/page.tsx
@@ -1,0 +1,21 @@
+export default function ProjectPromptLabPage() {
+  return (
+    <div className="flex items-center justify-center h-[calc(100vh-4rem)]">
+      <div className="text-center max-w-md px-6">
+        <h1 className="text-2xl font-bold text-[var(--text-primary)] mb-4">
+          Project Prompt Lab
+        </h1>
+        <p className="text-[var(--text-secondary)] mb-6">
+          Project-specific prompt management is coming soon. 
+          Use the global Prompt Lab to manage prompts across all projects.
+        </p>
+        <a
+          href="/prompts"
+          className="inline-flex items-center px-4 py-2 bg-[var(--accent)] text-[var(--accent-foreground)] rounded-lg hover:opacity-90 transition-opacity"
+        >
+          Go to Prompt Lab →
+        </a>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
Ticket: 18a507c7-b0ed-4b1d-90f8-789a8fdfb0fc

## Problem
The Task Analysis panel links to `/projects/${projectSlug}/prompt-lab` but this route did not exist, causing 404 errors.

## Solution
Created a placeholder page at `app/projects/[slug]/prompt-lab/page.tsx` with:
- A heading indicating this is the Project Prompt Lab
- A message explaining that project-specific prompt management is coming soon
- A link to the global Prompt Lab (`/prompts`) for immediate use

## Acceptance Criteria
- [x] No 404 errors when clicking Prompt Lab links from Task Analysis
- [x] Page provides clear navigation to the working global Prompt Lab