### PR TITLE
fix: restore active agent details in Observatory sidebar

### DIFF
--- a/lib/hooks/use-work-loop.ts
+++ b/lib/hooks/use-work-loop.ts
@@ -8,6 +8,7 @@ import type {
   WorkLoopStats,
 } from "@/lib/types/work-loop"
 import type { Task } from "@/lib/types"
+import type { TaskWithAgentSession } from "@/convex/tasks"
 
 /**
  * Reactive Convex subscription for work loop state.
@@ -104,6 +105,32 @@ export function useActiveAgentTasks(
 
   return {
     tasks: result ?? null,
+    isLoading: result === undefined,
+    error: null,
+  }
+}
+
+/**
+ * Reactive Convex subscription for tasks with active agents INCLUDING session data.
+ *
+ * Returns tasks with their associated session details (model, tokens, timing, status)
+ * from the Convex sessions table. This is the preferred hook for displaying
+ * active agent information in the UI.
+ */
+export function useActiveAgentSessions(
+  projectId: string | null
+): {
+  data: TaskWithAgentSession[] | null
+  isLoading: boolean
+  error: Error | null
+} {
+  const result = useQuery(
+    api.tasks.getWithActiveAgentSessions,
+    projectId ? { projectId } : "skip"
+  )
+
+  return {
+    data: result ?? null,
     isLoading: result === undefined,
     error: null,
   }


### PR DESCRIPTION
Ticket: a01afb09-83f5-4ae0-ab23-e0a3f0f0a6d5

## Summary
Restores the missing active agent details in the Observatory sidebar after migration to the Convex 
sessions table architecture.

## Changes
- Added 
getWithActiveAgentSessions
 Convex query that joins tasks with their session data from the sessions table
- Added 
useActiveAgentSessions
 hook for reactive session data fetching
- Updated ActiveAgents component to display:
  - Model name (e.g., claude-sonnet, kimi-k2)
  - Session status indicator (active/idle/completed/stale)
  - Token counts (formatted as k/M)
  - Cost tracking (USD)
  - Duration and last activity timestamps
  - Output preview (latest agent output)
  - Links to both task board and session detail pages

## Testing
- TypeScript compiles without errors
- Lint passes with only pre-existing warnings
- Uses reactive Convex subscriptions for live updates

## Notes
- No direct JSONL file reading from UI - all data sourced from Convex sessions table
- Works with multiple projects simultaneously
- Session data populated by session-watcher worker