### PR TITLE
feat: message delivery indicators (sending/sent/processing/failed)

### DIFF
--- a/components/chat/chat-thread.tsx
+++ b/components/chat/chat-thread.tsx
@@ -34,6 +34,7 @@ interface ChatThreadProps {
   activeCrons?: SubAgentDetails[]
   projectSlug?: string
   hasMore?: boolean
+  onRetryMessage?: (message: ChatMessage) => void
 }
 
 // Threshold in pixels for considering the user "at the bottom"
@@ -52,6 +53,7 @@ export function ChatThread({
   activeCrons = [],
   projectSlug,
   hasMore = false,
+  onRetryMessage,
 }: ChatThreadProps) {
   const bottomRef = useRef<HTMLDivElement>(null)
   const containerRef = useRef<HTMLDivElement>(null)
@@ -300,6 +302,12 @@ export function ChatThread({
               const prevGroup = groupedMessages[groupIndex - 1]
               prevMessage = prevGroup.messages[prevGroup.messages.length - 1]
             }
+
+            // Calculate the absolute index in the visible messages array
+            let messageIndex = msgIndex
+            for (let i = 0; i < groupIndex; i++) {
+              messageIndex += groupedMessages[i].messages.length
+            }
             
             return (
               <MessageBubble
@@ -311,6 +319,9 @@ export function ChatThread({
                 activeCrons={activeCrons}
                 projectSlug={projectSlug}
                 prevMessage={prevMessage}
+                allMessages={visibleMessages}
+                messageIndex={messageIndex}
+                onRetryMessage={onRetryMessage}
               />
             )
           })}

--- a/components/chat/delivery-status.tsx
+++ b/components/chat/delivery-status.tsx
@@ -1,0 +1,142 @@
+"use client"
+
+import { useState, useEffect, useCallback } from "react"
+import { Loader2, Check, X, RotateCcw } from "lucide-react"
+import type { DeliveryStatus, ChatMessage } from "@/lib/types"
+
+interface DeliveryStatusIndicatorProps {
+  status?: DeliveryStatus
+  sentAt?: number | null
+  deliveredAt?: number | null
+  failureReason?: string | null
+  onRetry?: () => void
+  hasResponse?: boolean  // True if agent has responded (to fade out indicator)
+}
+
+export function DeliveryStatusIndicator({
+  status,
+  sentAt,
+  deliveredAt,
+  failureReason,
+  onRetry,
+  hasResponse = false,
+}: DeliveryStatusIndicatorProps) {
+  const [isVisible, setIsVisible] = useState(true)
+  const [isFading, setIsFading] = useState(false)
+
+  // Fade out indicators after response arrives
+  useEffect(() => {
+    if (hasResponse && status && status !== "failed") {
+      const fadeTimer = setTimeout(() => {
+        setIsFading(true)
+        setTimeout(() => setIsVisible(false), 500) // Wait for fade animation
+      }, 5000) // 5 seconds after response arrives
+
+      return () => clearTimeout(fadeTimer)
+    }
+  }, [hasResponse, status])
+
+  const handleRetry = useCallback(() => {
+    if (onRetry) {
+      onRetry()
+    }
+  }, [onRetry])
+
+  if (!isVisible || !status) {
+    return null
+  }
+
+  const baseClasses = `
+    flex items-center gap-1.5 text-xs mt-1 ml-auto w-fit
+    transition-opacity duration-500
+    ${isFading ? "opacity-0" : "opacity-100"}
+    ${status === "failed" ? "text-red-500" : "text-muted-foreground"}
+  `
+
+  switch (status) {
+    case "sending":
+      return (
+        <div className={baseClasses}>
+          <Loader2 className="h-3 w-3 animate-spin" />
+          <span className="text-[var(--text-muted)]">Sending...</span>
+        </div>
+      )
+
+    case "sent":
+      return (
+        <div className={baseClasses}>
+          <Check className="h-3 w-3 text-[var(--text-muted)]" />
+          <span className="text-[var(--text-muted)]">Sent</span>
+          {deliveredAt && sentAt && (
+            <span className="text-[10px] text-[var(--text-muted)]/60">
+              ({Math.round((deliveredAt - sentAt) / 100)}ms)
+            </span>
+          )}
+        </div>
+      )
+
+    case "processing":
+      return (
+        <div className={baseClasses}>
+          <div className="flex">
+            <Check className="h-3 w-3 text-blue-500" />
+            <Check className="h-3 w-3 text-blue-500 -ml-1.5" />
+          </div>
+          <span className="text-blue-500">Processing</span>
+        </div>
+      )
+
+    case "failed":
+      return (
+        <div className={baseClasses}>
+          <X className="h-3 w-3 text-red-500" />
+          <span className="text-red-500">Failed</span>
+          {failureReason && (
+            <span className="text-[10px] text-red-400/80 max-w-[200px] truncate" title={failureReason}>
+              {failureReason}
+            </span>
+          )}
+          {onRetry && (
+            <button
+              onClick={handleRetry}
+              className="flex items-center gap-1 text-blue-500 hover:text-blue-600 hover:underline ml-1"
+            >
+              <RotateCcw className="h-3 w-3" />
+              Retry
+            </button>
+          )}
+        </div>
+      )
+
+    default:
+      return null
+  }
+}
+
+// Hook to track if a response has arrived for a given message
+export function useHasResponse(
+  messages: ChatMessage[],
+  messageIndex: number
+): boolean {
+  // A response has arrived if there's a message after this one from a different author
+  // that was created after this message
+  if (messageIndex >= messages.length - 1) return false
+
+  const currentMessage = messages[messageIndex]
+  if (!currentMessage) return false
+
+  // Look for any message after this one from a different author
+  for (let i = messageIndex + 1; i < messages.length; i++) {
+    const nextMessage = messages[i]
+    if (
+      nextMessage &&
+      nextMessage.author !== currentMessage.author &&
+      nextMessage.author !== "system" &&
+      nextMessage.created_at >= currentMessage.created_at
+    ) {
+      return true
+    }
+  }
+
+  return false
+}

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -154,6 +154,16 @@ export default defineSchema({
     run_id: v.optional(v.string()),
     session_key: v.optional(v.string()),
     is_automated: v.optional(v.boolean()),
+    // Delivery status tracking
+    delivery_status: v.optional(v.union(
+      v.literal("sending"),
+      v.literal("sent"),
+      v.literal("processing"),
+      v.literal("failed")
+    )),
+    sent_at: v.optional(v.number()), // timestamp when send initiated
+    delivered_at: v.optional(v.number()), // timestamp when HTTP 200 received
+    failure_reason: v.optional(v.string()),
     created_at: v.number(),
   })
     .index("by_uuid", ["id"])

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -120,6 +120,8 @@ export interface Chat {
   updated_at: number
 }
 
+export type DeliveryStatus = "sending" | "sent" | "processing" | "failed"
+
 export interface ChatMessage {
   id: string
   chat_id: string
@@ -128,6 +130,11 @@ export interface ChatMessage {
   run_id?: string | null
   session_key?: string | null
   is_automated?: number | null  // SQLite boolean (0/1) - true for cron/sub-agent messages
+  // Delivery status tracking
+  delivery_status?: DeliveryStatus
+  sent_at?: number | null       // timestamp when send initiated
+  delivered_at?: number | null  // timestamp when HTTP 200 received
+  failure_reason?: string | null
   created_at: number
 }
 


### PR DESCRIPTION
Ticket: 096884fb-5c42-478e-aeb2-df12f281835e

## Summary
Add delivery status indicators to sent messages in the chat UI, like iMessage or WhatsApp. Users can now see whether their message was received and whether the agent is working on it.

## Changes
- Added \delivery_status\, \sent_at\, \delivered_at\, \failure_reason\ fields to ChatMessage type and Convex schema
- Created new DeliveryStatusIndicator component with visual states:
  - ⏳ Sending: HTTP POST in flight
  - ✓ Sent: HTTP 200 received from OpenClaw
  - ✓✓ Processing: Session activity detected (last_active_at updated)
  - ✗ Failed: HTTP error with retry button
- Added retry functionality for failed messages
- Indicators fade out ~5 seconds after agent response arrives
- Works for both main session and project chat sessions

## Visual Design
- Small, subtle indicators below message bubbles (right-aligned)
- Muted colors that don't compete with message content
- Spinner for sending, checkmarks for sent/processing, red X for failed