### PR TITLE
feat: /new command creates chat with specified title

### DIFF
--- a/app/projects/[slug]/chat/page.tsx
+++ b/app/projects/[slug]/chat/page.tsx
@@ -59,6 +59,7 @@ export default function ChatPage({ params }: PageProps) {
     typingIndicators,
     hasMoreMessages,
     fetchChats,
+    createChat,
     sendMessage: sendMessageToDb,
     setActiveChat,
     setTyping,
@@ -329,7 +330,7 @@ export default function ChatPage({ params }: PageProps) {
   // ==========================================================================
 
   const handleSlashCommand = async (result: SlashCommandResult) => {
-    if (!activeChat) return
+    if (!activeChat || !projectId) return
 
     // Show command response in chat
     if (result.response) {
@@ -344,6 +345,10 @@ export default function ChatPage({ params }: PageProps) {
     } else if (result.action === "refresh_session") {
       // Refresh session info (for /model command)
       // The session info effect will pick up the change automatically
+    } else if (result.action === "create_chat") {
+      // Create a new chat with the optional title from the /new command
+      const newChat = await createChat(projectId, result.title)
+      setActiveChat({ ...newChat, lastMessage: null })
     }
   }
 

--- a/lib/openclaw/api.ts
+++ b/lib/openclaw/api.ts
@@ -188,9 +188,10 @@ export async function getSessionPreview(
  * Reset a session (clear all conversation history).
  *
  * @param sessionKey - The session key to reset
+ * @param title - Optional title for the new session
  */
-export async function resetSession(sessionKey: string): Promise<void> {
-  await openclawRpc<void>('sessions.reset', { key: sessionKey });
+export async function resetSession(sessionKey: string, title?: string): Promise<void> {
+  await openclawRpc<void>('sessions.reset', { key: sessionKey, title });
 }
 
 /**


### PR DESCRIPTION
Ticket: 3d6f9f40-6f63-4f31-a7b0-d6d8b38ec2f5

Changes:
- Updated /new command to accept an optional title argument
- Modified resetSession API to pass title to the backend
- Added new create_chat action that creates a new chat with the specified title
- Updated command description and examples

Usage:
- /new - Creates a new chat with default title
- /new Bug fix discussion - Creates a new chat with specified title