### PR TITLE
feat: rename Trap UI chrome to OpenClutch

### DIFF
--- a/app/api/validate/github/route.ts
+++ b/app/api/validate/github/route.ts
@@ -26,7 +26,7 @@ export async function POST(request: NextRequest) {
       const response = await fetch(`https://api.github.com/repos/${normalizedRepo}`, {
         headers: {
           'Accept': 'application/vnd.github.v3+json',
-          'User-Agent': 'Trap-Project-Settings',
+          'User-Agent': 'OpenClutch-Project-Settings',
         },
       })
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -48,7 +48,7 @@
 }
 
 :root {
-  /* Custom Trap theme (light fallback) */
+  /* Custom OpenClutch theme (light fallback) */
   --bg-primary: #ffffff;
   --bg-secondary: #f4f4f5;
   --bg-tertiary: #e4e4e7;
@@ -97,7 +97,7 @@
 }
 
 .dark {
-  /* Custom Trap theme */
+  /* Custom OpenClutch theme */
   --bg-primary: #0a0a0b;
   --bg-secondary: #141415;
   --bg-tertiary: #1c1c1e;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -24,7 +24,7 @@ const inter = Inter({
 });
 
 export const metadata: Metadata = {
-  title: "The Trap - OpenClaw Dashboard",
+  title: "OpenClutch - Agent Orchestration Dashboard",
   description: "Real-time dashboard for OpenClaw AI agents",
 };
 

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -203,7 +203,7 @@ export default function SettingsPage() {
           <div className="space-y-1">
             <Label className="text-sm font-medium text-[var(--text-primary)]">Description</Label>
             <p className="text-sm text-[var(--text-secondary)]">
-              The Trap — AI Agent Dashboard for OpenClaw
+              OpenClutch — AI Agent Dashboard for OpenClaw
             </p>
           </div>
 

--- a/components/chat/message-bubble.tsx
+++ b/components/chat/message-bubble.tsx
@@ -127,8 +127,8 @@ export function MessageBubble({
     }
     
     // Look for ticket ID patterns
-    if (content.includes("Trap ticket ID:")) {
-      const ticketMatch = content.match(/Trap ticket ID: `([^`]+)`/m)
+    if (content.includes("OpenClutch ticket ID:")) {
+      const ticketMatch = content.match(/OpenClutch ticket ID: `([^`]+)`/m)
       const taskMatch = content.match(/## Task: (.+?)(?:\n|$)/m)
       if (ticketMatch && taskMatch) {
         return `Automated: ${taskMatch[1]}`

--- a/components/layout/mobile-nav.tsx
+++ b/components/layout/mobile-nav.tsx
@@ -92,7 +92,7 @@ export function MobileNav({ isOpen, onToggle, onClose }: MobileNavProps) {
             <div className="text-2xl">🦞</div>
             <div>
               <h1 className="text-lg font-bold text-[var(--text-primary)]">
-                The Trap
+                OpenClutch
               </h1>
               <p className="text-xs text-[var(--text-secondary)]">
                 AI Agent Dashboard

--- a/components/layout/sidebar.tsx
+++ b/components/layout/sidebar.tsx
@@ -41,7 +41,7 @@ export function Sidebar() {
           <div className="text-2xl">🦞</div>
           <div>
             <h1 className="text-lg font-bold text-[var(--text-primary)]">
-              The Trap
+              OpenClutch
             </h1>
             <p className="text-xs text-[var(--text-secondary)]">
               AI Agent Dashboard


### PR DESCRIPTION
Ticket: 4892b8d3-2f48-4559-a16b-36392e2140f9

Changes:
- Rename app metadata title to OpenClutch
- Rename sidebar/mobile header app name to OpenClutch
- Update Settings > About description string

Notes:
- No browser QA run here (dev role); please verify tab title + sidebar in browser.
