### PR TITLE
fix: prevent skeleton cards from overflowing viewport on work-loop page

### DIFF
--- a/app/work-loop/components/stats-panel.tsx
+++ b/app/work-loop/components/stats-panel.tsx
@@ -17,7 +17,7 @@ export function StatsPanel({ projectId }: StatsPanelProps) {
 
   if (stateLoading || statsLoading || countLoading) {
     return (
-      <div className="space-y-4">
+      <div className="space-y-4 min-w-0">
         <StatsCardSkeleton />
         <StatsCardSkeleton />
         <StatsCardSkeleton />

--- a/app/work-loop/components/work-loop-content.tsx
+++ b/app/work-loop/components/work-loop-content.tsx
@@ -132,7 +132,7 @@ export function WorkLoopContent() {
           </div>
 
           {/* Sidebar - 1 column */}
-          <div className="lg:col-span-1">
+          <div className="lg:col-span-1 min-w-0">
             <StatsPanel projectId={project.projectId} />
           </div>
         </div>

--- a/app/work-loop/page.tsx
+++ b/app/work-loop/page.tsx
@@ -35,7 +35,7 @@ function WorkLoopSkeleton() {
           <div className="h-48 bg-muted rounded animate-pulse" />
           <div className="h-96 bg-muted rounded animate-pulse" />
         </div>
-        <div className="lg:col-span-1 space-y-4">
+        <div className="lg:col-span-1 min-w-0 space-y-4">
           <div className="h-32 bg-muted rounded animate-pulse" />
           <div className="h-32 bg-muted rounded animate-pulse" />
           <div className="h-32 bg-muted rounded animate-pulse" />


### PR DESCRIPTION
Ticket: a28f8a8c-3dfc-4f8c-8618-9fd8c2255225

## Problem
The global /work-loop page showed ghost/skeleton loading cards that extended past the right edge of the viewport. These placeholder cards for the sidebar stats panel would overflow their container during the loading state.

## Solution
Added `min-w-0` CSS class to the sidebar column containers to prevent grid items from expanding beyond their allocated width. This is a standard CSS Grid fix for overflow issues.

## Changes
- `app/work-loop/page.tsx`: Added `min-w-0` to skeleton sidebar column
- `app/work-loop/components/work-loop-content.tsx`: Added `min-w-0` to stats panel sidebar column
- `app/work-loop/components/stats-panel.tsx`: Added `min-w-0` to skeleton cards container

## Testing
- TypeScript compiles without errors
- Lint passes (only pre-existing warnings)

**Note:** This is a UI fix that would benefit from browser QA verification.