### PR TITLE
fix: Feature Builder session creation 500 error

### DIFF
--- a/app/api/feature-builder/session/route.test.ts
+++ b/app/api/feature-builder/session/route.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from "vitest"
+import { POST, PATCH, DELETE } from "./route"
+import { NextRequest } from "next/server"
+
+describe("POST /api/feature-builder/session", () => {
+  it("should return 400 when project_id is missing", async () => {
+    // Set environment variable for this test
+    const originalUrl = process.env.CONVEX_URL
+    process.env.CONVEX_URL = "http://localhost:3210"
+
+    const request = new NextRequest("http://localhost:3002/api/feature-builder/session", {
+      method: "POST",
+      body: JSON.stringify({}),
+    })
+
+    const response = await POST(request)
+    expect(response.status).toBe(400)
+    const body = await response.json()
+    expect(body.error).toContain("project_id is required")
+
+    // Restore environment
+    process.env.CONVEX_URL = originalUrl
+  })
+
+  it("should return 500 when neither CONVEX_URL nor NEXT_PUBLIC_CONVEX_URL is set", async () => {
+    // Temporarily remove environment variables
+    const originalUrl = process.env.CONVEX_URL
+    const originalPublicUrl = process.env.NEXT_PUBLIC_CONVEX_URL
+    delete process.env.CONVEX_URL
+    delete process.env.NEXT_PUBLIC_CONVEX_URL
+
+    const request = new NextRequest("http://localhost:3002/api/feature-builder/session", {
+      method: "POST",
+      body: JSON.stringify({ project_id: "project-123" }),
+    })
+
+    const response = await POST(request)
+    expect(response.status).toBe(500)
+    const body = await response.json()
+    expect(body.error).toContain("not configured")
+
+    // Restore environment
+    process.env.CONVEX_URL = originalUrl
+    process.env.NEXT_PUBLIC_CONVEX_URL = originalPublicUrl
+  })
+})
+
+describe("PATCH /api/feature-builder/session", () => {
+  it("should return 400 when id is missing", async () => {
+    const originalUrl = process.env.CONVEX_URL
+    process.env.CONVEX_URL = "http://localhost:3210"
+
+    const request = new NextRequest("http://localhost:3002/api/feature-builder/session", {
+      method: "PATCH",
+      body: JSON.stringify({ current_step: "overview" }),
+    })
+
+    const response = await PATCH(request)
+    expect(response.status).toBe(400)
+    const body = await response.json()
+    expect(body.error).toContain("id is required")
+
+    process.env.CONVEX_URL = originalUrl
+  })
+})
+
+describe("DELETE /api/feature-builder/session", () => {
+  it("should return 400 when id is missing", async () => {
+    const originalUrl = process.env.CONVEX_URL
+    process.env.CONVEX_URL = "http://localhost:3210"
+
+    const request = new NextRequest("http://localhost:3002/api/feature-builder/session", {
+      method: "DELETE",
+      body: JSON.stringify({ action: "cancel" }),
+    })
+
+    const response = await DELETE(request)
+    expect(response.status).toBe(400)
+    const body = await response.json()
+    expect(body.error).toContain("id is required")
+
+    process.env.CONVEX_URL = originalUrl
+  })
+
+  it("should return 400 for invalid action", async () => {
+    const originalUrl = process.env.CONVEX_URL
+    process.env.CONVEX_URL = "http://localhost:3210"
+
+    const request = new NextRequest("http://localhost:3002/api/feature-builder/session", {
+      method: "DELETE",
+      body: JSON.stringify({ id: "session-123", action: "invalid" }),
+    })
+
+    const response = await DELETE(request)
+    expect(response.status).toBe(400)
+    const body = await response.json()
+    expect(body.error).toContain("Invalid action")
+
+    process.env.CONVEX_URL = originalUrl
+  })
+})

--- a/app/api/feature-builder/session/route.ts
+++ b/app/api/feature-builder/session/route.ts
@@ -4,11 +4,10 @@ import { ConvexHttpClient } from "convex/browser"
 // Session management for Feature Builder
 // Stores sessions in Convex for reference and analytics
 
-const convexUrl = process.env.NEXT_PUBLIC_CONVEX_URL
-
 function getConvexClient() {
+  const convexUrl = process.env.CONVEX_URL || process.env.NEXT_PUBLIC_CONVEX_URL
   if (!convexUrl) {
-    throw new Error("NEXT_PUBLIC_CONVEX_URL is not configured")
+    throw new Error("CONVEX_URL or NEXT_PUBLIC_CONVEX_URL is not configured")
   }
   return new ConvexHttpClient(convexUrl)
 }


### PR DESCRIPTION
Ticket: 3724ad56-b8e2-4b83-9942-b25d2b3a380d

## Problem
POST /api/feature-builder/session was returning 500 because it only checked NEXT_PUBLIC_CONVEX_URL, but the server environment only sets CONVEX_URL.

## Fix
Updated the route to check both CONVEX_URL and NEXT_PUBLIC_CONVEX_URL (with CONVEX_URL taking precedence), matching the pattern used in lib/convex/server.ts.

## Changes
- Fixed environment variable lookup in app/api/feature-builder/session/route.ts
- Added unit tests for route handlers

## Testing
- All existing tests pass
- New regression tests added and passing
- TypeScript and lint checks pass