### PR TITLE
fix: prevent 'No activity' banner showing when it's user's turn

### DIFF
--- a/app/projects/[slug]/chat/page.tsx
+++ b/app/projects/[slug]/chat/page.tsx
@@ -67,6 +67,11 @@ export default function ChatPage({ params }: PageProps) {
     getLastActiveChatForProject,
   } = useChatStore()
 
+  // Reset lastSentAt when switching chats to prevent stale "No activity" banner
+  useEffect(() => {
+    setLastSentAt(null)
+  }, [activeChat?.id])
+
   // Generate session key based on project and active chat
   // Format: trap:{projectSlug}:{chatId} - includes project for context
   // Use stored session_key if available, otherwise generate dynamically

--- a/components/chat/pipeline-status.tsx
+++ b/components/chat/pipeline-status.tsx
@@ -73,6 +73,17 @@ export function PipelineStatus({
       return "idle"
     }
 
+    // If no session exists and we're not typing, there's nothing to wait for
+    if (!session && !isAssistantTyping) {
+      return "idle"
+    }
+
+    // If session is in a terminal state, there's nothing to wait for
+    const terminalStates = ['completed', 'error', 'cancelled', 'not_found']
+    if (session?.status && terminalStates.includes(session.status) && !isAssistantTyping) {
+      return "idle"
+    }
+
     // If assistant is actively typing, show responding state
     if (isAssistantTyping) {
       return "responding"


### PR DESCRIPTION
Ticket: 58f100c5-3bfa-4ee5-a9a7-4b685243fc63