### PR TITLE
feat: spawn fixer agents on existing PR branch

### DIFF
--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -52,7 +52,7 @@ export interface Project {
 
 export type TaskStatus = "backlog" | "ready" | "in_progress" | "in_review" | "done"
 export type TaskPriority = "low" | "medium" | "high" | "urgent"
-export type TaskRole = "any" | "pm" | "dev" | "qa" | "research" | "security"
+export type TaskRole = "any" | "pm" | "dev" | "qa" | "research" | "security" | "fixer"
 export type DispatchStatus = "pending" | "spawning" | "active" | "completed" | "failed"
 
 export interface Task {


### PR DESCRIPTION
Ticket: c8dc34f2-ebec-4c0e-982e-980ba56b566a

## Summary

Adds support for \fixer\ role agents that work on existing PR branches to address review feedback.

## Changes

- Add 'fixer' to TaskRole type
- Add \buildFixerInstructions\ function with review comment handling
- Add worktree helpers: getWorktreePath and setupFixerWorktree
- Handle fixer tasks specially in work phase:
  - Validates branch exists before spawning
  - Creates worktree from existing PR branch (cleans up old if present)
  - Fetches review comments from task history
  - Passes reviewComments to buildPrompt
- Fixer uses same model as dev (openrouter/pony-alpha)

## Key Differences from Dev

| Aspect | Dev | Fixer |
|--------|-----|-------|
| Branch | Creates new fix/{taskId} | Uses existing PR branch |
| PR | Creates new PR | Pushes to existing PR |
| Worktree | New worktree on main | New worktree on PR branch |
| Prompt | buildDevInstructions | buildFixerInstructions |

## Acceptance Criteria

- [x] Fixer agents spawn on existing PR branch
- [x] Fixer agents push commits to same PR
- [x] Worktree created from PR branch
- [x] buildFixerInstructions receives review comments
- [x] After fixer completes, task goes to in_review
- [x] If no branch field, task is skipped with warning