### PR TITLE
fix: session log timestamps showing current time instead of actual message times

### DIFF
--- a/lib/openclaw/api.ts
+++ b/lib/openclaw/api.ts
@@ -118,7 +118,7 @@ export async function getSessionPreview(
     previews: Array<{
       key: string;
       status: 'ok' | 'empty' | 'missing' | 'error';
-      items: Array<{ role: string; text: string; model?: string }>;
+      items: Array<{ role: string; text: string; model?: string; timestamp?: number }>;
     }>;
   };
 
@@ -141,11 +141,15 @@ export async function getSessionPreview(
           item.role === 'user' || item.role === 'assistant' || item.role === 'system'
             ? item.role
             : 'assistant';
+        // Use item timestamp if available, otherwise fall back to response timestamp
+        const timestamp = item.timestamp
+          ? new Date(item.timestamp).toISOString()
+          : new Date(previewResponse.ts).toISOString();
         return {
           id: `${sessionKey}-msg-${index}`,
           role,
           content: item.text,
-          timestamp: new Date().toISOString(),
+          timestamp,
         };
       });
 


### PR DESCRIPTION
## Summary
Fixes session detail page showing current time for all message timestamps instead of actual message times.

## Changes

### 1. JSONL History API (app/api/sessions/[sessionKey]/history/route.ts)
- Fixed path resolution: Now resolves session key → UUID via sessions.json
- Fixed directory path: Uses ~/.openclaw/agents/main/sessions/ (was incorrectly ~/.openclaw/sessions/)
- Fixed JSONL parsing: Handles the actual record format using type field:
  - human → user messages
  - assistant → assistant messages  
  - message → nested message format with role
  - tool_use / tool_result → tool interactions
  - session, model_change, custom → metadata (skipped for message list)
- Added proper content extraction: Handles both string content and array of content objects

### 2. RPC Fallback (lib/openclaw/api.ts)
- Fixed getSessionPreview(): Uses actual timestamps from RPC response instead of new Date().toISOString()
- Updated PreviewResponse type: Added optional timestamp field to items
- Fallback logic: Uses item timestamp if available, otherwise response timestamp

## Testing
- TypeScript compiles without errors
- Lint passes (warnings only, no new errors)

Ticket: 7eeeb95d-fdf4-49e4-96a4-17afb4f14f0c
