### PR TITLE
feat: add conflict-resolver agent for CONFLICTING PRs

### DIFF
--- a/convex/modelAnalytics.ts
+++ b/convex/modelAnalytics.ts
@@ -67,7 +67,7 @@ interface TaskEventDoc {
 interface TaskDoc {
   id: string
   agent_model?: string | null
-  role?: 'pm' | 'dev' | 'research' | 'reviewer' | null
+  role?: 'pm' | 'dev' | 'research' | 'reviewer' | 'conflict_resolver' | null
   completed_at?: number | null
   agent_tokens_in?: number | null
   agent_tokens_out?: number | null

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -48,7 +48,8 @@ export default defineSchema({
       v.literal("pm"),
       v.literal("dev"),
       v.literal("research"),
-      v.literal("reviewer")
+      v.literal("reviewer"),
+      v.literal("conflict_resolver")
     )),
     assignee: v.optional(v.string()),
     requires_human_review: v.boolean(),

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -52,7 +52,7 @@ export interface Project {
 
 export type TaskStatus = "backlog" | "ready" | "in_progress" | "in_review" | "blocked" | "done"
 export type TaskPriority = "low" | "medium" | "high" | "urgent"
-export type TaskRole = "pm" | "dev" | "research" | "reviewer"
+export type TaskRole = "pm" | "dev" | "research" | "reviewer" | "conflict_resolver"
 export type DispatchStatus = "pending" | "spawning" | "active" | "completed" | "failed"
 
 export interface Task {

--- a/worker/config.ts
+++ b/worker/config.ts
@@ -18,10 +18,14 @@ export interface WorkLoopConfig {
   maxDevAgents: number
   /** Max concurrent reviewer agents — default 2 */
   maxReviewerAgents: number
+  /** Max concurrent conflict resolver agents — default 1 */
+  maxConflictResolverAgents: number
   /** How long before in_progress is considered "stalled" — default 15 minutes */
   staleTaskMinutes: number
   /** How long before in_review without PR is stalled — default 30 minutes */
   staleReviewMinutes: number
+  /** Max conflict resolution attempts before moving to blocked — default 2 */
+  maxConflictResolutionAttempts: number
 }
 
 /**
@@ -34,8 +38,10 @@ const DEFAULT_CONFIG: WorkLoopConfig = {
   maxAgentsGlobal: 5,
   maxDevAgents: 2,
   maxReviewerAgents: 2,
+  maxConflictResolverAgents: 1,
   staleTaskMinutes: 15,
   staleReviewMinutes: 30,
+  maxConflictResolutionAttempts: 2,
 }
 
 /**
@@ -81,8 +87,10 @@ export function loadConfig(): WorkLoopConfig {
     maxAgentsGlobal: parseNumber(process.env.WORK_LOOP_MAX_AGENTS, DEFAULT_CONFIG.maxAgentsGlobal),
     maxDevAgents: parseNumber(process.env.WORK_LOOP_MAX_DEV_AGENTS, DEFAULT_CONFIG.maxDevAgents),
     maxReviewerAgents: parseNumber(process.env.WORK_LOOP_MAX_REVIEWER_AGENTS, DEFAULT_CONFIG.maxReviewerAgents),
+    maxConflictResolverAgents: parseNumber(process.env.WORK_LOOP_MAX_CONFLICT_RESOLVER_AGENTS, DEFAULT_CONFIG.maxConflictResolverAgents),
     staleTaskMinutes: parseNumber(process.env.WORK_LOOP_STALE_TASK_MINUTES, DEFAULT_CONFIG.staleTaskMinutes),
     staleReviewMinutes: parseNumber(process.env.WORK_LOOP_STALE_REVIEW_MINUTES, DEFAULT_CONFIG.staleReviewMinutes),
+    maxConflictResolutionAttempts: parseNumber(process.env.WORK_LOOP_MAX_CONFLICT_RESOLUTION_ATTEMPTS, DEFAULT_CONFIG.maxConflictResolutionAttempts),
   }
 }
 


### PR DESCRIPTION
Ticket: 466f0ee8-c891-469f-a0e1-05bec105fd36

## Summary
Adds automated conflict resolution workflow for PRs with merge conflicts. Previously, CONFLICTING PRs were silently skipped, creating deadlocks where tasks stayed in_review forever.

## Changes

### New Role: conflict_resolver
- Uses kimi model for reliable execution
- Dedicated prompt with clear conflict resolution guidelines
- Prefers main for unrelated changes, preserves task intent for PR-specific changes

### Conflict Resolution Flow
1. Detect CONFLICTING or DIRTY PRs during review phase
2. Check retry count (max 2 attempts, configurable via WORK_LOOP_MAX_CONFLICT_RESOLUTION_ATTEMPTS)
3. If max attempts exceeded → move to blocked with triage comment
4. Otherwise → spawn conflict resolver agent
5. Agent rebases onto main, resolves conflicts, runs tests/lint, pushes
6. Task comments log all actions and outcomes

### Configuration
-  - max concurrent conflict resolvers (default: 1)
-  - max attempts before blocking (default: 2)

### Files Changed
-  - Added conflict_resolver to TaskRole
-  - Added conflict_resolver to role union
-  - Added conflict resolver config options
-  - Added conflict resolver prompt builder
-  - Added handleConflictingPR function and retry logic
-  - Updated TaskDoc interface

## Acceptance Criteria
- [x] Conflicted PRs get an automated attempt within 1 cycle
- [x] After N failed attempts → task moves to blocked with triage comment
- [x] Observability: task comment logs actions + outcome