### PR TITLE
fix: restore footer stats block when no session exists

### DIFF
--- a/components/chat/context-indicator.tsx
+++ b/components/chat/context-indicator.tsx
@@ -70,8 +70,19 @@ export function ContextIndicator({
   // Subscribe directly to Convex sessions table
   const { session, isLoading } = useSession(sessionKey)
 
+  // Show placeholder when no session exists yet (e.g., new chat)
   if (!session && !isLoading) {
-    return null
+    return (
+      <div className="flex items-center gap-2 text-[10px] text-[var(--text-muted)]/50">
+        <span className="font-medium">0</span>
+        <div className="w-12 h-1 bg-[var(--border)] rounded-full overflow-hidden flex-shrink-0">
+          <div className="h-full rounded-full bg-green-500" style={{ width: '0%' }} />
+        </div>
+        <span>0% · In 0 · Out 0</span>
+        <span className="text-[var(--text-muted)]/30">·</span>
+        <span className="text-[var(--text-muted)]/40 font-mono">no model</span>
+      </div>
+    )
   }
 
   const tokens = session?.tokens_total ?? 0


### PR DESCRIPTION
Ticket: 209e5481-0cd9-4a9d-a678-b080d43604b2

## Problem
After the chat vertical-space compaction work (PR #475), the footer stats block was not showing when no session existed in the database (e.g., when first opening a chat). The ContextIndicator component was returning , causing only the help text to be visible.

## Solution
Show a compact placeholder state with zeros and 'no model' text when there's no session. This maintains UI consistency while clearly indicating no active session.

## Changes
- Modified  to render a placeholder instead of returning  when no session exists
- Placeholder shows: 
- Keeps the compact styling from the previous PR

## Verification
- Type check passes
- Lint passes (no new warnings)
- UI maintains compact layout while showing placeholder stats