### PR TITLE
fix: switch work-loop Sonnet roles to OpenAI models

### DIFF
--- a/worker/children.test.ts
+++ b/worker/children.test.ts
@@ -87,12 +87,12 @@ describe("ChildManager", () => {
         projectId: "proj-456",
         role: "dev",
         message: "Do work",
-        model: "claude-sonnet",
+        model: "gpt",
       })
 
       expect(mockSpawnFn).toHaveBeenCalledWith(
         "openclaw",
-        ["chat", "--message", "Do work", "--model", "claude-sonnet"],
+        ["chat", "--message", "Do work", "--model", "gpt"],
         expect.any(Object)
       )
     })

--- a/worker/phases/review.ts
+++ b/worker/phases/review.ts
@@ -70,7 +70,7 @@ interface PRInfo {
  *    c. Check if reviewer child already running
  *    d. If PR exists and no reviewer running → spawn reviewer
  * 3. Build reviewer prompt using role template
- * 4. Spawn via ChildManager with role="reviewer", model="sonnet"
+ * 4. Spawn via ChildManager with role="reviewer", model="gpt"
  */
 export async function runReview(ctx: ReviewContext): Promise<ReviewResult> {
   const { convex, agents, config, cycle, project } = ctx
@@ -411,7 +411,7 @@ async function processTask(ctx: ReviewContext, task: Task): Promise<TaskProcessR
       projectId: project.id,
       role: "reviewer",
       message: prompt,
-      model: "sonnet",
+      model: "gpt",
       timeoutSeconds: 600,
     })
 
@@ -426,7 +426,7 @@ async function processTask(ctx: ReviewContext, task: Task): Promise<TaskProcessR
       await convex.mutation(api.task_events.logAgentAssigned, {
         taskId: task.id,
         sessionKey: handle.sessionKey,
-        model: "sonnet",
+        model: "gpt",
         role: "reviewer",
       })
     } catch (updateError) {

--- a/worker/phases/work.ts
+++ b/worker/phases/work.ts
@@ -69,8 +69,10 @@ function sortTasks(tasks: Task[]): Task[] {
 // ============================================
 
 const ROLE_MODEL_MAP: Record<string, string> = {
-  pm: "sonnet",
-  research: "sonnet",
+  // Use OpenAI models for non-coding roles to avoid Anthropic rate limits.
+  // Keep Anthropic capacity for Ada + Penny.
+  pm: "gpt",
+  research: "gpt",
   reviewer: "moonshot/kimi-for-coding",
   dev: "moonshot/kimi-for-coding",
 }


### PR DESCRIPTION
Anthropic is getting rate limited; reserve Anthropic tokens for Ada + Penny.

Changes:
- Work loop role→model mapping: pm/research now use .
- Review phase spawns reviewer with  instead of .
- Updated child manager tests accordingly.

Notes:
- This changes only work-loop default models; UI can still manually select Sonnet if desired.