### PR TITLE
feat: show from/to statuses in task history events

### DIFF
--- a/components/board/task-timeline.tsx
+++ b/components/board/task-timeline.tsx
@@ -273,7 +273,7 @@ function EventTitle({ event, config, data }: EventTitleProps) {
       if (data.from_status && data.to_status) {
         return (
           <span className="text-sm font-medium text-[var(--text-primary)]">
-            Status → <StatusBadge status={data.to_status} />
+            Status changed: <StatusBadge status={data.from_status} /> → <StatusBadge status={data.to_status} />
           </span>
         )
       }
@@ -351,11 +351,8 @@ function EventDetails({ event, data, sessionKey, projectSlug }: EventDetailsProp
   switch (event.type) {
     case "task_moved":
       return (
-        <div className="text-xs text-[var(--text-secondary)] space-y-1">
-          {data.from_status && (
-            <div>From: <StatusBadge status={String(data.from_status)} /></div>
-          )}
-          <div>Moved by: <span className={isAgentActor(actor) ? "text-cyan-400" : ""}>{formatActorName(actor)}</span></div>
+        <div className="text-xs text-[var(--text-secondary)]">
+          By: <span className={isAgentActor(actor) ? "text-cyan-400" : ""}>{formatActorName(actor)}</span>
         </div>
       )
     


### PR DESCRIPTION
Ticket: a34b2cf3-c1ec-40b9-b4ba-d3e2de43463f

## Summary
Display status transitions clearly in the task History tab.

## Changes
- Updated EventTitle to show both from and to status with format: "Status changed: {From} → {To}"
- Removed redundant "From:" line from EventDetails (now shown in title)
- Uses human-readable status labels via StatusBadge component (e.g., "In Progress" not "in_progress")

## Before
- Title: "Status → Ready"
- Details: "From: Backlog", "Moved by: agent"

## After
- Title: "Status changed: Backlog → Ready"
- Details: "By: agent"

The transition is now scannable at a glance with proper capitalization and an arrow indicator.