### PR TITLE
fix: session links from project Sessions tab open wrong sessions

### DIFF
--- a/components/sessions/sessions-list.tsx
+++ b/components/sessions/sessions-list.tsx
@@ -113,7 +113,12 @@ export function SessionsList({
   const handleRowClick = (sessionKey: string) => {
     if (onSessionClick) {
       onSessionClick(sessionKey);
+    } else if (projectSlug) {
+      // Use project-scoped route when in project context
+      const encodedSessionKey = encodeURIComponent(sessionKey);
+      router.push(`/projects/${projectSlug}/sessions/${encodedSessionKey}`);
     } else {
+      // Use global route for non-project contexts
       const encodedSessionKey = encodeURIComponent(sessionKey);
       router.push(`/sessions/${encodedSessionKey}`);
     }


### PR DESCRIPTION
## Problem
Session log links from the project-scoped Sessions tab were opening the wrong sessions. Clicking a session in /projects/{slug}/sessions would navigate to the global route /sessions/{id} instead of the project-scoped route /projects/{slug}/sessions/{sessionKey}.

## Root Cause
The SessionsList component's handleRowClick function always navigated to the global /sessions/{sessionKey} route, regardless of whether it was being used in a project context.

## Fix
Modified handleRowClick in SessionsList to check for projectSlug:
- When projectSlug is provided → navigate to /projects/{slug}/sessions/{sessionKey}
- When no projectSlug → navigate to /sessions/{sessionKey} (global route)

## Changes
- components/sessions/sessions-list.tsx: Added conditional routing logic

## Testing
- TypeScript compiles (pnpm typecheck)
- Lint passes (pnpm lint)

Ticket: 460e3e95-6d24-4a54-9ac9-a364807dfbb7