### PR TITLE
fix: task detail modal scrolling for all tabs

### DIFF
--- a/components/board/task-modal.tsx
+++ b/components/board/task-modal.tsx
@@ -502,7 +502,7 @@ export function TaskModal({ task, open, onOpenChange, onDelete }: TaskModalProps
                   {/* Main content */}
                   <div className="flex-1 min-h-0 flex flex-col overflow-hidden">
                     {/* Description Tab */}
-                    <TabsContent value="description" className="mt-0 flex-1 flex flex-col min-h-0">
+                    <TabsContent value="description" className="mt-0 flex-1 flex flex-col min-h-0 overflow-hidden">
                       {isEditingDescription ? (
                         <textarea
                           value={description}
@@ -514,13 +514,13 @@ export function TaskModal({ task, open, onOpenChange, onDelete }: TaskModalProps
                             }
                           }}
                           placeholder="Add a description..."
-                          className="w-full flex-1 min-h-[200px] bg-[var(--bg-primary)] border border-[var(--border)] rounded-lg px-3 py-2 text-sm text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus:outline-none focus:border-[var(--accent-blue)] resize-y"
+                          className="w-full flex-1 min-h-0 bg-[var(--bg-primary)] border border-[var(--border)] rounded-lg px-3 py-2 text-sm text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus:outline-none focus:border-[var(--accent-blue)] resize-none"
                           autoFocus
                         />
                       ) : (
                         <div
                           onClick={() => setIsEditingDescription(true)}
-                          className="w-full flex-1 min-h-[200px] bg-[var(--bg-primary)] border border-transparent hover:border-[var(--border)] rounded-lg px-4 py-3 cursor-text group transition-colors overflow-y-auto"
+                          className="w-full flex-1 min-h-0 bg-[var(--bg-primary)] border border-transparent hover:border-[var(--border)] rounded-lg px-4 py-3 cursor-text group transition-colors overflow-y-auto"
                         >
                           {description.trim() ? (
                             <div className="relative">
@@ -542,7 +542,7 @@ export function TaskModal({ task, open, onOpenChange, onDelete }: TaskModalProps
                     </TabsContent>
 
                     {/* Comments Tab */}
-                    <TabsContent value="comments" className="mt-0 h-full flex flex-col">
+                    <TabsContent value="comments" className="mt-0 flex-1 flex flex-col min-h-0 overflow-hidden">
                       {loadingComments ? (
                         <div className="text-sm text-[var(--text-muted)]">Loading comments...</div>
                       ) : (
@@ -556,17 +556,21 @@ export function TaskModal({ task, open, onOpenChange, onDelete }: TaskModalProps
                     </TabsContent>
 
                     {/* Analysis Tab */}
-                    <TabsContent value="analysis" className="mt-0 h-full overflow-y-auto">
-                      <TaskAnalysisContent taskId={task.id} projectSlug={projectSlug} />
+                    <TabsContent value="analysis" className="mt-0 flex-1 flex flex-col min-h-0 overflow-hidden">
+                      <div className="flex-1 overflow-y-auto min-h-0">
+                        <TaskAnalysisContent taskId={task.id} projectSlug={projectSlug} />
+                      </div>
                     </TabsContent>
 
                     {/* History Tab */}
-                    <TabsContent value="history" className="mt-0 h-full overflow-y-auto">
-                      <TaskTimeline 
-                        events={taskEvents} 
-                        isLoading={loadingEvents}
-                        projectSlug={projectSlug}
-                      />
+                    <TabsContent value="history" className="mt-0 flex-1 flex flex-col min-h-0 overflow-hidden">
+                      <div className="flex-1 overflow-y-auto min-h-0">
+                        <TaskTimeline 
+                          events={taskEvents} 
+                          isLoading={loadingEvents}
+                          projectSlug={projectSlug}
+                        />
+                      </div>
                     </TabsContent>
                   </div>
 


### PR DESCRIPTION
Fixes scrolling issues in the task detail modal's content tabs (description, comments, analysis, history).

## Problem
The flex layout chain from the modal root to the tab content panels had a broken height constraint. The `TabsContent` component rendered a plain `<div>` with no flex participation, so `h-full` and `overflow-y-auto` didn't work properly.

## Solution
Added proper flex constraints at every level:
- **TabsContent**: Changed from `h-full` to `flex-1 flex flex-col min-h-0 overflow-hidden` to participate in flex layout
- **Description tab**: Inner container uses `min-h-0` (was `min-h-[200px]`) and `overflow-y-auto`
- **Comments tab**: Updated TabsContent className for consistency
- **Analysis/History tabs**: Wrapped content in `flex-1 overflow-y-auto min-h-0` containers

## Acceptance Criteria
- [x] Description tab scrolls when content exceeds modal height
- [x] Comments tab scrolls (comment input stays fixed at bottom)
- [x] History tab scrolls when there are many events
- [x] Analysis tab scrolls
- [x] Sidebar does NOT scroll with main content (independent)
- [x] Modal never exceeds 95vh

Ticket: 71697542-4adb-4892-98de-358339699515

_Note: This PR requires browser QA to verify scrolling behavior._