### PR TITLE
feat: add blocked status to task state machine

### DIFF
--- a/components/board/board.tsx
+++ b/components/board/board.tsx
@@ -27,6 +27,7 @@ const COLUMNS: { status: TaskStatus; title: string; color: string; showAdd: bool
   { status: "ready", title: "Ready", color: "#3b82f6", showAdd: true },
   { status: "in_progress", title: "In Progress", color: "#eab308", showAdd: false },
   { status: "in_review", title: "In Review", color: "#a855f7", showAdd: false },
+  { status: "blocked", title: "Blocked", color: "#ef4444", showAdd: false },
   { status: "done", title: "Done", color: "#22c55e", showAdd: false },
 ]
 
@@ -38,6 +39,7 @@ const DEFAULT_VISIBILITY: Record<TaskStatus, boolean> = {
   ready: true,
   in_progress: true,
   in_review: true,
+  blocked: true,
   done: true,
 }
 
@@ -111,6 +113,7 @@ export function Board({ projectId, onTaskClick, onAddTask }: BoardProps) {
       ready: visible,
       in_progress: visible,
       in_review: visible,
+      blocked: visible,
       done: visible,
     }
     setColumnVisibility(next)

--- a/components/board/dependency-picker.tsx
+++ b/components/board/dependency-picker.tsx
@@ -20,6 +20,7 @@ const STATUS_COLORS: Record<TaskStatus, string> = {
   ready: "#3b82f6",
   in_progress: "#eab308",
   in_review: "#a855f7",
+  blocked: "#ef4444",
   done: "#22c55e",
 }
 
@@ -28,6 +29,7 @@ const STATUS_LABELS: Record<TaskStatus, string> = {
   ready: "Ready",
   in_progress: "In Progress",
   in_review: "Review",
+  blocked: "Blocked",
   done: "Done",
 }
 

--- a/components/board/mobile-board.tsx
+++ b/components/board/mobile-board.tsx
@@ -171,12 +171,13 @@ export function MobileBoard({
                   Show Columns
                 </div>
                 <div className="space-y-2">
-                  {(["backlog", "ready", "in_progress", "in_review", "done"] as TaskStatus[]).map((status) => {
+                  {(["backlog", "ready", "in_progress", "in_review", "blocked", "done"] as TaskStatus[]).map((status) => {
                     const colTitles: Record<TaskStatus, string> = {
                       backlog: "Backlog",
                       ready: "Ready",
                       in_progress: "In Progress",
                       in_review: "In Review",
+                      blocked: "Blocked",
                       done: "Done",
                     }
                     const colColors: Record<TaskStatus, string> = {
@@ -184,6 +185,7 @@ export function MobileBoard({
                       ready: "#3b82f6",
                       in_progress: "#eab308",
                       in_review: "#a855f7",
+                      blocked: "#ef4444",
                       done: "#22c55e",
                     }
                     return (

--- a/components/board/task-card-menu.tsx
+++ b/components/board/task-card-menu.tsx
@@ -36,10 +36,11 @@ const STATUS_LABELS: Record<TaskStatus, string> = {
   ready: "Ready",
   in_progress: "In Progress",
   in_review: "In Review",
+  blocked: "Blocked",
   done: "Done",
 }
 
-const STATUS_ORDER: TaskStatus[] = ["backlog", "ready", "in_progress", "in_review", "done"]
+const STATUS_ORDER: TaskStatus[] = ["backlog", "ready", "in_progress", "in_review", "blocked", "done"]
 
 export function TaskCardMenu({ task, projectId, columnTasks, onEdit, onTaskDeleted }: TaskCardMenuProps) {
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false)

--- a/components/board/task-modal.tsx
+++ b/components/board/task-modal.tsx
@@ -28,6 +28,7 @@ const STATUS_OPTIONS: { value: TaskStatus; label: string; color: string }[] = [
   { value: "ready", label: "Ready", color: "#3b82f6" },
   { value: "in_progress", label: "In Progress", color: "#eab308" },
   { value: "in_review", label: "Review", color: "#a855f7" },
+  { value: "blocked", label: "Blocked", color: "#ef4444" },
   { value: "done", label: "Done", color: "#22c55e" },
 ]
 

--- a/components/convex-session-sync-inner.tsx
+++ b/components/convex-session-sync-inner.tsx
@@ -32,7 +32,7 @@ function convertAgentSessionToSession(agentSession: {
   task: {
     id: string
     title: string
-    status: "backlog" | "ready" | "in_progress" | "in_review" | "done"
+    status: "backlog" | "ready" | "in_progress" | "in_review" | "blocked" | "done"
   }
 }): Session {
   return {

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -35,6 +35,7 @@ export default defineSchema({
       v.literal("ready"),
       v.literal("in_progress"),
       v.literal("in_review"),
+      v.literal("blocked"),
       v.literal("done")
     ),
     priority: v.union(

--- a/convex/tasks.ts
+++ b/convex/tasks.ts
@@ -8,7 +8,7 @@ import { logTaskEvent } from './task_events'
 // Type Helpers
 // ============================================
 
-type TaskStatus = "backlog" | "ready" | "in_progress" | "in_review" | "done"
+type TaskStatus = "backlog" | "ready" | "in_progress" | "in_review" | "blocked" | "done"
 type TaskPriority = "low" | "medium" | "high" | "urgent"
 type TaskRole = "any" | "pm" | "dev" | "qa" | "research" | "security" | "fixer"
 type DispatchStatus = "pending" | "spawning" | "active" | "completed" | "failed"
@@ -132,6 +132,7 @@ export const getByStatus = query({
       v.literal('ready'),
       v.literal('in_progress'),
       v.literal('in_review'),
+      v.literal('blocked'),
       v.literal('done')
     ),
   },
@@ -198,6 +199,7 @@ export const getByProject = query({
       v.literal('ready'),
       v.literal('in_progress'),
       v.literal('in_review'),
+      v.literal('blocked'),
       v.literal('done')
     )),
   },
@@ -241,6 +243,7 @@ export const getByProjectAndStatusPaginated = query({
       v.literal('ready'),
       v.literal('in_progress'),
       v.literal('in_review'),
+      v.literal('blocked'),
       v.literal('done')
     ),
     limit: v.optional(v.number()),
@@ -319,9 +322,10 @@ export const getByAssignee = query({
     const statusOrder: Record<TaskStatus, number> = {
       in_progress: 0,
       in_review: 1,
-      ready: 2,
-      backlog: 3,
-      done: 4,
+      blocked: 2,
+      ready: 3,
+      backlog: 4,
+      done: 5,
     }
 
     return tasks
@@ -689,6 +693,7 @@ export const create = mutation({
       v.literal('ready'),
       v.literal('in_progress'),
       v.literal('in_review'),
+      v.literal('blocked'),
       v.literal('done')
     )),
     priority: v.optional(v.union(
@@ -866,6 +871,7 @@ export const move = mutation({
       v.literal('ready'),
       v.literal('in_progress'),
       v.literal('in_review'),
+      v.literal('blocked'),
       v.literal('done')
     ),
     position: v.optional(v.number()),

--- a/lib/hooks/use-convex-sessions.ts
+++ b/lib/hooks/use-convex-sessions.ts
@@ -2,6 +2,7 @@
 
 import { useQuery } from "convex/react"
 import { api } from "@/convex/_generated/api"
+import type { TaskStatus } from "@/lib/types"
 
 /**
  * Task information for session association
@@ -9,7 +10,7 @@ import { api } from "@/convex/_generated/api"
 export interface SessionTaskInfo {
   id: string
   title: string
-  status: 'backlog' | 'ready' | 'in_progress' | 'in_review' | 'done'
+  status: TaskStatus
   project_id: string
   session_id: string
 }

--- a/lib/hooks/use-convex-tasks.ts
+++ b/lib/hooks/use-convex-tasks.ts
@@ -81,6 +81,7 @@ export function useConvexBoardTasks(
     ready: [],
     in_progress: [],
     in_review: [],
+    blocked: [],
     done: [],
   }
 
@@ -134,6 +135,7 @@ export function usePaginatedBoardTasks(
     ready: DEFAULT_PAGE_SIZE,
     in_progress: DEFAULT_PAGE_SIZE,
     in_review: DEFAULT_PAGE_SIZE,
+    blocked: DEFAULT_PAGE_SIZE,
     done: DEFAULT_PAGE_SIZE,
   })
 
@@ -154,6 +156,10 @@ export function usePaginatedBoardTasks(
     api.tasks.getByProjectAndStatusPaginated,
     projectId ? { projectId, status: "in_review", limit: pageSizes.in_review, offset: 0 } : "skip"
   )
+  const blockedResult = useQuery(
+    api.tasks.getByProjectAndStatusPaginated,
+    projectId ? { projectId, status: "blocked", limit: pageSizes.blocked, offset: 0 } : "skip"
+  )
   const doneResult = useQuery(
     api.tasks.getByProjectAndStatusPaginated,
     projectId ? { projectId, status: "done", limit: pageSizes.done, offset: 0 } : "skip"
@@ -164,6 +170,7 @@ export function usePaginatedBoardTasks(
     ready: readyResult,
     in_progress: inProgressResult,
     in_review: inReviewResult,
+    blocked: blockedResult,
     done: doneResult,
   }
 
@@ -176,6 +183,7 @@ export function usePaginatedBoardTasks(
     ready: readyResult?.tasks ?? [],
     in_progress: inProgressResult?.tasks ?? [],
     in_review: inReviewResult?.tasks ?? [],
+    blocked: blockedResult?.tasks ?? [],
     done: doneResult?.tasks ?? [],
   }
 
@@ -185,6 +193,7 @@ export function usePaginatedBoardTasks(
     ready: readyResult?.totalCount ?? 0,
     in_progress: inProgressResult?.totalCount ?? 0,
     in_review: inReviewResult?.totalCount ?? 0,
+    blocked: blockedResult?.totalCount ?? 0,
     done: doneResult?.totalCount ?? 0,
   }
 
@@ -194,6 +203,7 @@ export function usePaginatedBoardTasks(
     ready: (readyResult?.tasks.length ?? 0) < (readyResult?.totalCount ?? 0),
     in_progress: (inProgressResult?.tasks.length ?? 0) < (inProgressResult?.totalCount ?? 0),
     in_review: (inReviewResult?.tasks.length ?? 0) < (inReviewResult?.totalCount ?? 0),
+    blocked: (blockedResult?.tasks.length ?? 0) < (blockedResult?.totalCount ?? 0),
     done: (doneResult?.tasks.length ?? 0) < (doneResult?.totalCount ?? 0),
   }
 

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -50,7 +50,7 @@ export interface Project {
   updated_at: number
 }
 
-export type TaskStatus = "backlog" | "ready" | "in_progress" | "in_review" | "done"
+export type TaskStatus = "backlog" | "ready" | "in_progress" | "in_review" | "blocked" | "done"
 export type TaskPriority = "low" | "medium" | "high" | "urgent"
 export type TaskRole = "any" | "pm" | "dev" | "qa" | "research" | "security" | "fixer"
 export type DispatchStatus = "pending" | "spawning" | "active" | "completed" | "failed"

--- a/lib/types/session.ts
+++ b/lib/types/session.ts
@@ -3,6 +3,8 @@
  * Type definitions for OpenClaw sessions and RPC
  */
 
+import type { TaskStatus } from './index';
+
 export type SessionStatus = 'running' | 'idle' | 'completed' | 'error' | 'cancelled';
 
 export type SessionType = 'main' | 'isolated' | 'subagent';
@@ -13,7 +15,7 @@ export type SessionType = 'main' | 'isolated' | 'subagent';
 export interface SessionTaskInfo {
   id: string;
   title: string;
-  status: 'backlog' | 'ready' | 'in_progress' | 'in_review' | 'done';
+  status: TaskStatus;
   projectSlug?: string;
 }
 


### PR DESCRIPTION
Ticket: 67f1f587-66c5-42de-a889-c65d2e5c2896

## Summary

Add `blocked` as a first-class task status throughout the stack. This is the foundation for Work Loop v2 — agents signal `blocked` when they cannot complete a task, and Ada triages.

## Changes

- **Schema**: Added `v.literal("blocked")` to Convex schema tasks table
- **Types**: Added `blocked` to `TaskStatus` type
- **Validators**: Added `blocked` to all status union validators in Convex mutations/queries
- **UI**: Added `blocked` column to Kanban board between "In Review" and "Done"
- **Styling**: Red color (#ef4444) for blocked status badges

## Verification

- `pnpm typecheck` passes
- `pnpm lint` passes (pre-existing warnings only)
- `npx convex dev` applied schema changes successfully

## Testing

- Tasks can be moved to `blocked` via API: `PATCH /api/tasks/:id {"status": "blocked"}`
- Tasks CANNOT be moved backward from `done` to `blocked` (existing guard preserved)
- Kanban board shows "Blocked" column between "In Review" and "Done"