### PR TITLE
feat: persist board column settings

### DIFF
--- a/app/projects/[slug]/board/page.tsx
+++ b/app/projects/[slug]/board/page.tsx
@@ -74,6 +74,7 @@ export default function BoardPage({ params }: PageProps) {
     <div className="flex-1 flex flex-col min-h-0">
       <Board
         projectId={project.id}
+        projectSlug={slug}
         onTaskClick={handleTaskClick}
         onAddTask={handleAddTask}
       />


### PR DESCRIPTION
Ticket: 36637bf1-aa56-4db1-9f8a-47857c9cba64

## Summary
Board column visibility settings now persist across page reloads using localStorage.

## Changes
- Changed storage key format from  to 
- Settings are per-project (each project slug has its own config)
- Falls back to all columns visible when no saved settings exist
- Added  prop to Board component

## Acceptance Criteria
- [x] Column settings persist across page refreshes
- [x] Settings are per-project (different boards can have different configs)
- [x] Works for column visibility
- [x] Falls back to sensible defaults when no saved settings exist