### PR TITLE
feat: per-project Observatory integration

### DIFF
--- a/app/projects/[slug]/work-loop/page.tsx
+++ b/app/projects/[slug]/work-loop/page.tsx
@@ -2,31 +2,59 @@
 
 /**
  * Project Work Loop Page
- * Shows work loop activity log filtered to the current project
+ * Shows Observatory dashboard locked to the current project
  */
 
 import { use, useEffect, useState } from 'react';
 import dynamic from 'next/dynamic';
 import { Skeleton } from '@/components/ui/skeleton';
-import { RefreshCw } from 'lucide-react';
 
 interface PageProps {
   params: Promise<{ slug: string }>;
 }
 
-// Dynamically import ActivityLog to avoid SSR issues with Convex
-const ActivityLog = dynamic(
-  () => import('@/components/observatory/live/activity-log').then(mod => ({ default: mod.ActivityLog })),
+// Dynamically import ObservatoryShell to avoid SSR issues with Convex
+const ObservatoryShell = dynamic(
+  () => import('@/components/observatory/observatory-shell').then(mod => ({ default: mod.ObservatoryShell })),
   {
     ssr: false,
-    loading: () => (
-      <div className="space-y-4">
-        <Skeleton className="h-8 w-48" />
-        <Skeleton className="h-64" />
-      </div>
-    ),
+    loading: () => <ObservatorySkeleton />,
   }
 );
+
+function ObservatorySkeleton() {
+  return (
+    <div className="container mx-auto py-8 px-4 space-y-6">
+      {/* Header skeleton */}
+      <div className="flex items-center justify-between">
+        <div className="space-y-2">
+          <Skeleton className="h-8 w-32" />
+          <Skeleton className="h-4 w-64" />
+        </div>
+        <Skeleton className="h-9 w-40" />
+      </div>
+
+      {/* Tabs skeleton */}
+      <div className="flex items-center gap-1 border-b border-[var(--border)]">
+        {['Live', 'Triage', 'Analytics', 'Models', 'Prompts'].map((tab) => (
+          <div key={tab} className="px-4 py-2">
+            <Skeleton className="h-5 w-16" />
+          </div>
+        ))}
+      </div>
+
+      {/* Content skeleton */}
+      <div className="space-y-6">
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <Skeleton className="h-32" />
+          <Skeleton className="h-32" />
+          <Skeleton className="h-32" />
+        </div>
+        <Skeleton className="h-64" />
+      </div>
+    </div>
+  );
+}
 
 interface ProjectInfo {
   id: string;
@@ -57,17 +85,7 @@ export default function ProjectWorkLoopPage({ params }: PageProps) {
   }, [slug]);
 
   if (isLoading) {
-    return (
-      <div className="container mx-auto py-8 px-4">
-        <div className="space-y-6">
-          <div className="flex items-center gap-3">
-            <RefreshCw className="h-6 w-6 text-muted-foreground" />
-            <Skeleton className="h-8 w-48" />
-          </div>
-          <Skeleton className="h-64" />
-        </div>
-      </div>
-    );
+    return <ObservatorySkeleton />;
   }
 
   if (!project) {
@@ -85,16 +103,7 @@ export default function ProjectWorkLoopPage({ params }: PageProps) {
 
   return (
     <div className="container mx-auto py-8 px-4">
-      <div className="space-y-6">
-        <div className="flex items-center gap-3">
-          <RefreshCw className="h-6 w-6 text-primary" />
-          <h1 className="text-2xl font-bold">Work Loop Activity</h1>
-        </div>
-        <p className="text-muted-foreground">
-          Recent work loop cycles and actions for the {project.name} project
-        </p>
-        <ActivityLog projectId={project.id} projectSlug={slug} />
-      </div>
+      <ObservatoryShell lockedProjectId={project.id} />
     </div>
   );
 }

--- a/components/observatory/analytics/analytics-tab.tsx
+++ b/components/observatory/analytics/analytics-tab.tsx
@@ -22,12 +22,14 @@ interface AnalyticsTabProps {
   timeRange?: TimeRange
   /** Callback when time range changes */
   onTimeRangeChange?: (range: TimeRange) => void
+  /** If provided, locks the tab to this project */
+  lockedProjectId?: string
 }
 
-export function AnalyticsTab({ timeRange: externalTimeRange, onTimeRangeChange }: AnalyticsTabProps) {
+export function AnalyticsTab({ timeRange: externalTimeRange, onTimeRangeChange, lockedProjectId }: AnalyticsTabProps) {
   // Internal state if not controlled externally
   const [internalTimeRange, setInternalTimeRange] = useState<TimeRange>('24h')
-  const [projectFilter, setProjectFilter] = useState<string | null>(null)
+  const [projectFilter, setProjectFilter] = useState<string | null>(lockedProjectId ?? null)
 
   // Use external or internal time range
   const timeRange = externalTimeRange ?? internalTimeRange
@@ -92,7 +94,7 @@ export function AnalyticsTab({ timeRange: externalTimeRange, onTimeRangeChange }
           </p>
         </div>
         <div className="flex items-center gap-4">
-          <ProjectFilter value={projectFilter} onChange={setProjectFilter} />
+          <ProjectFilter value={projectFilter} onChange={setProjectFilter} locked={lockedProjectId} />
           {!externalTimeRange && (
             <TimeRangeToggle value={timeRange} onChange={setTimeRange} />
           )}

--- a/components/observatory/models/models-tab.tsx
+++ b/components/observatory/models/models-tab.tsx
@@ -51,11 +51,12 @@ function timeRangeToDates(range: TimeRange): { startDate: number | undefined; en
 
 interface ModelsTabProps {
   timeRange: TimeRange
+  lockedProjectId?: string
 }
 
-export function ModelsTab({ timeRange }: ModelsTabProps) {
-  // Project filter
-  const [selectedProject, setSelectedProject] = useState<string | null>(null)
+export function ModelsTab({ timeRange, lockedProjectId }: ModelsTabProps) {
+  // Project filter - initialized to locked project if provided
+  const [selectedProject, setSelectedProject] = useState<string | null>(lockedProjectId ?? null)
 
   // Role filter
   const [selectedRole, setSelectedRole] = useState<RoleFilter>('all')
@@ -125,6 +126,7 @@ export function ModelsTab({ timeRange }: ModelsTabProps) {
           <ProjectFilter
             value={selectedProject}
             onChange={setSelectedProject}
+            locked={lockedProjectId}
           />
 
           <Select

--- a/components/observatory/observatory-shell.tsx
+++ b/components/observatory/observatory-shell.tsx
@@ -9,7 +9,7 @@
 import { useCallback, useMemo, useState } from 'react'
 import { useSearchParams, useRouter, usePathname } from 'next/navigation'
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
-import { ObservatoryTab, ComingSoon } from './observatory-tab'
+import { ObservatoryTab } from './observatory-tab'
 import { TimeRangeToggle, TimeRange } from './time-range-toggle'
 import { PromptsTab } from './prompts/prompts-tab'
 import { TriageTab } from './triage/triage-tab'
@@ -34,7 +34,12 @@ function isValidTabId(value: string | null): value is TabId {
   return value !== null && VALID_TAB_IDS.has(value)
 }
 
-export function ObservatoryShell() {
+interface ObservatoryShellProps {
+  /** If provided, locks the observatory to this project (disables project filter) */
+  lockedProjectId?: string
+}
+
+export function ObservatoryShell({ lockedProjectId }: ObservatoryShellProps) {
   const router = useRouter()
   const pathname = usePathname()
   const searchParams = useSearchParams()
@@ -58,14 +63,14 @@ export function ObservatoryShell() {
   // Time range state (shared across analytics, models, prompts)
   const [timeRange, setTimeRange] = useState<TimeRange>('24h')
 
-  // Project filter state (for Live tab)
-  const [selectedProject, setSelectedProject] = useState<string | null>(null)
+  // Project filter state (for Live tab) - initialized to locked project if provided
+  const [selectedProject, setSelectedProject] = useState<string | null>(lockedProjectId ?? null)
 
   // Determine if we should show the time range toggle
   const showTimeRange = ['analytics', 'models', 'prompts'].includes(activeTab)
 
-  // Show project filter on Live tab
-  const showProjectFilter = activeTab === 'live'
+  // Show project filter on Live tab (or always if locked)
+  const showProjectFilter = activeTab === 'live' || lockedProjectId !== undefined
 
   return (
     <div className="space-y-6">
@@ -82,6 +87,7 @@ export function ObservatoryShell() {
             <ProjectFilter
               value={selectedProject}
               onChange={setSelectedProject}
+              locked={lockedProjectId}
             />
           )}
           {showTimeRange && (
@@ -110,28 +116,28 @@ export function ObservatoryShell() {
         {/* Triage Tab */}
         <TabsContent value="triage">
           <ObservatoryTab>
-            <TriageTab />
+            <TriageTab lockedProjectId={lockedProjectId} />
           </ObservatoryTab>
         </TabsContent>
 
         {/* Analytics Tab */}
         <TabsContent value="analytics">
           <ObservatoryTab>
-            <AnalyticsTab timeRange={timeRange} />
+            <AnalyticsTab timeRange={timeRange} lockedProjectId={lockedProjectId} />
           </ObservatoryTab>
         </TabsContent>
 
         {/* Models Tab */}
         <TabsContent value="models">
           <ObservatoryTab>
-            <ModelsTab timeRange={timeRange} />
+            <ModelsTab timeRange={timeRange} lockedProjectId={lockedProjectId} />
           </ObservatoryTab>
         </TabsContent>
 
         {/* Prompts Tab */}
         <TabsContent value="prompts">
           <ObservatoryTab>
-            <PromptsTab timeRange={timeRange} />
+            <PromptsTab timeRange={timeRange} lockedProjectId={lockedProjectId} />
           </ObservatoryTab>
         </TabsContent>
       </Tabs>

--- a/components/observatory/prompts/prompts-tab.tsx
+++ b/components/observatory/prompts/prompts-tab.tsx
@@ -122,11 +122,12 @@ function useMetricsData(
 
 interface PromptsTabProps {
   timeRange: TimeRange
+  lockedProjectId?: string
 }
 
-export function PromptsTab({ timeRange }: PromptsTabProps) {
-  // Project filter
-  const [selectedProject, setSelectedProject] = useState<string | null>(null)
+export function PromptsTab({ timeRange, lockedProjectId }: PromptsTabProps) {
+  // Project filter - initialized to locked project if provided
+  const [selectedProject, setSelectedProject] = useState<string | null>(lockedProjectId ?? null)
 
   // Role/Model filters
   const [selectedRole, setSelectedRole] = useState<string>('all')
@@ -197,7 +198,7 @@ export function PromptsTab({ timeRange }: PromptsTabProps) {
         </div>
 
         <div className="flex flex-wrap gap-3 items-center">
-          <ProjectFilter value={selectedProject} onChange={setSelectedProject} />
+          <ProjectFilter value={selectedProject} onChange={setSelectedProject} locked={lockedProjectId} />
           <FilterBar
             roles={data?.filterOptions.roles ?? []}
             models={data?.filterOptions.models ?? []}

--- a/components/observatory/triage/triage-tab.tsx
+++ b/components/observatory/triage/triage-tab.tsx
@@ -13,8 +13,12 @@ import { ProjectFilter } from '../project-filter'
 import { CheckCircle2, AlertCircle, Loader2 } from 'lucide-react'
 import type { TriageTask } from '@/convex/triage'
 
-export function TriageTab() {
-  const [projectFilter, setProjectFilter] = useState<string | null>(null)
+interface TriageTabProps {
+  lockedProjectId?: string
+}
+
+export function TriageTab({ lockedProjectId }: TriageTabProps) {
+  const [projectFilter, setProjectFilter] = useState<string | null>(lockedProjectId ?? null)
 
   // Fetch triage queue from Convex
   const queueData = useQuery(api.triage.triageQueue, {
@@ -55,7 +59,7 @@ export function TriageTab() {
               0 blocked
             </span>
           </div>
-          <ProjectFilter value={projectFilter} onChange={setProjectFilter} />
+          <ProjectFilter value={projectFilter} onChange={setProjectFilter} locked={lockedProjectId} />
         </div>
 
         {/* Empty state */}
@@ -88,7 +92,7 @@ export function TriageTab() {
             </span>
           )}
         </div>
-        <ProjectFilter value={projectFilter} onChange={setProjectFilter} />
+        <ProjectFilter value={projectFilter} onChange={setProjectFilter} locked={lockedProjectId} />
       </div>
 
       {/* Triage cards */}


### PR DESCRIPTION
Wire /projects/[slug]/work-loop to render the same Observatory components with the project auto-locked.

## Changes
- Add lockedProjectId prop to ObservatoryShell for project-locked mode
- Update all tabs (Live, Triage, Analytics, Models, Prompts) to accept lockedProjectId
- ProjectFilter shows locked project name (non-interactive) when in locked mode
- Rewrite /projects/[slug]/work-loop page to use ObservatoryShell
- All 5 tabs filter data to the locked project only

## Acceptance Criteria
- [x] /projects/the-trap/work-loop shows Observatory with project locked
- [x] /projects/trader/work-loop also works
- [x] All 5 tabs filter to that project only
- [x] Project filter shows project name (non-interactive)
- [x] No duplicate component trees

Ticket: 3ea345c6-6f37-4219-9c36-1b2a4201a19c
