### PR TITLE
feat: add hover tooltip on Running status with server details

### DIFF
--- a/app/api/status/route.ts
+++ b/app/api/status/route.ts
@@ -1,0 +1,146 @@
+import { NextResponse } from "next/server"
+import { readFile } from "node:fs/promises"
+import { join } from "node:path"
+
+// Server start time - captured when this module is first loaded
+const SERVER_STARTED_AT = Date.now()
+
+/**
+ * Format milliseconds into a human-readable duration string
+ * e.g., "2h 15m" or "45s"
+ */
+function formatDuration(ms: number): string {
+  const seconds = Math.floor(ms / 1000)
+  const minutes = Math.floor(seconds / 60)
+  const hours = Math.floor(minutes / 60)
+  const days = Math.floor(hours / 24)
+
+  if (days > 0) {
+    const remainingHours = hours % 24
+    return `${days}d ${remainingHours}h`
+  }
+  if (hours > 0) {
+    const remainingMinutes = minutes % 60
+    return `${hours}h ${remainingMinutes}m`
+  }
+  if (minutes > 0) {
+    const remainingSeconds = seconds % 60
+    return `${minutes}m ${remainingSeconds}s`
+  }
+  return `${seconds}s`
+}
+
+/**
+ * Format a timestamp into a relative time string
+ * e.g., "5 minutes ago"
+ */
+function formatRelativeTime(timestamp: number): string {
+  const now = Date.now()
+  const diff = now - timestamp
+  const seconds = Math.floor(diff / 1000)
+  const minutes = Math.floor(seconds / 60)
+  const hours = Math.floor(minutes / 60)
+
+  if (hours > 0) {
+    return `${hours} hour${hours !== 1 ? "s" : ""} ago`
+  }
+  if (minutes > 0) {
+    return `${minutes} minute${minutes !== 1 ? "s" : ""} ago`
+  }
+  return `${seconds} second${seconds !== 1 ? "s" : ""} ago`
+}
+
+/**
+ * Format a timestamp into an absolute time string
+ * e.g., "Feb 8, 2025, 2:42 PM"
+ */
+function formatAbsoluteTime(timestamp: number): string {
+  return new Date(timestamp).toLocaleString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: true,
+  })
+}
+
+/**
+ * Get the current git commit hash
+ */
+async function getGitCommit(): Promise<string | null> {
+  try {
+    // Try to read from .git/HEAD
+    const headPath = join(process.cwd(), ".git", "HEAD")
+    const headContent = await readFile(headPath, "utf-8")
+    const ref = headContent.trim().replace("ref: ", "")
+
+    // Read the actual commit from the ref file
+    const refPath = join(process.cwd(), ".git", ref)
+    const commit = await readFile(refPath, "utf-8")
+    return commit.trim().slice(0, 7)
+  } catch {
+    // Fallback: try to read from packed-refs or return null
+    return null
+  }
+}
+
+/**
+ * Get version info from package.json
+ */
+async function getPackageVersion(): Promise<string | null> {
+  try {
+    const packagePath = join(process.cwd(), "package.json")
+    const content = await readFile(packagePath, "utf-8")
+    const pkg = JSON.parse(content) as { version?: string }
+    return pkg.version ?? null
+  } catch {
+    return null
+  }
+}
+
+export interface ServerStatus {
+  startedAt: number
+  startedAtFormatted: string
+  startedAtRelative: string
+  uptime: number
+  uptimeFormatted: string
+  version: string | null
+  commit: string | null
+  nodeVersion: string
+  platform: string
+}
+
+/**
+ * GET /api/status
+ * Returns server status information including start time, uptime, and version
+ */
+export async function GET(): Promise<NextResponse<ServerStatus | { error: string }>> {
+  try {
+    const now = Date.now()
+    const uptime = now - SERVER_STARTED_AT
+
+    const [commit, version] = await Promise.all([
+      getGitCommit(),
+      getPackageVersion(),
+    ])
+
+    const status: ServerStatus = {
+      startedAt: SERVER_STARTED_AT,
+      startedAtFormatted: formatAbsoluteTime(SERVER_STARTED_AT),
+      startedAtRelative: formatRelativeTime(SERVER_STARTED_AT),
+      uptime,
+      uptimeFormatted: formatDuration(uptime),
+      version,
+      commit,
+      nodeVersion: process.version,
+      platform: process.platform,
+    }
+
+    return NextResponse.json(status)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
+}

--- a/components/observatory/live/status-badge.tsx
+++ b/components/observatory/live/status-badge.tsx
@@ -1,13 +1,25 @@
 "use client"
 
 import { Badge } from "@/components/ui/badge"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
+import { useServerStatus } from "@/lib/hooks/use-server-status"
 import type { WorkLoopStatus, WorkLoopPhase } from "@/lib/types/work-loop"
 
 interface StatusBadgeProps {
   status: WorkLoopStatus
+  /**
+   * When true and status is "running", shows a tooltip with server details
+   * on hover. Defaults to true.
+   */
+  showTooltip?: boolean
 }
 
-export function StatusBadge({ status }: StatusBadgeProps) {
+export function StatusBadge({ status, showTooltip = true }: StatusBadgeProps) {
   const variants: Record<WorkLoopStatus, "default" | "secondary" | "destructive" | "outline"> = {
     running: "default",
     paused: "secondary",
@@ -22,10 +34,95 @@ export function StatusBadge({ status }: StatusBadgeProps) {
     error: "Error",
   }
 
+  // Only show tooltip for running status
+  if (status === "running" && showTooltip) {
+    return (
+      <ServerStatusBadge status={status}>
+        {labels[status]}
+      </ServerStatusBadge>
+    )
+  }
+
   return (
     <Badge variant={variants[status]}>
       {labels[status]}
     </Badge>
+  )
+}
+
+/**
+ * Wrapper component that adds a tooltip with server status details.
+ * Only renders the tooltip when server status data is available.
+ */
+function ServerStatusBadge({
+  children,
+}: {
+  status: WorkLoopStatus
+  children: React.ReactNode
+}) {
+  const { status: serverStatus, isLoading } = useServerStatus()
+
+  const badge = (
+    <Badge variant="default">
+      {children}
+    </Badge>
+  )
+
+  // If loading or no server status, just return the badge without tooltip
+  if (isLoading || !serverStatus) {
+    return badge
+  }
+
+  return (
+    <TooltipProvider delayDuration={100}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          {badge}
+        </TooltipTrigger>
+        <TooltipContent
+          side="bottom"
+          align="start"
+          className="max-w-xs p-3 space-y-2"
+        >
+          <div className="space-y-1">
+            <div className="font-medium text-foreground">Server Status</div>
+            <div className="text-xs text-muted-foreground space-y-1">
+              <div className="flex justify-between gap-4">
+                <span>Started:</span>
+                <span className="font-mono text-foreground">
+                  {serverStatus.startedAtRelative}
+                </span>
+              </div>
+              <div className="flex justify-between gap-4">
+                <span>Uptime:</span>
+                <span className="font-mono text-foreground">
+                  {serverStatus.uptimeFormatted}
+                </span>
+              </div>
+              {serverStatus.commit && (
+                <div className="flex justify-between gap-4">
+                  <span>Commit:</span>
+                  <span className="font-mono text-foreground">
+                    {serverStatus.commit}
+                  </span>
+                </div>
+              )}
+              {serverStatus.version && (
+                <div className="flex justify-between gap-4">
+                  <span>Version:</span>
+                  <span className="font-mono text-foreground">
+                    {serverStatus.version}
+                  </span>
+                </div>
+              )}
+            </div>
+            <div className="pt-1 text-[10px] text-muted-foreground border-t border-border mt-1">
+              {serverStatus.startedAtFormatted}
+            </div>
+          </div>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   )
 }
 

--- a/lib/hooks/use-server-status.ts
+++ b/lib/hooks/use-server-status.ts
@@ -1,0 +1,62 @@
+"use client"
+
+import { useState, useEffect, useCallback } from "react"
+import type { ServerStatus } from "@/app/api/status/route"
+
+interface UseServerStatusReturn {
+  status: ServerStatus | null
+  isLoading: boolean
+  error: Error | null
+  refetch: () => void
+}
+
+/**
+ * Hook to fetch and poll server status information.
+ * 
+ * Returns the current server status including start time, uptime,
+ * version, and git commit. Automatically refreshes every 30 seconds.
+ */
+export function useServerStatus(): UseServerStatusReturn {
+  const [status, setStatus] = useState<ServerStatus | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<Error | null>(null)
+
+  const fetchStatus = useCallback(async () => {
+    try {
+      const response = await fetch("/api/status")
+      if (!response.ok) {
+        throw new Error(`Failed to fetch status: ${response.status}`)
+      }
+      const data = await response.json() as ServerStatus
+      setStatus(data)
+      setError(null)
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error(String(err)))
+    } finally {
+      setIsLoading(false)
+    }
+  }, [])
+
+  // Initial fetch
+  useEffect(() => {
+    fetchStatus()
+  }, [fetchStatus])
+
+  // Poll every 30 seconds to keep uptime current
+  useEffect(() => {
+    const interval = setInterval(fetchStatus, 30000)
+    return () => clearInterval(interval)
+  }, [fetchStatus])
+
+  const refetch = useCallback(() => {
+    setIsLoading(true)
+    fetchStatus()
+  }, [fetchStatus])
+
+  return {
+    status,
+    isLoading,
+    error,
+    refetch,
+  }
+}


### PR DESCRIPTION
## Summary

Adds a hover tooltip to the "Running" status badge in the Observatory that displays useful server information.

## Changes

- **New API endpoint** `GET /api/status` - Returns server start time, uptime (formatted), git commit hash, version from package.json, node version, and platform
- **New hook** `useServerStatus()` - Fetches server status and polls every 30 seconds to keep uptime current
- **Updated `StatusBadge` component** - When status is "Running", the badge now has a tooltip showing:
  - Server start time (relative, e.g. "5 minutes ago")
  - Current uptime (e.g. "2h 15m")
  - Git commit hash (short)
  - Version from package.json
  - Absolute timestamp at the bottom

## Testing

- Hover over the "Running" badge in the Observatory Live tab
- Tooltip should appear with server details
- Uptime updates automatically every 30 seconds

## Ticket

Ticket: 39eecf71-db8e-42e1-a6bb-81e95a9ca341