### PR TITLE
feat: board columns fill full viewport height and width

### DIFF
--- a/app/projects/[slug]/board/page.tsx
+++ b/app/projects/[slug]/board/page.tsx
@@ -71,8 +71,8 @@ export default function BoardPage({ params }: PageProps) {
   }
 
   return (
-    <>
-      <Board 
+    <div className="flex-1 flex flex-col min-h-0">
+      <Board
         projectId={project.id}
         onTaskClick={handleTaskClick}
         onAddTask={handleAddTask}
@@ -90,6 +90,6 @@ export default function BoardPage({ params }: PageProps) {
         open={taskModalOpen}
         onOpenChange={setTaskModalOpen}
       />
-    </>
+    </div>
   )
 }

--- a/app/projects/[slug]/layout.tsx
+++ b/app/projects/[slug]/layout.tsx
@@ -77,9 +77,9 @@ export default function ProjectLayout({ children, params }: LayoutProps) {
   }
 
   return (
-    <div className="min-h-screen bg-[var(--bg-primary)]">
+    <div className="min-h-screen bg-[var(--bg-primary)] flex flex-col">
       {/* Header */}
-      <header className="border-b border-[var(--border)] bg-[var(--bg-secondary)] sticky top-0 z-30">
+      <header className="border-b border-[var(--border)] bg-[var(--bg-secondary)] sticky top-0 z-30 flex-shrink-0">
         <div className="container mx-auto px-4 lg:px-6 max-w-7xl">
           {/* Mobile: Ultra-compact header */}
           {isMobile ? (
@@ -191,7 +191,7 @@ export default function ProjectLayout({ children, params }: LayoutProps) {
       </header>
       
       {/* Content */}
-      <main className={`px-4 py-6 overflow-x-hidden ${
+      <main className={`flex-1 flex flex-col min-h-0 px-4 py-6 overflow-x-hidden ${
         activeTab === "board"
           ? "w-full lg:px-6" // Full width on desktop with larger padding
           : "container mx-auto max-w-7xl" // Keep constraint for other pages

--- a/components/board/board.tsx
+++ b/components/board/board.tsx
@@ -259,13 +259,21 @@ export function Board({ projectId, onTaskClick, onAddTask }: BoardProps) {
 
   if (isLoading) {
     return (
-      <div className="flex gap-4 overflow-x-auto pb-4">
-        {COLUMNS.map((col) => (
-          <div 
-            key={col.status}
-            className="bg-[var(--bg-secondary)] rounded-lg border border-[var(--border)] min-h-[500px] w-[280px] flex-shrink-0 animate-pulse"
-          />
-        ))}
+      <div className="flex-1 flex flex-col min-h-0 space-y-6">
+        {/* Loading header */}
+        <div className="flex items-center justify-between flex-shrink-0">
+          <div className="h-7 w-20 bg-[var(--bg-secondary)] rounded animate-pulse" />
+          <div className="h-9 w-32 bg-[var(--bg-secondary)] rounded animate-pulse" />
+        </div>
+        {/* Loading columns */}
+        <div className="flex-1 flex gap-4 min-h-0 overflow-x-auto pb-4">
+          {COLUMNS.map((col) => (
+            <div
+              key={col.status}
+              className="flex-1 min-w-[280px] bg-[var(--bg-secondary)] rounded-lg border border-[var(--border)] animate-pulse"
+            />
+          ))}
+        </div>
       </div>
     )
   }
@@ -291,9 +299,9 @@ export function Board({ projectId, onTaskClick, onAddTask }: BoardProps) {
 
   // Desktop view
   return (
-    <div className="space-y-6">
+    <div className="flex-1 flex flex-col min-h-0 space-y-6">
       {/* Board Header */}
-      <div className="flex items-center justify-between">
+      <div className="flex items-center justify-between flex-shrink-0">
         <div className="flex items-center gap-3">
           <h2 className="text-xl font-semibold text-[var(--text-primary)]">
             Board
@@ -378,7 +386,7 @@ export function Board({ projectId, onTaskClick, onAddTask }: BoardProps) {
       {/* Board Columns */}
       <DragDropContext onDragEnd={handleDragEnd}>
         {/* Mobile: horizontal scroll flex layout */}
-        <div className="flex lg:hidden gap-4 overflow-x-auto pb-4">
+        <div className="flex lg:hidden gap-4 overflow-x-auto pb-4 flex-shrink-0">
           {visibleColumns.map((col) => (
             <Column
               key={col.status}
@@ -397,30 +405,24 @@ export function Board({ projectId, onTaskClick, onAddTask }: BoardProps) {
             />
           ))}
         </div>
-        {/* Desktop: grid layout with horizontal scroll */}
-        <div className="hidden lg:block overflow-x-auto pb-4">
-          <div className="flex gap-4 items-start" style={{
-            width: 'max-content',
-            minWidth: '100%'
-          }}>
-            {visibleColumns.map((col) => (
-              <div key={col.status} style={{ width: '280px', flexShrink: 0 }}>
-                <Column
-                  status={col.status}
-                  title={col.title}
-                  color={col.color}
-                  tasks={getTasksForColumn(col.status)}
-                  onTaskClick={onTaskClick}
-                  onAddTask={() => onAddTask(col.status)}
-                  showAddButton={col.showAdd}
-                  projectId={projectId}
-                  totalCount={totalCounts[col.status]}
-                  hasMore={hasMore[col.status]}
-                  onLoadMore={() => loadMore(col.status)}
-                />
-              </div>
-            ))}
-          </div>
+        {/* Desktop: flex layout with horizontal scroll, columns fill width */}
+        <div className="hidden lg:flex flex-1 min-h-0 gap-4 overflow-x-auto pb-4">
+          {visibleColumns.map((col) => (
+            <Column
+              key={col.status}
+              status={col.status}
+              title={col.title}
+              color={col.color}
+              tasks={getTasksForColumn(col.status)}
+              onTaskClick={onTaskClick}
+              onAddTask={() => onAddTask(col.status)}
+              showAddButton={col.showAdd}
+              projectId={projectId}
+              totalCount={totalCounts[col.status]}
+              hasMore={hasMore[col.status]}
+              onLoadMore={() => loadMore(col.status)}
+            />
+          ))}
         </div>
       </DragDropContext>
     </div>

--- a/components/board/column.tsx
+++ b/components/board/column.tsx
@@ -39,10 +39,10 @@ export function Column({
   const displayCount = totalCount !== undefined ? totalCount : tasks.length
 
   return (
-    <div className={`flex flex-col bg-[var(--bg-secondary)] rounded-lg border border-[var(--border)] max-h-[calc(100vh-200px)] ${
+    <div className={`flex flex-col bg-[var(--bg-secondary)] rounded-lg border border-[var(--border)] h-full ${
       isMobile
-        ? "w-full"
-        : "w-[280px] flex-shrink-0 lg:w-full lg:min-w-[280px]"
+        ? "w-full flex-shrink-0"
+        : "flex-1 min-w-[280px]"
     }`}>
       {/* Header */}
       <div className="p-3 border-b border-[var(--border)]">


### PR DESCRIPTION
Ticket: 7ca28f69-5ca3-4487-92a5-0270e45bd625

## Changes
- Add flex layout to project layout and board page for full height filling
- Remove fixed 280px width, use flex-1 with min-w-[280px] for even distribution
- Replace max-h-[calc(100vh-200px)] magic number with flex-1 h-full
- Update loading skeleton to match new layout
- Maintain horizontal scroll when columns exceed viewport

## Acceptance Criteria
- [x] Board columns fill the full available width, distributed evenly
- [x] Board fills full available height below nav/header (no magic calc values)
- [x] Horizontal scroll still works when columns exceed viewport
- [x] Column content area scrolls vertically when cards overflow
- [x] Mobile layout unaffected

Needs browser QA to verify visual layout.