### PR TITLE
feat: add Convex sessions table and mutations

### DIFF
--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -596,4 +596,52 @@ export default defineSchema({
     .index("by_project", ["project_id"])
     .index("by_project_period", ["project_id", "period", "period_start"])
     .index("by_period", ["period", "period_start"]),
+
+  // Sessions - unified tracking for all OpenClaw sessions (main, chat, agent, cron)
+  sessions: defineTable({
+    id: v.string(), // UUID primary key
+    session_key: v.string(), // e.g. "agent:main:main", "agent:main:trap:the-trap:xxx"
+    session_id: v.string(), // UUID from sessions.json
+    session_type: v.union(
+      v.literal("main"),
+      v.literal("chat"),
+      v.literal("agent"),
+      v.literal("cron")
+    ),
+    model: v.optional(v.string()), // last model used
+    provider: v.optional(v.string()),
+    status: v.union(
+      v.literal("active"),
+      v.literal("idle"),
+      v.literal("completed"),
+      v.literal("stale")
+    ),
+    // Token counts
+    tokens_input: v.optional(v.number()),
+    tokens_output: v.optional(v.number()),
+    tokens_cache_read: v.optional(v.number()),
+    tokens_cache_write: v.optional(v.number()),
+    tokens_total: v.optional(v.number()),
+    // Cost tracking (USD)
+    cost_input: v.optional(v.float64()),
+    cost_output: v.optional(v.float64()),
+    cost_cache_read: v.optional(v.float64()),
+    cost_cache_write: v.optional(v.float64()),
+    cost_total: v.optional(v.float64()),
+    last_active_at: v.optional(v.number()),
+    output_preview: v.optional(v.string()),
+    stop_reason: v.optional(v.string()),
+    // Relationships
+    task_id: v.optional(v.string()), // UUID ref to tasks
+    project_slug: v.optional(v.string()), // extracted from session_key
+    file_path: v.optional(v.string()), // path to session JSON file
+    created_at: v.optional(v.number()),
+    updated_at: v.number(),
+  })
+    .index("by_uuid", ["id"])
+    .index("by_session_key", ["session_key"])
+    .index("by_status", ["status"])
+    .index("by_project", ["project_slug"])
+    .index("by_type", ["session_type"])
+    .index("by_task", ["task_id"]),
 })

--- a/convex/sessions.ts
+++ b/convex/sessions.ts
@@ -1,0 +1,656 @@
+import { query, mutation } from './_generated/server'
+import { v } from 'convex/values'
+import { generateId } from './_helpers'
+
+// ============================================
+// Types
+// ============================================
+
+export type SessionType = 'main' | 'chat' | 'agent' | 'cron'
+export type SessionStatus = 'active' | 'idle' | 'completed' | 'stale'
+
+export interface Session {
+  id: string
+  session_key: string
+  session_id: string
+  session_type: SessionType
+  model: string | null
+  provider: string | null
+  status: SessionStatus
+  tokens_input: number | null
+  tokens_output: number | null
+  tokens_cache_read: number | null
+  tokens_cache_write: number | null
+  tokens_total: number | null
+  cost_input: number | null
+  cost_output: number | null
+  cost_cache_read: number | null
+  cost_cache_write: number | null
+  cost_total: number | null
+  last_active_at: number | null
+  output_preview: string | null
+  stop_reason: string | null
+  task_id: string | null
+  project_slug: string | null
+  file_path: string | null
+  created_at: number | null
+  updated_at: number
+}
+
+export interface SessionInput {
+  session_key: string
+  session_id: string
+  session_type: SessionType
+  model?: string
+  provider?: string
+  status: SessionStatus
+  tokens_input?: number
+  tokens_output?: number
+  tokens_cache_read?: number
+  tokens_cache_write?: number
+  tokens_total?: number
+  cost_input?: number
+  cost_output?: number
+  cost_cache_read?: number
+  cost_cache_write?: number
+  cost_total?: number
+  last_active_at?: number
+  output_preview?: string
+  stop_reason?: string
+  task_id?: string
+  project_slug?: string
+  file_path?: string
+  created_at?: number
+  updated_at: number
+}
+
+// ============================================
+// Helper Functions
+// ============================================
+
+/**
+ * Extract project_slug from session_key.
+ * Pattern: agent:main:trap:{slug}:{chatId} -> slug
+ * Falls back to undefined if pattern doesn't match.
+ */
+function extractProjectSlug(sessionKey: string): string | undefined {
+  // Pattern: agent:main:trap:{slug}:{chatId} or similar trap:slug patterns
+  const trapMatch = sessionKey.match(/:trap:([^:]+)/)
+  if (trapMatch) {
+    return trapMatch[1]
+  }
+  return undefined
+}
+
+// ============================================
+// Queries
+// ============================================
+
+/**
+ * Get a single session by session_key
+ */
+export const get = query({
+  args: { sessionKey: v.string() },
+  handler: async (ctx, args): Promise<Session | null> => {
+    const session = await ctx.db
+      .query('sessions')
+      .withIndex('by_session_key', (q) => q.eq('session_key', args.sessionKey))
+      .unique()
+
+    if (!session) {
+      return null
+    }
+
+    return {
+      id: session.id,
+      session_key: session.session_key,
+      session_id: session.session_id,
+      session_type: session.session_type as SessionType,
+      model: session.model ?? null,
+      provider: session.provider ?? null,
+      status: session.status as SessionStatus,
+      tokens_input: session.tokens_input ?? null,
+      tokens_output: session.tokens_output ?? null,
+      tokens_cache_read: session.tokens_cache_read ?? null,
+      tokens_cache_write: session.tokens_cache_write ?? null,
+      tokens_total: session.tokens_total ?? null,
+      cost_input: session.cost_input ?? null,
+      cost_output: session.cost_output ?? null,
+      cost_cache_read: session.cost_cache_read ?? null,
+      cost_cache_write: session.cost_cache_write ?? null,
+      cost_total: session.cost_total ?? null,
+      last_active_at: session.last_active_at ?? null,
+      output_preview: session.output_preview ?? null,
+      stop_reason: session.stop_reason ?? null,
+      task_id: session.task_id ?? null,
+      project_slug: session.project_slug ?? null,
+      file_path: session.file_path ?? null,
+      created_at: session.created_at ?? null,
+      updated_at: session.updated_at,
+    }
+  },
+})
+
+/**
+ * Get session(s) by task_id
+ */
+export const getByTask = query({
+  args: {
+    taskId: v.string(),
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, args): Promise<Session[]> => {
+    let sessions = await ctx.db
+      .query('sessions')
+      .withIndex('by_task', (q) => q.eq('task_id', args.taskId))
+      .collect()
+
+    if (args.limit) {
+      sessions = sessions.slice(0, args.limit)
+    }
+
+    return sessions.map((s) => ({
+      id: s.id,
+      session_key: s.session_key,
+      session_id: s.session_id,
+      session_type: s.session_type as SessionType,
+      model: s.model ?? null,
+      provider: s.provider ?? null,
+      status: s.status as SessionStatus,
+      tokens_input: s.tokens_input ?? null,
+      tokens_output: s.tokens_output ?? null,
+      tokens_cache_read: s.tokens_cache_read ?? null,
+      tokens_cache_write: s.tokens_cache_write ?? null,
+      tokens_total: s.tokens_total ?? null,
+      cost_input: s.cost_input ?? null,
+      cost_output: s.cost_output ?? null,
+      cost_cache_read: s.cost_cache_read ?? null,
+      cost_cache_write: s.cost_cache_write ?? null,
+      cost_total: s.cost_total ?? null,
+      last_active_at: s.last_active_at ?? null,
+      output_preview: s.output_preview ?? null,
+      stop_reason: s.stop_reason ?? null,
+      task_id: s.task_id ?? null,
+      project_slug: s.project_slug ?? null,
+      file_path: s.file_path ?? null,
+      created_at: s.created_at ?? null,
+      updated_at: s.updated_at,
+    }))
+  },
+})
+
+/**
+ * Get all sessions for a project_slug
+ */
+export const getForProject = query({
+  args: {
+    projectSlug: v.string(),
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, args): Promise<Session[]> => {
+    let sessions = await ctx.db
+      .query('sessions')
+      .withIndex('by_project', (q) => q.eq('project_slug', args.projectSlug))
+      .collect()
+
+    if (args.limit) {
+      sessions = sessions.slice(0, args.limit)
+    }
+
+    return sessions.map((s) => ({
+      id: s.id,
+      session_key: s.session_key,
+      session_id: s.session_id,
+      session_type: s.session_type as SessionType,
+      model: s.model ?? null,
+      provider: s.provider ?? null,
+      status: s.status as SessionStatus,
+      tokens_input: s.tokens_input ?? null,
+      tokens_output: s.tokens_output ?? null,
+      tokens_cache_read: s.tokens_cache_read ?? null,
+      tokens_cache_write: s.tokens_cache_write ?? null,
+      tokens_total: s.tokens_total ?? null,
+      cost_input: s.cost_input ?? null,
+      cost_output: s.cost_output ?? null,
+      cost_cache_read: s.cost_cache_read ?? null,
+      cost_cache_write: s.cost_cache_write ?? null,
+      cost_total: s.cost_total ?? null,
+      last_active_at: s.last_active_at ?? null,
+      output_preview: s.output_preview ?? null,
+      stop_reason: s.stop_reason ?? null,
+      task_id: s.task_id ?? null,
+      project_slug: s.project_slug ?? null,
+      file_path: s.file_path ?? null,
+      created_at: s.created_at ?? null,
+      updated_at: s.updated_at,
+    }))
+  },
+})
+
+/**
+ * List sessions with optional filters
+ */
+export const list = query({
+  args: {
+    status: v.optional(v.union(
+      v.literal('active'),
+      v.literal('idle'),
+      v.literal('completed'),
+      v.literal('stale')
+    )),
+    sessionType: v.optional(v.union(
+      v.literal('main'),
+      v.literal('chat'),
+      v.literal('agent'),
+      v.literal('cron')
+    )),
+    projectSlug: v.optional(v.string()),
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, args): Promise<Session[]> => {
+    let sessions
+
+    // Use the most specific index available
+    if (args.projectSlug) {
+      sessions = await ctx.db
+        .query('sessions')
+        .withIndex('by_project', (q) => q.eq('project_slug', args.projectSlug))
+        .collect()
+    } else if (args.status) {
+      sessions = await ctx.db
+        .query('sessions')
+        .withIndex('by_status', (q) => q.eq('status', args.status))
+        .collect()
+    } else if (args.sessionType) {
+      sessions = await ctx.db
+        .query('sessions')
+        .withIndex('by_type', (q) => q.eq('session_type', args.sessionType))
+        .collect()
+    } else {
+      sessions = await ctx.db.query('sessions').collect()
+    }
+
+    // Apply additional filters in memory
+    if (args.status && args.projectSlug) {
+      sessions = sessions.filter((s) => s.status === args.status)
+    }
+    if (args.sessionType) {
+      if (args.projectSlug || args.status) {
+        sessions = sessions.filter((s) => s.session_type === args.sessionType)
+      }
+    }
+
+    // Sort by updated_at descending (most recent first)
+    sessions = sessions.sort((a, b) => b.updated_at - a.updated_at)
+
+    if (args.limit) {
+      sessions = sessions.slice(0, args.limit)
+    }
+
+    return sessions.map((s) => ({
+      id: s.id,
+      session_key: s.session_key,
+      session_id: s.session_id,
+      session_type: s.session_type as SessionType,
+      model: s.model ?? null,
+      provider: s.provider ?? null,
+      status: s.status as SessionStatus,
+      tokens_input: s.tokens_input ?? null,
+      tokens_output: s.tokens_output ?? null,
+      tokens_cache_read: s.tokens_cache_read ?? null,
+      tokens_cache_write: s.tokens_cache_write ?? null,
+      tokens_total: s.tokens_total ?? null,
+      cost_input: s.cost_input ?? null,
+      cost_output: s.cost_output ?? null,
+      cost_cache_read: s.cost_cache_read ?? null,
+      cost_cache_write: s.cost_cache_write ?? null,
+      cost_total: s.cost_total ?? null,
+      last_active_at: s.last_active_at ?? null,
+      output_preview: s.output_preview ?? null,
+      stop_reason: s.stop_reason ?? null,
+      task_id: s.task_id ?? null,
+      project_slug: s.project_slug ?? null,
+      file_path: s.file_path ?? null,
+      created_at: s.created_at ?? null,
+      updated_at: s.updated_at,
+    }))
+  },
+})
+
+// ============================================
+// Mutations
+// ============================================
+
+/**
+ * Upsert a session by session_key.
+ * Creates if doesn't exist, updates if it does.
+ */
+export const upsert = mutation({
+  args: {
+    sessionKey: v.string(),
+    sessionId: v.string(),
+    sessionType: v.union(v.literal('main'), v.literal('chat'), v.literal('agent'), v.literal('cron')),
+    status: v.union(v.literal('active'), v.literal('idle'), v.literal('completed'), v.literal('stale')),
+    model: v.optional(v.string()),
+    provider: v.optional(v.string()),
+    tokensInput: v.optional(v.number()),
+    tokensOutput: v.optional(v.number()),
+    tokensCacheRead: v.optional(v.number()),
+    tokensCacheWrite: v.optional(v.number()),
+    tokensTotal: v.optional(v.number()),
+    costInput: v.optional(v.float64()),
+    costOutput: v.optional(v.float64()),
+    costCacheRead: v.optional(v.float64()),
+    costCacheWrite: v.optional(v.float64()),
+    costTotal: v.optional(v.float64()),
+    lastActiveAt: v.optional(v.number()),
+    outputPreview: v.optional(v.string()),
+    stopReason: v.optional(v.string()),
+    taskId: v.optional(v.string()),
+    projectSlug: v.optional(v.string()),
+    filePath: v.optional(v.string()),
+    createdAt: v.optional(v.number()),
+  },
+  handler: async (ctx, args): Promise<Session> => {
+    const now = Date.now()
+
+    // Try to find existing session
+    const existing = await ctx.db
+      .query('sessions')
+      .withIndex('by_session_key', (q) => q.eq('session_key', args.sessionKey))
+      .unique()
+
+    // Extract project_slug from session_key if not provided
+    const projectSlug = args.projectSlug ?? extractProjectSlug(args.sessionKey)
+
+    if (existing) {
+      // Update existing session
+      await ctx.db.patch(existing._id, {
+        session_id: args.sessionId,
+        session_type: args.sessionType,
+        status: args.status,
+        model: args.model,
+        provider: args.provider,
+        tokens_input: args.tokensInput,
+        tokens_output: args.tokensOutput,
+        tokens_cache_read: args.tokensCacheRead,
+        tokens_cache_write: args.tokensCacheWrite,
+        tokens_total: args.tokensTotal,
+        cost_input: args.costInput,
+        cost_output: args.costOutput,
+        cost_cache_read: args.costCacheRead,
+        cost_cache_write: args.costCacheWrite,
+        cost_total: args.costTotal,
+        last_active_at: args.lastActiveAt,
+        output_preview: args.outputPreview,
+        stop_reason: args.stopReason,
+        task_id: args.taskId,
+        project_slug: projectSlug,
+        file_path: args.filePath,
+        updated_at: now,
+      })
+
+      return {
+        id: existing.id,
+        session_key: args.sessionKey,
+        session_id: args.sessionId,
+        session_type: args.sessionType,
+        model: args.model ?? null,
+        provider: args.provider ?? null,
+        status: args.status,
+        tokens_input: args.tokensInput ?? null,
+        tokens_output: args.tokensOutput ?? null,
+        tokens_cache_read: args.tokensCacheRead ?? null,
+        tokens_cache_write: args.tokensCacheWrite ?? null,
+        tokens_total: args.tokensTotal ?? null,
+        cost_input: args.costInput ?? null,
+        cost_output: args.costOutput ?? null,
+        cost_cache_read: args.costCacheRead ?? null,
+        cost_cache_write: args.costCacheWrite ?? null,
+        cost_total: args.costTotal ?? null,
+        last_active_at: args.lastActiveAt ?? null,
+        output_preview: args.outputPreview ?? null,
+        stop_reason: args.stopReason ?? null,
+        task_id: args.taskId ?? null,
+        project_slug: projectSlug ?? null,
+        file_path: args.filePath ?? null,
+        created_at: existing.created_at ?? null,
+        updated_at: now,
+      }
+    } else {
+      // Create new session
+      const id = generateId()
+      const createdAt = args.createdAt ?? now
+
+      await ctx.db.insert('sessions', {
+        id,
+        session_key: args.sessionKey,
+        session_id: args.sessionId,
+        session_type: args.sessionType,
+        status: args.status,
+        model: args.model,
+        provider: args.provider,
+        tokens_input: args.tokensInput,
+        tokens_output: args.tokensOutput,
+        tokens_cache_read: args.tokensCacheRead,
+        tokens_cache_write: args.tokensCacheWrite,
+        tokens_total: args.tokensTotal,
+        cost_input: args.costInput,
+        cost_output: args.costOutput,
+        cost_cache_read: args.costCacheRead,
+        cost_cache_write: args.costCacheWrite,
+        cost_total: args.costTotal,
+        last_active_at: args.lastActiveAt,
+        output_preview: args.outputPreview,
+        stop_reason: args.stopReason,
+        task_id: args.taskId,
+        project_slug: projectSlug,
+        file_path: args.filePath,
+        created_at: createdAt,
+        updated_at: now,
+      })
+
+      return {
+        id,
+        session_key: args.sessionKey,
+        session_id: args.sessionId,
+        session_type: args.sessionType,
+        model: args.model ?? null,
+        provider: args.provider ?? null,
+        status: args.status,
+        tokens_input: args.tokensInput ?? null,
+        tokens_output: args.tokensOutput ?? null,
+        tokens_cache_read: args.tokensCacheRead ?? null,
+        tokens_cache_write: args.tokensCacheWrite ?? null,
+        tokens_total: args.tokensTotal ?? null,
+        cost_input: args.costInput ?? null,
+        cost_output: args.costOutput ?? null,
+        cost_cache_read: args.costCacheRead ?? null,
+        cost_cache_write: args.costCacheWrite ?? null,
+        cost_total: args.costTotal ?? null,
+        last_active_at: args.lastActiveAt ?? null,
+        output_preview: args.outputPreview ?? null,
+        stop_reason: args.stopReason ?? null,
+        task_id: args.taskId ?? null,
+        project_slug: projectSlug ?? null,
+        file_path: args.filePath ?? null,
+        created_at: createdAt,
+        updated_at: now,
+      }
+    }
+  },
+})
+
+/**
+ * Batch upsert multiple sessions.
+ * Used by the watcher for batched writes.
+ */
+export const batchUpsert = mutation({
+  args: {
+    sessions: v.array(v.object({
+      sessionKey: v.string(),
+      sessionId: v.string(),
+      sessionType: v.union(v.literal('main'), v.literal('chat'), v.literal('agent'), v.literal('cron')),
+      status: v.union(v.literal('active'), v.literal('idle'), v.literal('completed'), v.literal('stale')),
+      model: v.optional(v.string()),
+      provider: v.optional(v.string()),
+      tokensInput: v.optional(v.number()),
+      tokensOutput: v.optional(v.number()),
+      tokensCacheRead: v.optional(v.number()),
+      tokensCacheWrite: v.optional(v.number()),
+      tokensTotal: v.optional(v.number()),
+      costInput: v.optional(v.float64()),
+      costOutput: v.optional(v.float64()),
+      costCacheRead: v.optional(v.float64()),
+      costCacheWrite: v.optional(v.float64()),
+      costTotal: v.optional(v.float64()),
+      lastActiveAt: v.optional(v.number()),
+      outputPreview: v.optional(v.string()),
+      stopReason: v.optional(v.string()),
+      taskId: v.optional(v.string()),
+      projectSlug: v.optional(v.string()),
+      filePath: v.optional(v.string()),
+      createdAt: v.optional(v.number()),
+    })),
+  },
+  handler: async (ctx, args): Promise<{ count: number; errors: string[] }> => {
+    const now = Date.now()
+    const errors: string[] = []
+    let count = 0
+
+    for (const session of args.sessions) {
+      try {
+        // Try to find existing session
+        const existing = await ctx.db
+          .query('sessions')
+          .withIndex('by_session_key', (q) => q.eq('session_key', session.sessionKey))
+          .unique()
+
+        // Extract project_slug from session_key if not provided
+        const projectSlug = session.projectSlug ?? extractProjectSlug(session.sessionKey)
+
+        if (existing) {
+          // Update existing session
+          await ctx.db.patch(existing._id, {
+            session_id: session.sessionId,
+            session_type: session.sessionType,
+            status: session.status,
+            model: session.model,
+            provider: session.provider,
+            tokens_input: session.tokensInput,
+            tokens_output: session.tokensOutput,
+            tokens_cache_read: session.tokensCacheRead,
+            tokens_cache_write: session.tokensCacheWrite,
+            tokens_total: session.tokensTotal,
+            cost_input: session.costInput,
+            cost_output: session.costOutput,
+            cost_cache_read: session.costCacheRead,
+            cost_cache_write: session.costCacheWrite,
+            cost_total: session.costTotal,
+            last_active_at: session.lastActiveAt,
+            output_preview: session.outputPreview,
+            stop_reason: session.stopReason,
+            task_id: session.taskId,
+            project_slug: projectSlug,
+            file_path: session.filePath,
+            updated_at: now,
+          })
+        } else {
+          // Create new session
+          const id = generateId()
+          const createdAt = session.createdAt ?? now
+
+          await ctx.db.insert('sessions', {
+            id,
+            session_key: session.sessionKey,
+            session_id: session.sessionId,
+            session_type: session.sessionType,
+            status: session.status,
+            model: session.model,
+            provider: session.provider,
+            tokens_input: session.tokensInput,
+            tokens_output: session.tokensOutput,
+            tokens_cache_read: session.tokensCacheRead,
+            tokens_cache_write: session.tokensCacheWrite,
+            tokens_total: session.tokensTotal,
+            cost_input: session.costInput,
+            cost_output: session.costOutput,
+            cost_cache_read: session.costCacheRead,
+            cost_cache_write: session.costCacheWrite,
+            cost_total: session.costTotal,
+            last_active_at: session.lastActiveAt,
+            output_preview: session.outputPreview,
+            stop_reason: session.stopReason,
+            task_id: session.taskId,
+            project_slug: projectSlug,
+            file_path: session.filePath,
+            created_at: createdAt,
+            updated_at: now,
+          })
+        }
+        count++
+      } catch (error) {
+        errors.push(`Failed to upsert ${session.sessionKey}: ${error instanceof Error ? error.message : String(error)}`)
+      }
+    }
+
+    return { count, errors }
+  },
+})
+
+/**
+ * Remove a session by session_key
+ */
+export const remove = mutation({
+  args: { sessionKey: v.string() },
+  handler: async (ctx, args): Promise<boolean> => {
+    const session = await ctx.db
+      .query('sessions')
+      .withIndex('by_session_key', (q) => q.eq('session_key', args.sessionKey))
+      .unique()
+
+    if (!session) {
+      return false
+    }
+
+    await ctx.db.delete(session._id)
+    return true
+  },
+})
+
+/**
+ * Remove stale sessions (not updated in N hours)
+ */
+export const removeStale = mutation({
+  args: {
+    hours: v.number(), // Remove sessions not updated in this many hours
+    dryRun: v.optional(v.boolean()), // If true, return count without deleting
+  },
+  handler: async (ctx, args): Promise<{ deleted: number; sessionKeys: string[] }> => {
+    const cutoff = Date.now() - (args.hours * 60 * 60 * 1000)
+
+    // Get all sessions
+    const allSessions = await ctx.db.query('sessions').collect()
+
+    // Filter to stale ones
+    const staleSessions = allSessions.filter((s) => s.updated_at < cutoff)
+
+    const sessionKeys: string[] = []
+
+    if (!args.dryRun) {
+      for (const session of staleSessions) {
+        await ctx.db.delete(session._id)
+        sessionKeys.push(session.session_key)
+      }
+    } else {
+      for (const session of staleSessions) {
+        sessionKeys.push(session.session_key)
+      }
+    }
+
+    return {
+      deleted: staleSessions.length,
+      sessionKeys,
+    }
+  },
+})


### PR DESCRIPTION
Ticket: 741729c3-3a9e-4f95-b984-f31ae9505730

## Summary
Create a new Convex  table that stores data for ALL OpenClaw sessions (main, chat, agent, cron).

## Changes
- **Schema**: Added  table to  with all indexes
- **Mutations/Queries**: Created  with:
  - Queries: , , , 
  - Mutations: , , , 
- **Types**: Exported , ,  types
- **Auto-extraction**:  is auto-extracted from  pattern

## Testing
- TypeScript compiles (
> trap-6@0.1.0 typecheck /home/dan/src/trap-worktrees/fix/741729c3
> tsc --noEmit)
- Lint passes (
> trap-6@0.1.0 lint /home/dan/src/trap-worktrees/fix/741729c3
> eslint


/home/dan/src/trap-worktrees/fix/741729c3/app/api/prompts/seed/route.ts
  15:28  warning  '_request' is defined but never used  @typescript-eslint/no-unused-vars

/home/dan/src/trap-worktrees/fix/741729c3/app/api/tasks/[id]/complete/route.ts
  49:11  warning  'now' is assigned a value but never used  @typescript-eslint/no-unused-vars

/home/dan/src/trap-worktrees/fix/741729c3/components/agents/create-agent-wizard.tsx
   10:62  warning  'Code' is defined but never used                 @typescript-eslint/no-unused-vars
   10:68  warning  'Users' is defined but never used                @typescript-eslint/no-unused-vars
   10:75  warning  'Eye' is defined but never used                  @typescript-eslint/no-unused-vars
  245:9   warning  'canProceed' is assigned a value but never used  @typescript-eslint/no-unused-vars

/home/dan/src/trap-worktrees/fix/741729c3/components/chat/chat-input.tsx
   57:10  warning  'contextUpdateTrigger' is assigned a value but never used                                                                                                                                                                                                                                @typescript-eslint/no-unused-vars
  305:6   warning  React Hook useEffect has a missing dependency: 'images'. Either include it or remove the dependency array                                                                                                                                                                                react-hooks/exhaustive-deps
  317:17  warning  Using `<img>` could result in slower LCP and higher bandwidth. Consider using `<Image />` from `next/image` or a custom image loader to automatically optimize images. This may incur additional usage or cost from your provider. See: https://nextjs.org/docs/messages/no-img-element  @next/next/no-img-element

/home/dan/src/trap-worktrees/fix/741729c3/components/chat/new-issue-dialog.tsx
  362:23  warning  Using `<img>` could result in slower LCP and higher bandwidth. Consider using `<Image />` from `next/image` or a custom image loader to automatically optimize images. This may incur additional usage or cost from your provider. See: https://nextjs.org/docs/messages/no-img-element  @next/next/no-img-element

/home/dan/src/trap-worktrees/fix/741729c3/components/feature-builder/steps/task-breakdown-step.tsx
  603:6  warning  React Hook useCallback has a missing dependency: 'data.qaValidation'. Either include it or remove the dependency array  react-hooks/exhaustive-deps

/home/dan/src/trap-worktrees/fix/741729c3/components/session-provider.tsx
  24:22  warning  '_refreshIntervalMs' is defined but never used  @typescript-eslint/no-unused-vars

/home/dan/src/trap-worktrees/fix/741729c3/components/sessions/session-table.tsx
   35:3   warning  Unused eslint-disable directive (no problems were reported from 'react-hooks/exhaustive-deps')
   38:6   warning  React Hook useMemo has an unnecessary dependency: 'tickingTime'. Either exclude it or remove the dependency array                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        react-hooks/exhaustive-deps
  622:17  warning  Compilation Skipped: Use of incompatible library

This API returns functions which cannot be memoized without leading to stale UI. To prevent this, by default React Compiler will skip memoizing this component/hook. However, you may see issues if values from this API are passed to other components/hooks that are memoized.

/home/dan/src/trap-worktrees/fix/741729c3/components/sessions/session-table.tsx:622:17
  620 |   const columns = getColumns(tickingTime);
  621 |
> 622 |   const table = useReactTable({
      |                 ^^^^^^^^^^^^^ TanStack Table's `useReactTable()` API returns functions that cannot be memoized safely
  623 |     data,
  624 |     columns,
  625 |     state: {  react-hooks/incompatible-library

/home/dan/src/trap-worktrees/fix/741729c3/components/sessions/transcript-message.tsx
  3:10  warning  'formatDistanceToNow' is defined but never used  @typescript-eslint/no-unused-vars

/home/dan/src/trap-worktrees/fix/741729c3/components/ui/avatar.tsx
  25:7  warning  Using `<img>` could result in slower LCP and higher bandwidth. Consider using `<Image />` from `next/image` or a custom image loader to automatically optimize images. This may incur additional usage or cost from your provider. See: https://nextjs.org/docs/messages/no-img-element  @next/next/no-img-element

/home/dan/src/trap-worktrees/fix/741729c3/components/ui/tabs.tsx
  3:37  warning  'useState' is defined but never used  @typescript-eslint/no-unused-vars

/home/dan/src/trap-worktrees/fix/741729c3/convex/_generated/api.js
  1:1  warning  Unused eslint-disable directive (no problems were reported)

/home/dan/src/trap-worktrees/fix/741729c3/convex/_generated/dataModel.d.ts
  1:1  warning  Unused eslint-disable directive (no problems were reported)

/home/dan/src/trap-worktrees/fix/741729c3/convex/_generated/server.d.ts
  1:1  warning  Unused eslint-disable directive (no problems were reported)

/home/dan/src/trap-worktrees/fix/741729c3/convex/_generated/server.js
  1:1  warning  Unused eslint-disable directive (no problems were reported)

/home/dan/src/trap-worktrees/fix/741729c3/convex/promptMetrics.ts
  333:3  warning  '_computedAt' is defined but never used  @typescript-eslint/no-unused-vars

/home/dan/src/trap-worktrees/fix/741729c3/instrumentation.ts
  6:10  warning  'getConvexClient' is defined but never used  @typescript-eslint/no-unused-vars
  7:10  warning  'api' is defined but never used              @typescript-eslint/no-unused-vars

/home/dan/src/trap-worktrees/fix/741729c3/lib/hooks/use-openclaw-http.ts
   26:32  warning  '_refreshIntervalMs' is assigned a value but never used  @typescript-eslint/no-unused-vars
   26:60  warning  '_shouldPoll' is assigned a value but never used         @typescript-eslint/no-unused-vars
  180:39  warning  '_agentId' is defined but never used                     @typescript-eslint/no-unused-vars
  184:43  warning  '_agentId' is defined but never used                     @typescript-eslint/no-unused-vars
  188:46  warning  '_agentId' is defined but never used                     @typescript-eslint/no-unused-vars
  188:64  warning  '_content' is defined but never used                     @typescript-eslint/no-unused-vars
  192:50  warning  '_agentId' is defined but never used                     @typescript-eslint/no-unused-vars
  196:49  warning  '_agentId' is defined but never used                     @typescript-eslint/no-unused-vars
  196:67  warning  '_filePath' is defined but never used                    @typescript-eslint/no-unused-vars
  200:52  warning  '_agentId' is defined but never used                     @typescript-eslint/no-unused-vars
  200:70  warning  '_filePath' is defined but never used                    @typescript-eslint/no-unused-vars
  200:89  warning  '_content' is defined but never used                     @typescript-eslint/no-unused-vars
  204:42  warning  '_params' is defined but never used                      @typescript-eslint/no-unused-vars
  208:48  warning  '_agentId' is defined but never used                     @typescript-eslint/no-unused-vars
  208:66  warning  '_config' is defined but never used                      @typescript-eslint/no-unused-vars

/home/dan/src/trap-worktrees/fix/741729c3/lib/openclaw/api.ts
   99:10  warning  'calculateContextPercentage' is defined but never used  @typescript-eslint/no-unused-vars
  162:12  warning  '_error' is defined but never used                      @typescript-eslint/no-unused-vars

/home/dan/src/trap-worktrees/fix/741729c3/lib/slash-commands.ts
  170:36  warning  'sessionKey' is defined but never used             @typescript-eslint/no-unused-vars
  296:10  warning  'getModelContextWindow' is defined but never used  @typescript-eslint/no-unused-vars

/home/dan/src/trap-worktrees/fix/741729c3/lib/stores/project-store.ts
  35:59  warning  'get' is defined but never used  @typescript-eslint/no-unused-vars

/home/dan/src/trap-worktrees/fix/741729c3/lib/stores/session-store.ts
  110:30  warning  '_isInitialLoad' is assigned a value but never used  @typescript-eslint/no-unused-vars

/home/dan/src/trap-worktrees/fix/741729c3/worker/agent-manager.ts
  105:5  warning  '_spawnedAt' is defined but never used  @typescript-eslint/no-unused-vars

/home/dan/src/trap-worktrees/fix/741729c3/worker/gateway-client.ts
   55:7   warning  'RECONNECT_DELAY_MS' is assigned a value but never used  @typescript-eslint/no-unused-vars
  359:16  warning  'req' is assigned a value but never used                 @typescript-eslint/no-unused-vars

✖ 49 problems (0 errors, 49 warnings)
  0 errors and 5 warnings potentially fixable with the `--fix` option.)
- All pre-commit hooks pass

## Deployment
The Convex dev server is already running at . The schema will be picked up automatically on hot reload.