### PR TITLE
feat: Observatory reusable project filter component

### DIFF
--- a/components/observatory/project-filter.tsx
+++ b/components/observatory/project-filter.tsx
@@ -1,0 +1,136 @@
+"use client"
+
+import { useMemo } from "react"
+import { useQuery } from "convex/react"
+import { api } from "@/convex/_generated/api"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import type { Project } from "@/lib/types"
+
+interface ProjectWithCount extends Project {
+  task_count: number
+}
+
+interface ProjectFilterProps {
+  /** Current selected project ID (null = All Projects) */
+  value: string | null
+  /** Callback when selection changes */
+  onChange: (projectId: string | null) => void
+  /** If provided, the filter is locked to this project (disables dropdown) */
+  locked?: string
+  /** Optional className for styling */
+  className?: string
+}
+
+/**
+ * Project filter dropdown for Observatory pages.
+ * 
+ * Features:
+ * - Lists all work-loop-enabled projects from Convex
+ * - "All Projects" option at the top (value = null)
+ * - Shows project color dots next to names
+ * - Compact design suitable for header placement
+ * - Locked mode for per-project pages (disables dropdown, shows project name)
+ */
+export function ProjectFilter({
+  value,
+  onChange,
+  locked,
+  className,
+}: ProjectFilterProps) {
+  const projects = useQuery(api.projects.getAll, {})
+
+  // Filter to only work-loop-enabled projects
+  const enabledProjects = useMemo(() => {
+    if (!projects) return []
+    return projects.filter((p: ProjectWithCount) => p.work_loop_enabled)
+  }, [projects])
+
+  // Find the locked project name if in locked mode
+  const lockedProject = useMemo(() => {
+    if (!locked || !projects) return null
+    return projects.find((p: ProjectWithCount) => p.id === locked || p.slug === locked)
+  }, [locked, projects])
+
+  // Handle selection change
+  const handleChange = (selectedValue: string) => {
+    onChange(selectedValue === "__all__" ? null : selectedValue)
+  }
+
+  // Locked mode: show static display
+  if (locked && lockedProject) {
+    return (
+      <div
+        className={`flex items-center gap-2 px-3 py-1.5 text-sm text-muted-foreground ${className || ""}`}
+        title={`Locked to project: ${lockedProject.name}`}
+      >
+        <ColorDot color={lockedProject.color} />
+        <span className="font-medium text-foreground">{lockedProject.name}</span>
+      </div>
+    )
+  }
+
+  // Loading state
+  if (projects === undefined) {
+    return (
+      <div
+        className={`h-8 w-40 bg-muted rounded animate-pulse ${className || ""}`}
+        aria-label="Loading projects..."
+      />
+    )
+  }
+
+  // No enabled projects
+  if (enabledProjects.length === 0) {
+    return (
+      <div className={`text-sm text-muted-foreground ${className || ""}`}>
+        No work loop projects
+      </div>
+    )
+  }
+
+  return (
+    <Select
+      value={value || "__all__"}
+      onValueChange={handleChange}
+    >
+      <SelectTrigger className={`w-[180px] ${className || ""}`} size="sm">
+        <SelectValue placeholder="Select project..." />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="__all__">
+          <span className="flex items-center gap-2">
+            <span className="flex h-2 w-2 rounded-full bg-gray-400" />
+            All Projects
+          </span>
+        </SelectItem>
+        {enabledProjects.map((project: ProjectWithCount) => (
+          <SelectItem key={project.id} value={project.id}>
+            <span className="flex items-center gap-2">
+              <ColorDot color={project.color} />
+              {project.name}
+            </span>
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  )
+}
+
+/**
+ * Small color dot component for project indicators.
+ */
+function ColorDot({ color }: { color: string }) {
+  return (
+    <span
+      className="h-2 w-2 rounded-full shrink-0"
+      style={{ backgroundColor: color }}
+      aria-hidden="true"
+    />
+  )
+}

--- a/hooks/use-observatory-filters.ts
+++ b/hooks/use-observatory-filters.ts
@@ -1,0 +1,105 @@
+"use client"
+
+import { useCallback, useMemo } from "react"
+import { useSearchParams, useRouter, usePathname } from "next/navigation"
+
+export type TimeRange = "1h" | "24h" | "7d" | "30d" | "all"
+
+export interface ObservatoryFilters {
+  /** Selected project ID, or null for "All Projects" */
+  projectId: string | null
+  /** Selected time range for data display */
+  timeRange: TimeRange
+  /** Set the project filter (null = All Projects) */
+  setProjectId: (projectId: string | null) => void
+  /** Set the time range filter */
+  setTimeRange: (range: TimeRange) => void
+  /** Build a URL with the current filters applied */
+  buildUrl: (pathname: string) => string
+}
+
+const DEFAULT_TIME_RANGE: TimeRange = "7d"
+
+/**
+ * Hook for managing Observatory filter state (project + time range).
+ * 
+ * Persists filter state to URL search params:
+ * - `?project=the-trap&range=7d`
+ * - `?range=24h` (no project = All Projects)
+ * 
+ * Use this hook across all Observatory tabs to maintain filter
+ * consistency during navigation.
+ * 
+ * @param lockedProjectId - If provided, project filter is locked to this value (for per-project pages)
+ */
+export function useObservatoryFilters(lockedProjectId?: string): ObservatoryFilters {
+  const router = useRouter()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+
+  // Parse current values from URL
+  const projectId = useMemo(() => {
+    if (lockedProjectId) return lockedProjectId
+    const param = searchParams.get("project")
+    return param || null
+  }, [searchParams, lockedProjectId])
+
+  const timeRange = useMemo<TimeRange>(() => {
+    const param = searchParams.get("range") as TimeRange | null
+    const validRanges: TimeRange[] = ["1h", "24h", "7d", "30d", "all"]
+    return param && validRanges.includes(param) ? param : DEFAULT_TIME_RANGE
+  }, [searchParams])
+
+  // Update URL with new project filter
+  const setProjectId = useCallback(
+    (newProjectId: string | null) => {
+      if (lockedProjectId) return // Can't change locked filter
+
+      const params = new URLSearchParams(searchParams.toString())
+      if (newProjectId) {
+        params.set("project", newProjectId)
+      } else {
+        params.delete("project")
+      }
+
+      router.replace(`${pathname}?${params.toString()}`, { scroll: false })
+    },
+    [router, pathname, searchParams, lockedProjectId]
+  )
+
+  // Update URL with new time range
+  const setTimeRange = useCallback(
+    (newRange: TimeRange) => {
+      const params = new URLSearchParams(searchParams.toString())
+      if (newRange === DEFAULT_TIME_RANGE) {
+        params.delete("range")
+      } else {
+        params.set("range", newRange)
+      }
+
+      router.replace(`${pathname}?${params.toString()}`, { scroll: false })
+    },
+    [router, pathname, searchParams]
+  )
+
+  // Build a URL to another page with current filters preserved
+  const buildUrl = useCallback(
+    (targetPathname: string) => {
+      const params = new URLSearchParams()
+      if (projectId) params.set("project", projectId)
+      if (timeRange !== DEFAULT_TIME_RANGE) params.set("range", timeRange)
+
+      const queryString = params.toString()
+      return queryString ? `${targetPathname}?${queryString}` : targetPathname
+    },
+    [projectId, timeRange]
+  )
+
+  return {
+    projectId,
+    timeRange,
+    setProjectId,
+    setTimeRange,
+    buildUrl,
+  }
+}


### PR DESCRIPTION
## Summary
Build a project filter dropdown used across all Observatory tabs. At the global level it defaults to "All Projects" with a dropdown to filter to one. At the per-project level, it auto-locks to that project.

## Changes
- **`hooks/use-observatory-filters.ts`**: Hook combining project filter + time range with URL persistence
- **`components/observatory/project-filter.tsx`**: Reusable project filter component with color dots

## Features
- Shows all work-loop-enabled projects from Convex
- "All Projects" is the default at global level (null projectId)
- Locked mode works for per-project pages (pass `locked` prop)
- URL params persist filter state across tab switches (`?project=slug&range=7d`)
- Hook provides `{ projectId, timeRange, setProjectId, setTimeRange, buildUrl }`
- Color dots match project colors from Convex

## Usage
```tsx
// Global page with filter
const { projectId, timeRange, setProjectId, setTimeRange } = useObservatoryFilters()

// Per-project page (locked)
const { projectId, timeRange, setTimeRange } = useObservatoryFilters(project.id)
```

## Acceptance Criteria
- [x] Project filter shows all work-loop-enabled projects
- [x] "All Projects" is the default at global level
- [x] Locked mode works for per-project pages
- [x] URL params persist filter state across tab switches
- [x] Hook provides `{ projectId, timeRange, setProjectId, setTimeRange }`

Ticket: 53f2972c-9eb8-47f3-a351-d693a9461278