### PR TITLE
fix: add minWidth/minHeight to chart ResponsiveContainers

### DIFF
--- a/components/observatory/prompts/before-after-chart.tsx
+++ b/components/observatory/prompts/before-after-chart.tsx
@@ -93,7 +93,7 @@ export function BeforeAfterChart({ analyses, promptVersions }: BeforeAfterChartP
         Before / After Version Changes
       </h3>
       <div style={{ width: '100%', height: Math.max(200, transitions.length * 60 + 60) }}>
-        <ResponsiveContainer>
+        <ResponsiveContainer width="100%" height="100%" minWidth={200} minHeight={200}>
           <BarChart
             data={data}
             layout="vertical"

--- a/components/observatory/prompts/success-rate-chart.tsx
+++ b/components/observatory/prompts/success-rate-chart.tsx
@@ -84,7 +84,7 @@ export function SuccessRateChart({ analyses }: SuccessRateChartProps) {
         Success Rate Over Time
       </h3>
       <div style={{ width: '100%', height: 300 }}>
-        <ResponsiveContainer>
+        <ResponsiveContainer width="100%" height="100%" minWidth={200} minHeight={200}>
           <LineChart data={data} margin={{ top: 5, right: 20, left: 0, bottom: 5 }}>
             <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" />
             <XAxis

--- a/components/observatory/prompts/token-efficiency-chart.tsx
+++ b/components/observatory/prompts/token-efficiency-chart.tsx
@@ -90,7 +90,7 @@ export function TokenEfficiencyChart({ analyses, promptVersions }: TokenEfficien
         Token Efficiency by Role & Version
       </h3>
       <div style={{ width: '100%', height: 300 }}>
-        <ResponsiveContainer>
+        <ResponsiveContainer width="100%" height="100%" minWidth={200} minHeight={200}>
           <BarChart data={data} margin={{ top: 5, right: 20, left: 0, bottom: 5 }}>
             <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" />
             <XAxis


### PR DESCRIPTION
## Summary
Adds explicit `width`, `height`, `minWidth`, and `minHeight` props to `ResponsiveContainer` components in Observatory prompts charts to prevent console warnings about negative dimensions during initial render/hydration.

## Changes
- **before-after-chart.tsx**: Added `width="100%" height="100%" minWidth={200} minHeight={200}` to ResponsiveContainer
- **success-rate-chart.tsx**: Added `width="100%" height="100%" minWidth={200} minHeight={200}` to ResponsiveContainer  
- **token-efficiency-chart.tsx**: Added `width="100%" height="100%" minWidth={200} minHeight={200}` to ResponsiveContainer

## Why
The ResponsiveContainer from recharts may render before its parent container has measurable dimensions, particularly during SSR or initial client-side hydration. This causes console warnings like:
> The width(-1) and height(-1) of chart should be greater than 0

The analytics charts already had these props; this PR adds them to the prompts charts for consistency.

## Ticket
Ticket: c7f07ba1-9e5a-497f-b3c2-a450ef97b211

## Testing
- Type check passes
- Lint passes (no new errors)
