### PR TITLE
feat: reduce vertical space in chat composer footer

### DIFF
--- a/components/chat/chat-input.tsx
+++ b/components/chat/chat-input.tsx
@@ -312,10 +312,10 @@ export function ChatInput({
   const hasContent = content.trim() || images.length > 0
 
   return (
-    <div className="border-t border-[var(--border)] p-3 md:p-4">
+    <div className="border-t border-[var(--border)] p-2 md:p-3">
       {/* Image previews */}
       {images.length > 0 && (
-        <div className="mb-3 flex flex-wrap gap-2">
+        <div className="mb-2 flex flex-wrap gap-2">
           {images.map(image => (
             <div key={image.id} className="relative group">
               <div className="relative w-20 h-20 rounded-lg overflow-hidden border border-[var(--border)]">
@@ -360,7 +360,7 @@ export function ChatInput({
 
       {/* Slash command indicator (shown when not using autocomplete or for unknown commands) */}
       {slashCommandMode.active && !showAutocomplete && (
-        <div className={`mb-2 flex items-center gap-2 text-xs px-2 py-1.5 rounded-lg ${slashCommandMode.valid ? 'bg-[var(--accent-blue)]/10 text-[var(--accent-blue)]' : 'bg-amber-500/10 text-amber-600 dark:text-amber-400'}`}>
+        <div className={`mb-1.5 flex items-center gap-2 text-xs px-2 py-1 rounded-lg ${slashCommandMode.valid ? 'bg-[var(--accent-blue)]/10 text-[var(--accent-blue)]' : 'bg-amber-500/10 text-amber-600 dark:text-amber-400'}`}>
           {slashCommandMode.valid ? (
             <>
               <Command className="h-3.5 w-3.5" />
@@ -437,14 +437,14 @@ export function ChatInput({
       </div>
 
       {/* Context indicator */}
-      <div className="mt-2 md:mt-3 mb-1 md:mb-2">
+      <div className="mt-1.5 md:mt-2">
         <ContextIndicator
           sessionKey={sessionKey}
           projectId={projectId}
         />
       </div>
 
-      <p className="text-xs text-[var(--text-muted)] hidden md:block">
+      <p className="text-xs text-[var(--text-muted)] hidden md:block mt-1">
         Press Enter to send, Shift+Enter for newline • Paste images with Cmd+V • Use /help for commands
       </p>
     </div>

--- a/components/chat/context-indicator.tsx
+++ b/components/chat/context-indicator.tsx
@@ -91,56 +91,43 @@ export function ContextIndicator({
   const displayModel = model?.split("/").pop() || model
 
   return (
-    <div className="flex flex-col gap-1 text-xs text-[var(--text-muted)]">
-      {/* Main token display with progress bar */}
-      <div className="flex items-center gap-2">
-        <span>Context:</span>
-        <span className="font-medium">
-          {formatTokenCount(tokens)}
-          {contextWindow > 0 && ` / ${formatTokenCount(contextWindow)} (${percentage}%)`}
-        </span>
+    <div className="flex items-center gap-2 text-[10px] text-[var(--text-muted)]">
+      {/* Compact single-line layout */}
+      <span className="font-medium">{formatTokenCount(tokens)}</span>
 
-        {/* Progress bar */}
-        {contextWindow > 0 && (
-          <div className="w-16 h-1.5 bg-[var(--border)] rounded-full overflow-hidden">
-            <div
-              className={`h-full rounded-full transition-all ${getProgressColor(percentage)}`}
-              style={{ width: `${Math.min(percentage, 100)}%` }}
-            />
-          </div>
-        )}
+      {/* Progress bar */}
+      {contextWindow > 0 && (
+        <div className="w-12 h-1 bg-[var(--border)] rounded-full overflow-hidden flex-shrink-0">
+          <div
+            className={`h-full rounded-full transition-all ${getProgressColor(percentage)}`}
+            style={{ width: `${Math.min(percentage, 100)}%` }}
+          />
+        </div>
+      )}
 
-        {isLoading && (
-          <span className="text-[var(--text-muted)]/70">loading...</span>
-        )}
-      </div>
-
-      {/* Token breakdown */}
-      <div className="flex items-center gap-2 text-[10px] text-[var(--text-muted)]/70">
-        <span>In: {formatTokenCount(tokensInput)}</span>
-        <span>·</span>
-        <span>Out: {formatTokenCount(tokensOutput)}</span>
+      <span className="text-[var(--text-muted)]/70">
+        {percentage}% · In {formatTokenCount(tokensInput)} · Out {formatTokenCount(tokensOutput)}
         {(tokensCacheRead > 0 || tokensCacheWrite > 0) && (
-          <>
-            <span>·</span>
-            <span>Cache: +{formatTokenCount(tokensCacheRead)}/-{formatTokenCount(tokensCacheWrite)}</span>
-          </>
+          <span> · Cache +{formatTokenCount(tokensCacheRead)}/-{formatTokenCount(tokensCacheWrite)}</span>
         )}
         {cost && cost > 0 && (
-          <>
-            <span>·</span>
-            <span className="text-green-500/80">{formatCost(cost)}</span>
-          </>
+          <span className="text-green-500/80"> · {formatCost(cost)}</span>
         )}
-      </div>
+      </span>
 
-      {/* Model info */}
+      <span className="text-[var(--text-muted)]/50">
+        ·
+      </span>
+
+      {/* Model info - compact */}
       {(displayModel || provider) && (
-        <div className="flex items-center gap-1 text-[10px] text-[var(--text-muted)]/60">
-          {provider && <span>{provider}</span>}
-          {provider && displayModel && <span>/</span>}
-          {displayModel && <span className="font-mono">{displayModel}</span>}
-        </div>
+        <span className="text-[var(--text-muted)]/60 font-mono truncate max-w-[120px]">
+          {provider && `${provider}/`}{displayModel}
+        </span>
+      )}
+
+      {isLoading && (
+        <span className="text-[var(--text-muted)]/50">loading...</span>
       )}
     </div>
   )

--- a/components/chat/pipeline-status.tsx
+++ b/components/chat/pipeline-status.tsx
@@ -172,7 +172,7 @@ export function PipelineStatus({
 
   return (
     <TooltipProvider>
-      <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-[var(--bg-secondary)] border border-[var(--border)]">
+      <div className="flex items-center gap-2 px-2.5 py-1.5 rounded-lg bg-[var(--bg-secondary)] border border-[var(--border)] mb-2">
         <span className={`flex items-center gap-2 text-sm ${config.className}`}>
           {config.icon}
           <span>{config.text}</span>


### PR DESCRIPTION
## Summary
Reduces vertical space in the chat composer area to show more message history without scrolling.

## Changes
- **ChatInput container**: Reduced padding from `p-3/4` to `p-2/3`
- **ContextIndicator**: Collapsed from 3 rows to a single compact line
  - Reduced font size to `text-[10px]`
  - Combined context, tokens, and model info on one line
  - Smaller progress bar (w-12 instead of w-16)
- **PipelineStatus**: Added `mb-2` margin and reduced padding
- **Slash command indicator**: Reduced margin and padding
- **Context indicator wrapper**: Reduced margins from `mt-2/3 mb-1/2` to `mt-1.5/2`

## Before
The composer footer had ~3 rows of context stats with significant padding, taking up ~100px+ of vertical space.

## After
Compact single-line layout with minimal padding, reducing footer height by ~40-50%.

## QA Notes
- [x] Input remains usable (focus ring, multiline, send on Enter)
- [x] Responsive behavior works on narrow widths
- [x] TypeScript compiles
- [x] Lint passes
- [ ] Visual QA needed on desktop and mobile

Ticket: bfc57265-4de8-4275-8b57-fdb670277600