### PR TITLE
feat: wire up session data for Agents page

### DIFF
--- a/lib/hooks/use-work-loop.ts
+++ b/lib/hooks/use-work-loop.ts
@@ -139,19 +139,21 @@ export function useActiveAgentSessions(
 /**
  * Reactive Convex subscription for agent activity history.
  *
- * Returns all tasks that have been worked on by agents (have agent_started_at),
- * sorted by most recently started first. Used by the Agents page.
+ * Returns all tasks that have been worked on by agents, joined with their session data
+ * (tokens, cost, model, duration). Used by the Agents page.
+ *
+ * @param projectId - Optional project filter. Pass null to get data across ALL projects.
  */
 export function useAgentHistory(
   projectId: string | null
 ): {
-  tasks: Task[] | null
+  tasks: TaskWithAgentSession[] | null
   isLoading: boolean
   error: Error | null
 } {
   const result = useQuery(
-    api.tasks.getAgentHistory,
-    projectId ? { projectId } : "skip"
+    api.tasks.getAgentHistoryWithSessions,
+    projectId === null ? {} : { projectId }
   )
 
   return {


### PR DESCRIPTION
## Summary
Wires up the Agents page to show real session data (tokens, cost, model, duration) from the Convex sessions table.

## Changes
- **convex/tasks.ts**: Add `getAgentHistoryWithSessions` query that joins tasks with their session data; add `completed_at` to `ActiveAgentSession` interface
- **lib/hooks/use-work-loop.ts**: Update `useAgentHistory` hook to use new query returning session data
- **app/agents/agents-content.tsx**: 
  - Update `calculateStats` to aggregate tokens, cost, duration from sessions
  - Update `AgentStats` interface with `costTotal`
  - Show data across ALL projects (removed single-project filter)
  - Add cost display to role cards and overview
  - Add `formatCost` helper

## Acceptance Criteria
- [x] Role cards show real token counts (in/out), model names, and average duration
- [x] Overview cards show real totals (not zeros)
- [x] Cost data displayed per role and in overview
- [x] Data comes from the `sessions` Convex table
- [x] No commented-out code left in calculateStats

Ticket: a7ebb0db-bf39-4a58-a748-0d9b79edcb72