### PR TITLE
feat: show response generation time on assistant messages in chat

### DIFF
--- a/components/chat/chat-thread.tsx
+++ b/components/chat/chat-thread.tsx
@@ -289,6 +289,18 @@ export function ChatThread({
             // Determine if this is the user's own message based on layout
             const isOwnMessage = chatLayout === 'imessage' && message.author === currentUser
             
+            // Find the previous message for generation time calculation
+            // Need to look across groups to find the immediately preceding message
+            let prevMessage: ChatMessage | undefined = undefined
+            if (msgIndex > 0) {
+              // Previous message in same group
+              prevMessage = group.messages[msgIndex - 1]
+            } else if (groupIndex > 0) {
+              // Last message of previous group
+              const prevGroup = groupedMessages[groupIndex - 1]
+              prevMessage = prevGroup.messages[prevGroup.messages.length - 1]
+            }
+            
             return (
               <MessageBubble
                 key={message.id}
@@ -298,6 +310,7 @@ export function ChatThread({
                 onCreateTask={onCreateTask}
                 activeCrons={activeCrons}
                 projectSlug={projectSlug}
+                prevMessage={prevMessage}
               />
             )
           })}


### PR DESCRIPTION
Ticket: dac678b6-895b-4295-b225-70c77243219e

## What
Show how long it took to generate each assistant response, displayed next to the existing "x minutes ago" timestamp.

## Implementation
- Added `formatGenerationTime` helper function that formats durations as "4.2s" (under 60s) or "1m 12s" (over 60s)
- Added `prevMessage` prop to MessageBubble to calculate generation time (Option A from spec)
- Generation time shown in italic muted text next to timestamp
- Only shows for assistant messages (ada, kimi-coder, sonnet-reviewer, haiku-triage, automated)
- Works in both Slack and iMessage layouts
- Gracefully hidden when calculation isn't possible (first message, no previous user message)

## Files changed
- `components/chat/message-bubble.tsx` - Added generation time calculation and display
- `components/chat/chat-thread.tsx` - Pass previous message to MessageBubble

## Acceptance Criteria
- [x] Assistant messages show generation time next to timestamp
- [x] Format is human-readable ("4.2s" or "1m 12s")
- [x] User messages and system messages do NOT show generation time
- [x] Works in both Slack and iMessage chat layouts
- [x] Graceful fallback when time cannot be calculated