### PR TITLE
fix: Analytics tab client-side exception due to chart dimensions

### DIFF
--- a/components/observatory/analytics/cost-breakdown-chart.tsx
+++ b/components/observatory/analytics/cost-breakdown-chart.tsx
@@ -130,7 +130,7 @@ export function CostBreakdownChart({ data, isLoading }: CostBreakdownChartProps)
           <div className="h-4 w-48 bg-muted rounded animate-pulse" />
         </CardHeader>
         <CardContent>
-          <div className="h-[300px] bg-muted rounded animate-pulse" />
+          <div className="h-[300px] min-h-[300px] bg-muted rounded animate-pulse" />
         </CardContent>
       </Card>
     )
@@ -145,7 +145,7 @@ export function CostBreakdownChart({ data, isLoading }: CostBreakdownChartProps)
           <CardDescription>Cost distribution by role</CardDescription>
         </CardHeader>
         <CardContent>
-          <div className="h-[300px] flex flex-col items-center justify-center border-2 border-dashed border-border rounded-lg bg-muted/30">
+          <div className="h-[300px] min-h-[300px] flex flex-col items-center justify-center border-2 border-dashed border-border rounded-lg bg-muted/30">
             <p className="text-muted-foreground text-sm">No cost data available</p>
           </div>
         </CardContent>
@@ -168,8 +168,8 @@ export function CostBreakdownChart({ data, isLoading }: CostBreakdownChartProps)
         </div>
       </CardHeader>
       <CardContent>
-        <div className="h-[300px]">
-          <ResponsiveContainer width="100%" height="100%">
+        <div className="h-[300px] min-h-[300px]">
+          <ResponsiveContainer width="100%" height="100%" minWidth={200} minHeight={200}>
             <PieChart>
               <Pie
                 data={chartData}

--- a/components/observatory/analytics/cycle-time-chart.tsx
+++ b/components/observatory/analytics/cycle-time-chart.tsx
@@ -147,7 +147,7 @@ export function CycleTimeChart({ data, isLoading }: CycleTimeChartProps) {
           <div className="h-4 w-48 bg-muted rounded animate-pulse" />
         </CardHeader>
         <CardContent>
-          <div className="h-[250px] bg-muted rounded animate-pulse" />
+          <div className="h-[250px] min-h-[250px] bg-muted rounded animate-pulse" />
         </CardContent>
       </Card>
     )
@@ -162,7 +162,7 @@ export function CycleTimeChart({ data, isLoading }: CycleTimeChartProps) {
           <CardDescription>Average time spent in each phase</CardDescription>
         </CardHeader>
         <CardContent>
-          <div className="h-[250px] flex flex-col items-center justify-center border-2 border-dashed border-border rounded-lg bg-muted/30">
+          <div className="h-[250px] min-h-[250px] flex flex-col items-center justify-center border-2 border-dashed border-border rounded-lg bg-muted/30">
             <p className="text-muted-foreground text-sm">No cycle time data available</p>
           </div>
         </CardContent>
@@ -185,8 +185,8 @@ export function CycleTimeChart({ data, isLoading }: CycleTimeChartProps) {
         </div>
       </CardHeader>
       <CardContent>
-        <div className="h-[250px]">
-          <ResponsiveContainer width="100%" height="100%">
+        <div className="h-[250px] min-h-[250px]">
+          <ResponsiveContainer width="100%" height="100%" minWidth={200} minHeight={200}>
             <BarChart
               data={chartData}
               layout="vertical"

--- a/components/observatory/analytics/throughput-chart.tsx
+++ b/components/observatory/analytics/throughput-chart.tsx
@@ -105,7 +105,7 @@ export function ThroughputChart({ data, timeRange, showCost = false, isLoading }
           <div className="h-4 w-48 bg-muted rounded animate-pulse" />
         </CardHeader>
         <CardContent>
-          <div className="h-[300px] bg-muted rounded animate-pulse" />
+          <div className="h-[300px] min-h-[300px] bg-muted rounded animate-pulse" />
         </CardContent>
       </Card>
     )
@@ -120,7 +120,7 @@ export function ThroughputChart({ data, timeRange, showCost = false, isLoading }
           <CardDescription>Tasks completed per {timeRange === '24h' ? 'hour' : 'day'}</CardDescription>
         </CardHeader>
         <CardContent>
-          <div className="h-[300px] flex flex-col items-center justify-center border-2 border-dashed border-border rounded-lg bg-muted/30">
+          <div className="h-[300px] min-h-[300px] flex flex-col items-center justify-center border-2 border-dashed border-border rounded-lg bg-muted/30">
             <p className="text-muted-foreground text-sm">No data for selected time range</p>
           </div>
         </CardContent>
@@ -159,8 +159,8 @@ export function ThroughputChart({ data, timeRange, showCost = false, isLoading }
         </div>
       </CardHeader>
       <CardContent>
-        <div className="h-[300px]">
-          <ResponsiveContainer width="100%" height="100%">
+        <div className="h-[300px] min-h-[300px]">
+          <ResponsiveContainer width="100%" height="100%" minWidth={200} minHeight={200}>
             <ChartComponent data={chartData} margin={{ top: 20, right: 30, left: 0, bottom: 5 }}>
               <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" vertical={false} />
               <XAxis


### PR DESCRIPTION
## Problem
The Analytics tab in Observatory was showing a client-side exception when clicked. Console showed warnings about chart dimensions being -1.

## Root Cause
Recharts' ResponsiveContainer tries to measure its parent container before the tab layout has stabilized. When a Radix UI tab becomes active, the content renders before CSS dimensions are computed, causing ResponsiveContainer to receive invalid dimensions.

## Solution
Add explicit minimum dimensions to all chart containers:
- Added `min-h-[300px]` / `min-h-[250px]` CSS classes to chart wrapper divs
- Added `minWidth={200} minHeight={200}` props to ResponsiveContainer components
- Applied consistently across ThroughputChart, CostBreakdownChart, and CycleTimeChart
- Also updated loading state and empty state containers for consistency

## Testing
- TypeScript compiles without errors
- Lint passes (no new warnings)
- Charts now have explicit minimum dimensions even when parent layout is still calculating

Ticket: d0c70a32-98bc-4fef-b3d9-4890a9777463