### PR TITLE
feat: switch work-loop default models from Sonnet to GPT

### DIFF
--- a/worker/phases/review.ts
+++ b/worker/phases/review.ts
@@ -70,7 +70,7 @@ interface PRInfo {
  *    c. Check if reviewer child already running
  *    d. If PR exists and no reviewer running → spawn reviewer
  * 3. Build reviewer prompt using role template
- * 4. Spawn via ChildManager with role="reviewer", model="sonnet"
+ * 4. Spawn via ChildManager with role="reviewer", model="gpt"
  */
 export async function runReview(ctx: ReviewContext): Promise<ReviewResult> {
   const { convex, agents, config, cycle, project } = ctx
@@ -411,7 +411,7 @@ async function processTask(ctx: ReviewContext, task: Task): Promise<TaskProcessR
       projectId: project.id,
       role: "reviewer",
       message: prompt,
-      model: "sonnet",
+      model: "gpt",
       timeoutSeconds: 600,
     })
 
@@ -426,7 +426,7 @@ async function processTask(ctx: ReviewContext, task: Task): Promise<TaskProcessR
       await convex.mutation(api.task_events.logAgentAssigned, {
         taskId: task.id,
         sessionKey: handle.sessionKey,
-        model: "sonnet",
+        model: "gpt",
         role: "reviewer",
       })
     } catch (updateError) {

--- a/worker/phases/work.ts
+++ b/worker/phases/work.ts
@@ -69,8 +69,8 @@ function sortTasks(tasks: Task[]): Task[] {
 // ============================================
 
 const ROLE_MODEL_MAP: Record<string, string> = {
-  pm: "sonnet",
-  research: "sonnet",
+  pm: "gpt",
+  research: "gpt",
   reviewer: "moonshot/kimi-for-coding",
   dev: "moonshot/kimi-for-coding",
 }


### PR DESCRIPTION
Ticket: 8135ad01-89cc-4916-9e60-bd2d2349f35e

## Summary
Change default models for work-loop automated agents from Anthropic Sonnet to OpenAI GPT to avoid Anthropic rate limits. Anthropic models are now reserved for Ada + Penny.

## Changes
- **work.ts ROLE_MODEL_MAP:**
  - `pm` role: sonnet → gpt
  - `research` role: sonnet → gpt
- **review.ts reviewer spawn:**
  - Reviewer model: sonnet → gpt
  - Updated logged model in `logAgentAssigned` to match

## Verification
- [x] TypeScript compiles (`pnpm typecheck`)
- [x] Lint passes (`pnpm lint`)
- [x] All tests pass (`pnpm test`)