### PR TITLE
feat: add conflict-resolver agent for CONFLICTING PRs

### DIFF
--- a/convex/modelAnalytics.ts
+++ b/convex/modelAnalytics.ts
@@ -67,7 +67,7 @@ interface TaskEventDoc {
 interface TaskDoc {
   id: string
   agent_model?: string | null
-  role?: 'pm' | 'dev' | 'research' | 'reviewer' | null
+  role?: 'pm' | 'dev' | 'research' | 'reviewer' | 'conflict_resolver' | null
   completed_at?: number | null
   agent_tokens_in?: number | null
   agent_tokens_out?: number | null

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -48,7 +48,8 @@ export default defineSchema({
       v.literal("pm"),
       v.literal("dev"),
       v.literal("research"),
-      v.literal("reviewer")
+      v.literal("reviewer"),
+      v.literal("conflict_resolver")
     )),
     assignee: v.optional(v.string()),
     requires_human_review: v.boolean(),

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -52,7 +52,7 @@ export interface Project {
 
 export type TaskStatus = "backlog" | "ready" | "in_progress" | "in_review" | "blocked" | "done"
 export type TaskPriority = "low" | "medium" | "high" | "urgent"
-export type TaskRole = "pm" | "dev" | "research" | "reviewer"
+export type TaskRole = "pm" | "dev" | "research" | "reviewer" | "conflict_resolver"
 export type DispatchStatus = "pending" | "spawning" | "active" | "completed" | "failed"
 
 export interface Task {

--- a/worker/config.ts
+++ b/worker/config.ts
@@ -18,6 +18,8 @@ export interface WorkLoopConfig {
   maxDevAgents: number
   /** Max concurrent reviewer agents — default 2 */
   maxReviewerAgents: number
+  /** Max concurrent conflict resolver agents — default 1 */
+  maxConflictResolverAgents: number
   /** How long before in_progress is considered "stalled" — default 15 minutes */
   staleTaskMinutes: number
   /** How long before in_review without PR is stalled — default 30 minutes */
@@ -34,6 +36,7 @@ const DEFAULT_CONFIG: WorkLoopConfig = {
   maxAgentsGlobal: 5,
   maxDevAgents: 2,
   maxReviewerAgents: 2,
+  maxConflictResolverAgents: 1,
   staleTaskMinutes: 15,
   staleReviewMinutes: 30,
 }
@@ -81,6 +84,7 @@ export function loadConfig(): WorkLoopConfig {
     maxAgentsGlobal: parseNumber(process.env.WORK_LOOP_MAX_AGENTS, DEFAULT_CONFIG.maxAgentsGlobal),
     maxDevAgents: parseNumber(process.env.WORK_LOOP_MAX_DEV_AGENTS, DEFAULT_CONFIG.maxDevAgents),
     maxReviewerAgents: parseNumber(process.env.WORK_LOOP_MAX_REVIEWER_AGENTS, DEFAULT_CONFIG.maxReviewerAgents),
+    maxConflictResolverAgents: parseNumber(process.env.WORK_LOOP_MAX_CONFLICT_RESOLVER_AGENTS, DEFAULT_CONFIG.maxConflictResolverAgents),
     staleTaskMinutes: parseNumber(process.env.WORK_LOOP_STALE_TASK_MINUTES, DEFAULT_CONFIG.staleTaskMinutes),
     staleReviewMinutes: parseNumber(process.env.WORK_LOOP_STALE_REVIEW_MINUTES, DEFAULT_CONFIG.staleReviewMinutes),
   }

--- a/worker/prompts.ts
+++ b/worker/prompts.ts
@@ -360,6 +360,120 @@ NEVER finish without updating the task status. If unsure, move to blocked with a
 }
 
 /**
+ * Build Conflict Resolver role instructions
+ */
+function buildConflictResolverInstructions(params: PromptParams): string {
+  const commentsSection = formatCommentsSection(params.comments)
+
+  return `## Task: ${params.taskTitle}
+
+**Read ${params.repoDir}/AGENTS.md first** (use: \`exec(command="cat ${params.repoDir}/AGENTS.md")\`).
+
+## Tool Usage (CRITICAL)
+- **\`read\` tool REQUIRES a \`path\` parameter.** Never call read() with no arguments.
+- **Use \`exec\` with \`cat\` to read files:** \`exec(command="cat /path/to/file.ts")\`
+- **Use \`rg\` to search code:** \`exec(command="rg 'pattern' ${params.worktreeDir} -t ts")\` (note: \`-t ts\` covers both .ts AND .tsx — do NOT use \`-t tsx\`, it doesn't exist)
+- **Quote paths with brackets:** Next.js uses \`[slug]\` dirs — always quote these in shell: \`cat '${params.worktreeDir}/app/projects/[slug]/page.tsx'\`
+
+Ticket ID: \`${params.taskId}\`
+Role: \`conflict_resolver\`
+
+${params.taskDescription}${commentsSection}
+
+---
+
+**Your job:** Resolve merge conflicts on this PR so it can be reviewed and merged.
+
+**PR Number:** #${params.prNumber}
+**Branch:** ${params.branch}
+**Worktree Path:** ${params.worktreeDir}
+
+## Conflict Resolution Steps
+
+1. **Navigate to the worktree (should already exist):**
+   \`\`\`bash
+   cd ${params.worktreeDir}
+   git status
+   \`\`\`
+
+2. **Fetch latest main and attempt rebase:**
+   \`\`\`bash
+   git fetch origin main
+   git rebase origin/main
+   \`\`\`
+
+3. **If conflicts occur, analyze them carefully:**
+   - Check which files have conflicts: \`git diff --name-only --diff-filter=U\`
+   - Read conflict markers and understand both sides
+   - Resolve conflicts preserving the intended functionality
+   - Prefer the incoming changes from main for structural/deps changes
+   - Prefer the branch changes for feature logic
+
+4. **After resolving conflicts:**
+   \`\`\`bash
+   git add -A
+   git rebase --continue
+   \`\`\`
+   
+   If rebase shows "No changes - did you forget to use 'git add'?", use:
+   \`\`\`bash
+   git rebase --skip
+   \`\`\`
+
+5. **Verify the resolution:**
+   \`\`\`bash
+   pnpm typecheck
+   pnpm lint
+   \`\`\`
+
+6. **Push the resolved branch (force push required after rebase):**
+   \`\`\`bash
+   git push --force-with-lease
+   \`\`\`
+
+7. **Post success comment and mark done:**
+   \`\`\`bash
+   curl -X POST http://localhost:3002/api/tasks/${params.taskId}/comments -H 'Content-Type: application/json' -d '{"content": "Resolved merge conflicts. Branch rebased onto main and force-pushed. PR is now ready for review.", "author": "agent", "author_type": "agent"}'
+   curl -X PATCH http://localhost:3002/api/tasks/${params.taskId} -H 'Content-Type: application/json' -d '{"status": "done"}'
+   \`\`\`
+
+## If Conflicts Cannot Be Resolved
+
+If the conflicts are too complex or you're unsure about the correct resolution:
+
+1. **Abort the rebase:**
+   \`\`\`bash
+   git rebase --abort
+   \`\`\`
+
+2. **Identify conflicting files:**
+   \`\`\`bash
+   git diff --name-only origin/main...HEAD
+   \`\`\`
+
+3. **Post comment explaining the blocker and move to blocked:**
+   \`\`\`bash
+   curl -X POST http://localhost:3002/api/tasks/${params.taskId}/comments -H 'Content-Type: application/json' -d '{"content": "Cannot resolve conflicts automatically. Conflicting files: <list files here>. Reason: <specific explanation>", "author": "agent", "author_type": "agent"}'
+   curl -X PATCH http://localhost:3002/api/tasks/${params.taskId} -H 'Content-Type: application/json' -d '{"status": "blocked"}'
+   \`\`\`
+
+## Completion Contract (REQUIRED)
+
+Before you finish, you MUST update the task status. Choose ONE:
+
+### Task completed successfully:
+- Dev with PR: \`curl -X PATCH http://localhost:3002/api/tasks/{TASK_ID} -H 'Content-Type: application/json' -d '{"status": "in_review", "pr_number": NUM, "branch": "BRANCH"}'\`
+- Other roles: \`curl -X PATCH http://localhost:3002/api/tasks/{TASK_ID} -H 'Content-Type: application/json' -d '{"status": "done"}'\`
+
+### CANNOT complete the task:
+Post a comment explaining why, then move to blocked:
+1. \`curl -X POST http://localhost:3002/api/tasks/{TASK_ID}/comments -H 'Content-Type: application/json' -d '{"content": "Blocked: [specific reason]", "author": "agent", "author_type": "agent", "type": "message"}'\`
+2. \`curl -X PATCH http://localhost:3002/api/tasks/{TASK_ID} -H 'Content-Type: application/json' -d '{"status": "blocked"}'\`
+
+NEVER finish without updating the task status. If unsure, move to blocked with an explanation.`
+}
+
+/**
  * Build Dev role instructions (default)
  */
 function buildDevInstructions(params: PromptParams): string {
@@ -463,6 +577,8 @@ export function buildPrompt(params: PromptParams): string {
         return buildResearchInstructions(params)
       case "reviewer":
         return buildReviewerInstructions(params)
+      case "conflict_resolver":
+        return buildConflictResolverInstructions(params)
       case "dev":
       default:
         return buildDevInstructions(params)


### PR DESCRIPTION
Ticket: 49cc4024-9e8b-4500-8955-6d7c5b2f4307

## Summary
Adds automated conflict resolution for PRs with merge conflicts (CONFLICTING or DIRTY merge state).

## Changes
- Added `conflict_resolver` role to TaskRole type and Convex schema
- Added `maxConflictResolverAgents` config option (default: 1)
- Added conflict_resolver prompt with step-by-step rebase workflow
- Updated review phase to spawn conflict_resolver for CONFLICTING/DIRTY PRs instead of skipping
- Tracks conflict resolution attempts via `agent_retry_count`
- Escalates to blocked after 2 failed attempts with triage comment
- Logs all actions for observability

## Behavior
1. When a PR is in_review with mergeable=CONFLICTING or DIRTY:
   - If retry_count < 2: Spawn conflict_resolver agent
   - If retry_count >= 2: Move to blocked with comment explaining the failure
2. Conflict resolver attempts: fetch main → rebase → resolve conflicts → typecheck/lint → force-push
3. Success: Task marked done, PR ready for review
4. Failure: Task moved to blocked with specific reason and file list