### PR TITLE
docs: update README for Feb 2026 project state

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,16 @@ AI agent orchestration system where Ada serves as coordinator for specialized su
 
 ```bash
 # Install dependencies
-npm install
+pnpm install
 
 # Run development server
-npm run dev
+pnpm dev
 
 # Build for production
-npm run build
+pnpm build
 
 # Run production server
-PORT=3002 npm run start
+PORT=3002 pnpm start
 ```
 
 **Dev URL:** http://192.168.7.200:3002  
@@ -24,31 +24,195 @@ PORT=3002 npm run start
 ## Architecture
 
 ### Core Concept
-- **Ada (Opus)** - Coordinator agent, maintains state via board
+- **Ada (Coordinator)** - Main agent that triages and delegates to sub-agents
 - **Worker Agents** - Stateless, fresh session per task (kimi-coder, sonnet-reviewer, haiku-triage)
-- **Board** - Convex-backed task management (replaces GitHub Projects)
+- **Trap Board** - Convex-backed task management (replaces GitHub Projects)
+- **Observatory** - 5-tab dashboard for monitoring and controlling AI agents
 - **Chat** - Bidirectional communication with OpenClaw main session
 
 ### Tech Stack
-- Next.js 15, TypeScript, React 19
+- Next.js 16, TypeScript, React 19
 - Convex (self-hosted) for real-time data
+- Tailwind CSS v4 + shadcn/ui
 - Zustand for state management
-- Tailwind + shadcn/ui
-- Convex reactivity for real-time updates
+- Vitest for testing
+- pnpm for package management
+
+### Process Architecture
+
+Trap runs as **4 separate processes** managed by `run.sh`:
+
+1. **Next.js Server** (`trap-server`) - Serves web UI and API routes (port 3002)
+2. **Work Loop** (`trap-loop`) - Agent orchestration, task scheduling, triage
+3. **Chat Bridge** (`trap-bridge`) - WebSocket client syncing OpenClaw ↔ Convex
+4. **Session Watcher** (`trap-session-watcher`) - Reads OpenClaw JSONL files, upserts to Convex `sessions` table
+
+**Why split:** Running work loop + WebSocket client in Next.js blocked the event loop, causing 30s+ page loads.
+
+**Management:**
+```bash
+./run.sh start      # Build + enable/start all systemd services
+./run.sh stop       # Stop all services
+./run.sh restart    # Stop + start
+./run.sh status     # Show systemd service status
+./run.sh logs       # Tail server logs (journald)
+./run.sh loop-logs  # Tail work loop logs
+./run.sh bridge-logs # Tail chat bridge logs
+./run.sh watcher-logs # Tail session watcher logs
+./run.sh all-logs   # Tail all logs
+```
+
+## Observatory
+
+The **Observatory** is the centralized dashboard that replaced the old work-loop page. It provides a tabbed interface for monitoring and controlling AI agents across projects.
+
+### Routes
+- **Global Observatory:** `/work-loop` - All projects
+- **Per-Project Observatory:** `/projects/[slug]/work-loop` - Locked to single project
+
+### Tabs
+
+1. **Live** - Real-time work-loop monitoring
+   - Active agents and their status
+   - Work-loop statistics and metrics
+   - Recent agent actions and events
+
+2. **Triage** - Blocked task management
+   - Review and unblock stuck tasks
+   - Triage performance metrics
+
+3. **Analytics** - Historical performance data
+   - Cost tracking and visualizations
+   - Agent performance metrics over time
+
+4. **Models** - Model usage and performance
+   - Model comparison and usage stats
+   - Cost per model
+
+5. **Prompts** - Prompt performance analysis
+   - A/B testing results
+   - Prompt version performance
+
+## Work Loop v2
+
+The work loop is Trap's agent orchestration engine. It runs continuously, cycling through phases to manage agent execution across all projects.
+
+### Phases
+
+1. **Cleanup** - Close stale browser tabs, reset transient state
+2. **Triage** - Identify blocked tasks and notify Ada
+3. **Review** - Check completed work, spawn reviewers for PRs
+4. **Work** - Spawn agents for ready tasks
+
+### Agent Roles
+
+| Role | Model | Purpose |
+|------|-------|---------|
+| `dev` | kimi-for-coding | Implement features, fix bugs |
+| `reviewer` | kimi-for-coding | Review PRs, request changes or merge |
+| `pm` | sonnet | Research, plan, write specs |
+| `research` | sonnet | Deep investigation, analysis |
+| `conflict_resolver` | kimi-for-coding | Auto-rebase and resolve merge conflicts |
+
+### Status Flow
+
+```
+backlog → ready → in_progress → in_review → done
+              ↓        ↓
+           blocked ←─┘
+```
+
+- **backlog** - Holding pen for future work
+- **ready** - Available for agents to pick up
+- **in_progress** - Agent actively working
+- **in_review** - PR opened, waiting for review
+- **blocked** - Stuck, needs triage
+- **done** - Completed
+
+### Triage System
+
+When tasks become blocked, the work loop:
+1. Detects blocking conditions (signals, failed agents, conflicts)
+2. Sends batched triage messages to Ada via HTTP
+3. Ada reviews and decides: unblock, reassign, split, or escalate
+4. Circuit breaker: auto-escalates to Dan after 3 triage attempts
+
+### Agent Limits
+
+Configured via environment variables:
+
+```bash
+WORK_LOOP_MAX_AGENTS=4              # Global max concurrent agents
+WORK_LOOP_MAX_AGENTS_PER_PROJECT=3  # Per-project limit
+WORK_LOOP_MAX_DEV_AGENTS=2          # Max dev agents
+WORK_LOOP_MAX_REVIEWER_AGENTS=2     # Max reviewer agents
+```
+
+### Concurrency Tuning (Critical)
+
+Trap's agent limits must match OpenClaw's command lane concurrency:
+
+**In `~/.openclaw/openclaw.json`:**
+```json
+{
+  "agents": {
+    "defaults": {
+      "maxConcurrent": 8
+    }
+  }
+}
+```
+
+If OpenClaw's limit is lower than Trap's, agents will queue and may be falsely reaped ("ghost-completing" with 0 tokens).
+
+**Trap reaper grace period:** Located in `worker/agent-manager.ts`. Recommended: **10 minutes** when running high parallelism.
+
+### Multi-Project Support
+
+The work loop runs for all projects with `work_loop_enabled=1`. Each project needs:
+- `local_path` - Where to create worktrees
+- `github_repo` - For PR operations
+
+Worktree convention: `{project.local_path}-worktrees/fix/{taskId.slice(0,8)}`
 
 ## Database
 
 Trap uses **Convex** (self-hosted) for real-time data synchronization.
 
 ### Tables
-- `projects` - Project metadata, repo links
-- `tasks` - Kanban tasks with status, priority, assignee
+
+**Core:**
+- `projects` - Project metadata, repo links, work loop config
+- `tasks` - Kanban tasks with status, priority, assignee, agent tracking
 - `comments` - Task comments for agent communication
 - `chats` - Chat threads per project
-- `chat_messages` - Chat message history
+- `chatMessages` - Chat message history
+
+**Work Loop:**
+- `workLoopRuns` - Audit log of every loop action
+- `workLoopState` - Current state of each project's loop
+- `task_events` - Detailed audit trail for task transitions
+- `sessions` - Unified tracking for all OpenClaw sessions
+
+**Agent System:**
 - `signals` - Agent signals (questions, blockers, alerts)
+- `taskDependencies` - Task dependency graph
+- `promptVersions` - Versioned role prompt templates
+- `taskAnalyses` - Post-mortem analysis of completed tasks
+- `promptMetrics` - Aggregated performance per role/model/version
+
+**Observatory:**
+- `model_pricing` - Cost per 1M tokens for each model
 - `notifications` - System notifications
 - `events` - Activity log
+
+**Feature Builder:**
+- `features` - High-level feature/epic definitions
+- `requirements` - Individual requirements
+- `roadmapPhases` - GSD-style phase definitions
+- `phaseRequirements` - Phase-to-requirement mappings
+- `featureBuilderSessions` - Feature builder usage tracking
+- `featureBuilderAnalytics` - Aggregated metrics
 
 ### Convex Setup
 
@@ -67,7 +231,7 @@ The Convex URL is configured via `NEXT_PUBLIC_CONVEX_URL` (defaults to `http://1
 
 ### WebSocket Chat
 
-The Trap connects to OpenClaw via WebSocket for real-time chat. The connection uses OpenClaw's protocol v3:
+The Trap connects to OpenClaw via WebSocket for real-time chat.
 
 ```javascript
 // Connect handshake (first message required)
@@ -87,30 +251,6 @@ The Trap connects to OpenClaw via WebSocket for real-time chat. The connection u
     auth: { token: "<OPENCLAW_TOKEN>" }
   }
 }
-
-// RPC request format
-{
-  type: "req",
-  id: "<uuid>",
-  method: "<method>",
-  params: { ... }
-}
-
-// Response format
-{
-  type: "res",
-  id: "<uuid>",
-  ok: true/false,
-  payload: { ... },
-  error: { code, message }
-}
-
-// Event format  
-{
-  type: "event",
-  event: "<event-name>",
-  payload: { ... }
-}
 ```
 
 ### Channel Plugin
@@ -118,11 +258,128 @@ The Trap connects to OpenClaw via WebSocket for real-time chat. The connection u
 The trap-channel plugin enables bidirectional messaging:
 - Plugin location: `plugins/trap-channel.ts`
 - Symlink to: `~/.openclaw/extensions/trap-channel.ts`
-- Manifest: `~/.openclaw/extensions/openclaw.plugin.json`
+
+### Session Tracking
+
+The **session watcher** worker (`worker/session-watcher.ts`) is the only code that reads OpenClaw JSONL session files. It batches/upserts into Convex `sessions` table; everything else reads from Convex. This allows swapping storage later without touching loop/UI.
+
+Agent completion is detected via `stopReason: "stop"` in JSONL files.
+
+## Environment Variables
+
+Create `.env.local`:
+
+```bash
+# OpenClaw API (server-side)
+OPENCLAW_HTTP_URL=http://127.0.0.1:18789
+OPENCLAW_WS_URL=ws://127.0.0.1:18789/ws
+OPENCLAW_TOKEN=<your-gateway-token>
+OPENCLAW_HOOKS_URL=http://localhost:18789/hooks
+OPENCLAW_HOOKS_TOKEN=<your-hooks-token>
+
+# OpenClaw (client-side)
+NEXT_PUBLIC_OPENCLAW_API_URL=http://192.168.7.200:18789
+NEXT_PUBLIC_OPENCLAW_WS_URL=ws://192.168.7.200:18789/ws
+NEXT_PUBLIC_OPENCLAW_TOKEN=<your-gateway-token>
+
+# Convex
+CONVEX_SELF_HOSTED_URL=http://127.0.0.1:3210
+CONVEX_SELF_HOSTED_ADMIN_KEY=<admin-key>
+CONVEX_URL=http://127.0.0.1:3210
+NEXT_PUBLIC_CONVEX_SITE_URL=http://127.0.0.1:3211
+
+# Work Loop
+WORK_LOOP_ENABLED=true
+WORK_LOOP_MAX_AGENTS=4
+WORK_LOOP_MAX_AGENTS_PER_PROJECT=3
+WORK_LOOP_MAX_DEV_AGENTS=2
+WORK_LOOP_MAX_REVIEWER_AGENTS=2
+
+# Server
+PORT=3002
+```
+
+## Project Structure
+
+```
+trap/
+├── app/                          # Next.js app router
+│   ├── api/                      # API routes
+│   │   ├── chats/                # Chat CRUD
+│   │   ├── tasks/                # Task CRUD
+│   │   ├── projects/             # Project CRUD
+│   │   ├── signal/               # Agent signal API
+│   │   ├── triage/               # Triage endpoints
+│   │   ├── prompts/metrics/      # Prompt metrics API
+│   │   └── work-loop/config      # Dynamic work loop config
+│   ├── projects/[slug]/          # Project pages (board, chat, work-loop)
+│   ├── work-loop/                # Global Observatory
+│   ├── prompts/                  # Prompt management
+│   ├── agents/                   # Agent status page
+│   ├── sessions/                 # Session list
+│   └── settings/                 # Settings page
+├── components/                   # React components
+│   ├── board/                    # Kanban board components
+│   ├── chat/                     # Chat UI components
+│   ├── observatory/              # Observatory dashboard
+│   │   ├── live/                 # Live tab components
+│   │   ├── triage/               # Triage tab components
+│   │   ├── analytics/            # Analytics tab components
+│   │   ├── models/               # Models tab components
+│   │   └── prompts/              # Prompts tab components
+│   ├── providers/                # Context providers
+│   └── ui/                       # shadcn/ui components
+├── lib/                          # Library code
+│   ├── api/                      # API utilities
+│   ├── convex/                   # Convex queries/mutations
+│   ├── hooks/                    # React hooks
+│   ├── stores/                   # Zustand stores
+│   ├── types/                    # TypeScript types
+│   └── utils/                    # Utility functions
+├── worker/                       # Background workers
+│   ├── loop.ts                   # Main work loop
+│   ├── agent-manager.ts          # Agent lifecycle management
+│   ├── session-watcher.ts        # Session file monitoring
+│   ├── chat-bridge.ts            # OpenClaw WS bridge
+│   ├── gateway-client.ts         # OpenClaw RPC client
+│   ├── session-file-reader.ts    # JSONL file parsing
+│   ├── decide.ts                 # Loop decision logic
+│   ├── prompts.ts                # Prompt fetching
+│   └── phases/                   # Work loop phases
+│       ├── cleanup.ts
+│       ├── triage.ts
+│       ├── review.ts
+│       └── work.ts
+├── convex/                       # Convex schema and functions
+│   ├── schema.ts                 # Database schema
+│   ├── tasks.ts                  # Task mutations/queries
+│   ├── workLoop.ts               # Work loop state
+│   ├── sessions.ts               # Session tracking
+│   ├── task_events.ts            # Event logging
+│   └── ...
+├── plugins/                      # OpenClaw plugins
+│   ├── trap-channel.ts           # Channel plugin for chat
+│   └── trap-signal.ts            # Signal plugin for notifications
+├── bin/                          # CLI tools
+│   └── trap-cli.ts               # Trap CLI
+├── scripts/                      # Utility scripts
+├── systemd/                      # Systemd service files
+├── run.sh                        # Process management script
+└── roles/                        # Agent role prompts (external)
+```
+
+**Note:** Role prompts are stored in `/home/dan/clawd/roles/` (not in this repo):
+- `dev.md` - Developer agent prompt
+- `reviewer.md` - Reviewer agent prompt
+- `pm.md` - Product manager prompt
+- `research.md` - Researcher prompt
+- `conflict_resolver.md` - Conflict resolver prompt
+- `qa.md` - QA agent prompt
+- `pe.md` - Prompt engineer prompt
 
 ## Nginx Configuration
 
-For HTTPS deployment, WebSocket connections need to be proxied through nginx to avoid mixed-content errors.
+For HTTPS deployment, WebSocket connections need to be proxied through nginx.
 
 Add to nginx custom config (`/data/nginx/custom/server_proxy.conf` in NPM):
 
@@ -150,226 +407,74 @@ After updating, reload nginx:
 docker exec nginx-proxy-manager nginx -t && docker exec nginx-proxy-manager nginx -s reload
 ```
 
-## Environment Variables
-
-Create `.env.local`:
+## Development Commands
 
 ```bash
-# OpenClaw API (server-side)
-OPENCLAW_HOOKS_URL=http://localhost:18789/hooks
-OPENCLAW_HOOKS_TOKEN=<your-hooks-token>
+# Type-check
+pnpm typecheck
 
-# OpenClaw WebSocket (client-side, for HTTP dev only)
-NEXT_PUBLIC_OPENCLAW_WS_URL=ws://192.168.7.200:18789/ws
-NEXT_PUBLIC_OPENCLAW_TOKEN=<your-gateway-token>
+# Lint
+pnpm lint
 
-# For HTTPS, WebSocket URL is auto-detected as wss://<host>/openclaw-ws
+# Run tests
+pnpm test
+
+# Run tests with UI
+pnpm test:ui
+
+# Convex dev mode
+pnpm convex:dev
+
+# Deploy schema changes
+pnpm convex:deploy
 ```
-
-## Work Loop Concurrency Tuning (Important)
-
-Trap can spawn multiple dev/reviewer agents in parallel, but **OpenClaw also has a global concurrency limit** for the `main` command lane.
-
-If you increase Trap's work loop agent limits (e.g. `WORK_LOOP_MAX_AGENTS`), you must also ensure OpenClaw can actually run that many agents concurrently, otherwise agent runs will queue and may appear to "ghost-complete" (no tokens, no JSONL transcript).
-
-### OpenClaw gateway concurrency
-
-In `~/.openclaw/openclaw.json`:
-
-- `agents.defaults.maxConcurrent` — concurrency for the `main` lane (default 4)
-
-For example, to support 6 parallel agents, set it to 8:
-
-```json
-{
-  "agents": {
-    "defaults": {
-      "maxConcurrent": 8
-    }
-  }
-}
-```
-
-### Trap reaper grace period
-
-Trap considers an agent "gone" if its session JSONL file does not appear after a grace period.
-If OpenClaw is queuing work, this grace must be large enough.
-
-See `worker/agent-manager.ts` (look for the comment: "give it time to create its session file").
-
-Recommended (when running high parallelism): **10 minutes**.
-
-## Project Structure
-
-```
-trap/
-├── app/                    # Next.js app router
-│   ├── api/               # API routes
-│   │   ├── chats/         # Chat CRUD
-│   │   ├── tasks/         # Task CRUD
-│   │   ├── projects/      # Project CRUD
-│   │   ├── signal/        # Agent signal API
-│   │   └── gate/          # Wake condition API
-│   └── projects/[slug]/   # Project pages (board, chat, etc)
-├── components/            # React components
-│   ├── board/            # Kanban board components
-│   ├── chat/             # Chat UI components
-│   └── providers/        # Context providers
-├── lib/
-│   ├── db/               # Database (schema, migrations)
-│   ├── hooks/            # React hooks (useOpenClawChat, etc)
-│   └── stores/           # Zustand stores
-├── plugins/              # OpenClaw plugins
-│   └── trap-channel.ts   # Channel plugin for bidirectional chat
-└── bin/
-    └── trap-cli-gate.sh  # Gate script for cron-based wakeups
-```
-
-## Voice Chat Setup
-
-The Trap includes a complete voice chat system with speech-to-text (Whisper) and text-to-speech (Qwen3-TTS) capabilities.
-
-### Prerequisites
-
-**1. OpenAI Whisper (STT)**
-
-Install via pipx for isolated environment:
-```bash
-pipx install openai-whisper
-```
-
-Verify installation:
-```bash
-whisper --help
-# Should show: /home/dan/.local/bin/whisper
-```
-
-**2. Qwen3-TTS (TTS)**
-
-The Ada voice is already set up at `/home/dan/src/qwen3-tts-test/` with:
-- Voice model: `voices/ada_voice.pt`
-- Voice config: `voices/ada_voice.json` 
-- Reference audio: `voices/ada_reference.wav`
-
-Test TTS generation:
-```bash
-cd /home/dan/src/qwen3-tts-test
-uv run python simple_tts.py "Hello, this is a test" --voice ada
-```
-
-**3. FFmpeg (Audio Conversion)**
-
-Should already be installed system-wide:
-```bash
-which ffmpeg
-# Should show: /usr/bin/ffmpeg
-```
-
-If not installed:
-```bash
-sudo apt install ffmpeg  # Ubuntu/Debian
-brew install ffmpeg      # macOS
-```
-
-### Voice Chat Pipeline
-
-The voice chat system processes audio through this pipeline:
-
-1. **Recording**: Browser captures audio via `MediaRecorder` (WebM format)
-2. **Upload**: Audio uploaded to `/api/voice` endpoint
-3. **Conversion**: FFmpeg converts WebM → WAV for Whisper compatibility
-4. **STT**: Whisper transcribes audio to text
-5. **Processing**: Ada generates response (currently prototype echo)
-6. **TTS**: Qwen3-TTS synthesizes response with Ada voice
-7. **Conversion**: FFmpeg converts WAV → WebM for browser playback
-8. **Response**: Client receives transcript, response text, and audio URL
-
-### Using Voice Chat
-
-**Access**: Navigate to `/projects/{slug}/voice` in any project.
-
-**Browser Requirements**:
-- **HTTPS required** for microphone access (Chrome security policy)
-- **Dev workaround**: Use `localhost:3002` (Chrome allows localhost over HTTP)
-
-**Usage**:
-1. Allow microphone access when prompted
-2. Hold the mic button and speak (1-3 seconds recommended)
-3. Release to send - processing will start automatically
-4. Ada's response will appear as text and play as audio
-5. Click "Replay" to hear previous responses again
-
-**Troubleshooting**:
-- **"Could not access microphone"** → Check HTTPS/localhost, allow microphone permission
-- **"Failed to process audio"** → Check Whisper installation, try shorter recordings
-- **No audio response but text works** → Check TTS setup, see logs for TTS errors
-- **"Audio file is empty"** → Hold mic button while speaking, ensure browser recording works
-
-### Audio Format Support
-
-**Recording Formats**:
-- Primary: `audio/webm;codecs=opus` (modern browsers)
-- Fallback: `audio/webm` (broader compatibility)
-- Automatic browser capability detection
-
-**Response Formats**:
-- TTS generates WAV (high quality)
-- Converted to WebM Opus for efficient browser playback
-- Base64 data URL for immediate playback (no file serving needed)
-
-### Integration with OpenClaw
-
-**Current**: Prototype with echo responses for testing voice pipeline.
-
-**Future**: Will integrate with main OpenClaw session to:
-- Send voice transcripts as messages to Ada
-- Receive real AI responses back
-- Maintain conversation context across voice/text interactions
-
-### Debugging Voice Issues
-
-Check component status:
-```bash
-# Test Whisper
-whisper --version
-
-# Test TTS
-cd /home/dan/src/qwen3-tts-test && uv run python simple_tts.py "test" --voice ada
-
-# Test FFmpeg
-ffmpeg -version
-
-# Check API logs
-tail -f .next/trace
-```
-
-API logging includes detailed processing steps for debugging audio pipeline issues.
 
 ## Development Notes
 
-### Running Trap Server
+### Dev Server
 
-Production mode (recommended for HTTPS testing):
+The dev server runs on port 3002 with Turbopack hot-reload:
+
+```bash
+pnpm dev
+```
+
+**Do not start another dev server** - use `run.sh` for production mode.
+
+### Pre-commit Hooks
+
+Pre-commit hooks run lint and typecheck. **Never use `--no-verify`** - fix any failures before committing.
+
+### Git Worktrees
+
+**Never switch branches in `/home/dan/src/trap`** - the dev server runs there on `main`.
+
+For feature work:
 ```bash
 cd /home/dan/src/trap
-npm run build
-PORT=3002 npm run start
+git worktree add /home/dan/src/trap-worktrees/fix/<ticket-id> -b fix/<ticket-id>
+cd /home/dan/src/trap-worktrees/fix/<ticket-id>
+# ... work ...
 ```
 
-Development mode:
-```bash
-npm run dev
-```
-
-### Debugging WebSocket
+### Debugging
 
 Check OpenClaw logs for connection issues:
 ```bash
 journalctl --user -u openclaw-gateway.service -f --no-pager | grep -i ws
 ```
 
-Common issues:
+Check Trap logs:
+```bash
+./run.sh logs        # Server logs
+./run.sh loop-logs   # Work loop logs
+./run.sh all-logs    # All logs
+```
+
+### Common Issues
+
 - **"invalid handshake"** - First message must be `connect` with proper params
 - **"protocol mismatch"** - Use protocol version 3
 - **"Mixed Content"** - HTTPS pages need WSS via nginx proxy
-- **"invalid request frame"** - All requests need `type: "req"` field
+- **Ghost-completing agents** - OpenClaw lane concurrency too low vs Trap agent limits
+- **Tasks stuck in_review with 0 reviews** - PR has conflicts, needs conflict_resolver role


### PR DESCRIPTION
Updates README.md to reflect the current project architecture and features.

## Changes
- **Package manager:** All `npm` references changed to `pnpm`
- **Observatory:** Added documentation for the 5-tab dashboard (Live, Triage, Analytics, Models, Prompts)
- **Work Loop v2:** Documented multi-project support, role-based agents, triage pipeline
- **Process Architecture:** Documented 4-process model (Next.js server, work loop, chat bridge, session watcher) managed by `run.sh`
- **Database:** Added missing Convex tables (task_events, model_pricing, workLoop state, sessions, and more)
- **Project Structure:** Updated directory tree with `worker/`, `components/observatory/`, `run.sh`
- **Environment Variables:** Added all new env vars (WORK_LOOP_*, CONVEX_*)
- **Work Loop Docs:** Documented phases, agent roles, triage system, agent limits, concurrency tuning
- **Cleanup:** Removed stale voice chat section

## Ticket
Ticket: a53ded62-b4b6-41d2-8bec-7ae3a915e579