### PR TITLE
feat: simplify cleanup phase — remove orphan recovery

### DIFF
--- a/worker/loop.ts
+++ b/worker/loop.ts
@@ -363,7 +363,6 @@ async function runProjectCycle(
         agents: agentManager,
         cycle,
         project,
-        staleTaskMinutes: config.staleTaskMinutes,
         log: (params) => logRun(convex, params),
       })
       return { success: true, actions: result.actions }


### PR DESCRIPTION
Ticket: c5967550-1a71-48eb-81a4-c3e22b19e9ce

## Summary
With the blocked state and triage in place, cleanup no longer needs orphan recovery or stuck-in-review handling. Those are handled by reap → auto-block → triage.

## Changes
- Removed orphaned `in_progress` detection (handled by reap auto-block)
- Removed stuck `in_review` without PRs handling (handled by reap auto-block)  
- Removed `staleTaskMinutes` parameter from `CleanupContext` — no longer needed
- Kept ghost agent field clearing on `in_review` tasks
- Kept stale agent field clearing on `done`/`ready` tasks
- Kept orphan worktree removal
- Kept stale browser tab cleanup
- Cleaned up unused constants (`MS_PER_MINUTE`, `DEFAULT_STALE_MINUTES`, `STUCK_IN_REVIEW_MINUTES`)

## Acceptance Criteria
- [x] Cleanup phase does NOT move tasks between statuses
- [x] Cleanup DOES clean worktrees, browser tabs, and ghost agent fields
- [x] `staleTaskMinutes` not passed to or used in cleanup
- [x] `pnpm typecheck` passes