### PR TITLE
feat: rename trap CLI to trap-cli to avoid zsh built-in conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ trap/
 ├── plugins/              # OpenClaw plugins
 │   └── trap-channel.ts   # Channel plugin for bidirectional chat
 └── bin/
-    └── trap-gate.sh      # Gate script for cron-based wakeups
+    └── trap-cli-gate.sh  # Gate script for cron-based wakeups
 ```
 
 ## Voice Chat Setup

--- a/bin/trap-cli-gate.sh
+++ b/bin/trap-cli-gate.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
-# trap-gate.sh — Gate script for OpenClaw cron
+# trap-cli-gate.sh — Gate script for OpenClaw cron
 #
 # Returns 0 (wake) if coordinator should process work
 # Returns 1 (sleep) if nothing needs attention
 #
-# Usage: TRAP_URL=http://localhost:3002 ./trap-gate.sh
+# Usage: TRAP_URL=http://localhost:3002 ./trap-cli-gate.sh
 
 set -e
 

--- a/bin/trap-cli.ts
+++ b/bin/trap-cli.ts
@@ -3,8 +3,8 @@
  * Trap CLI - Command line interface for Trap operations
  *
  * Usage:
- *   trap deploy convex [--project <slug>]   Deploy Convex for a project
- *   trap deploy check [--project <slug>]    Check if convex/ is dirty vs deployed
+ *   trap-cli deploy convex [--project <slug>]   Deploy Convex for a project
+ *   trap-cli deploy check [--project <slug>]    Check if convex/ is dirty vs deployed
  */
 
 import { execFileSync } from "node:child_process"
@@ -57,7 +57,7 @@ function showHelp(): void {
 Trap CLI - Manage your Trap projects
 
 Usage:
-  trap <command> [options]
+  trap-cli <command> [options]
 
 Commands:
   deploy convex [--project <slug>]   Deploy Convex schema/functions for a project
@@ -68,9 +68,9 @@ Options:
   --help, -h          Show this help message
 
 Examples:
-  trap deploy convex                    Deploy Convex for default project
-  trap deploy convex --project myapp    Deploy Convex for "myapp" project
-  trap deploy check                     Check convex/ status
+  trap-cli deploy convex                    Deploy Convex for default project
+  trap-cli deploy convex --project myapp    Deploy Convex for "myapp" project
+  trap-cli deploy check                     Check convex/ status
 `)
 }
 
@@ -218,7 +218,7 @@ async function cmdDeployCheck(
     for (const file of convexFiles) {
       console.log(`  - ${file}`)
     }
-    console.log("\nRun 'trap deploy convex' to deploy these changes.")
+    console.log("\nRun 'trap-cli deploy convex' to deploy these changes.")
     process.exit(1)
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
@@ -266,7 +266,7 @@ async function main(): Promise<void> {
       break
     default:
       console.error(`Unknown command: ${command}`)
-      console.error("Run 'trap --help' for usage information.")
+      console.error("Run 'trap-cli --help' for usage information.")
       process.exit(1)
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "bin": {
-    "trap": "./bin/trap.ts"
+    "trap-cli": "./bin/trap-cli.ts"
   },
   "scripts": {
     "dev": "volta run node ./node_modules/next/dist/bin/next dev -p 3002",


### PR DESCRIPTION
Ticket: 1ea3538f-b17d-4a03-9882-7a89602381a5

Renames the CLI command from trap to trap-cli to avoid conflict with zsh built-in trap command (used for signal handling).

Changes:
- bin/trap.ts → bin/trap-cli.ts
- bin/trap-gate.sh → bin/trap-cli-gate.sh
- Updated package.json bin entry
- Updated help text and error messages
- Updated README.md reference