### PR TITLE
chore: prep for repo rename to openclutch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ Statuses: `backlog` → `ready` → `in_progress` → `in_review` → `done`
 
 **`read` tool — ALWAYS pass a `path` parameter:**
 ```
-read(path="/home/dan/src/trap/some/file.ts")
+read(path="/home/dan/src/openclutch/some/file.ts")
 ```
 Never call `read()` with no arguments — it will fail. If you need to explore the project structure, use `exec` with `fd`, `rg`, or `cat` instead.
 
@@ -38,37 +38,37 @@ Never call `read()` with no arguments — it will fail. If you need to explore t
 **Common patterns:**
 ```bash
 # Find files by name (fd is available)
-fd "\.tsx$" /home/dan/src/trap/app
+fd "\.tsx$" /home/dan/src/openclutch/app
 
 # Search for code (rg is available — use it instead of grep)
 # NOTE: -t ts covers .ts AND .tsx. Do NOT use -t tsx (doesn't exist)
-rg "functionName" /home/dan/src/trap/app -t ts
+rg "functionName" /home/dan/src/openclutch/app -t ts
 
 # Read a file
-cat /home/dan/src/trap/app/page.tsx
+cat /home/dan/src/openclutch/app/page.tsx
 
 # IMPORTANT: Quote paths with brackets (Next.js [slug] dirs)
-cat '/home/dan/src/trap/app/projects/[slug]/page.tsx'
+cat '/home/dan/src/openclutch/app/projects/[slug]/page.tsx'
 
 # List directory
-ls /home/dan/src/trap/app/
+ls /home/dan/src/openclutch/app/
 ```
 
 ## Git Worktrees (REQUIRED)
 
-**NEVER switch branches in `/home/dan/src/trap`** — the dev server runs there on `main`.
+**NEVER switch branches in `/home/dan/src/openclutch`** — the dev server runs there on `main`.
 
 **For ALL feature work:**
 ```bash
 # Create worktree for your task
-cd /home/dan/src/trap
-git worktree add /home/dan/src/trap-worktrees/<branch-name> -b <branch-name>
+cd /home/dan/src/openclutch
+git worktree add /home/dan/src/openclutch-worktrees/<branch-name> -b <branch-name>
 
 # Work in the worktree
-cd /home/dan/src/trap-worktrees/<branch-name>
+cd /home/dan/src/openclutch-worktrees/<branch-name>
 
 # When done (after PR merged), clean up
-git worktree remove /home/dan/src/trap-worktrees/<branch-name>
+git worktree remove /home/dan/src/openclutch-worktrees/<branch-name>
 ```
 
 Branch naming: `fix/<ticket-id-prefix>-<short-desc>` or `feat/<ticket-id-prefix>-<short-desc>`

--- a/AGENTS.md.bak
+++ b/AGENTS.md.bak
@@ -29,7 +29,7 @@ Statuses: `backlog` → `ready` → `in_progress` → `in_review` → `done`
 
 **`read` tool — ALWAYS pass a `path` parameter:**
 ```
-read(path="/home/dan/src/trap/some/file.ts")
+read(path="/home/dan/src/openclutch/some/file.ts")
 ```
 Never call `read()` with no arguments — it will fail. If you need to explore the project structure, use `exec` with `fd`, `rg`, or `cat` instead.
 
@@ -38,37 +38,37 @@ Never call `read()` with no arguments — it will fail. If you need to explore t
 **Common patterns:**
 ```bash
 # Find files by name (fd is available)
-fd "\.tsx$" /home/dan/src/trap/app
+fd "\.tsx$" /home/dan/src/openclutch/app
 
 # Search for code (rg is available — use it instead of grep)
 # NOTE: -t ts covers .ts AND .tsx. Do NOT use -t tsx (doesn't exist)
-rg "functionName" /home/dan/src/trap/app -t ts
+rg "functionName" /home/dan/src/openclutch/app -t ts
 
 # Read a file
-cat /home/dan/src/trap/app/page.tsx
+cat /home/dan/src/openclutch/app/page.tsx
 
 # IMPORTANT: Quote paths with brackets (Next.js [slug] dirs)
-cat '/home/dan/src/trap/app/projects/[slug]/page.tsx'
+cat '/home/dan/src/openclutch/app/projects/[slug]/page.tsx'
 
 # List directory
-ls /home/dan/src/trap/app/
+ls /home/dan/src/openclutch/app/
 ```
 
 ## Git Worktrees (REQUIRED)
 
-**NEVER switch branches in `/home/dan/src/trap`** — the dev server runs there on `main`.
+**NEVER switch branches in `/home/dan/src/openclutch`** — the dev server runs there on `main`.
 
 **For ALL feature work:**
 ```bash
 # Create worktree for your task
-cd /home/dan/src/trap
-git worktree add /home/dan/src/trap-worktrees/<branch-name> -b <branch-name>
+cd /home/dan/src/openclutch
+git worktree add /home/dan/src/openclutch-worktrees/<branch-name> -b <branch-name>
 
 # Work in the worktree
-cd /home/dan/src/trap-worktrees/<branch-name>
+cd /home/dan/src/openclutch-worktrees/<branch-name>
 
 # When done (after PR merged), clean up
-git worktree remove /home/dan/src/trap-worktrees/<branch-name>
+git worktree remove /home/dan/src/openclutch-worktrees/<branch-name>
 ```
 
 Branch naming: `fix/<ticket-id-prefix>-<short-desc>` or `feat/<ticket-id-prefix>-<short-desc>`

--- a/README.md
+++ b/README.md
@@ -447,13 +447,13 @@ Pre-commit hooks run lint and typecheck. **Never use `--no-verify`** - fix any f
 
 ### Git Worktrees
 
-**Never switch branches in `/home/dan/src/trap`** - the dev server runs there on `main`.
+**Never switch branches in `/home/dan/src/openclutch`** - the dev server runs there on `main`.
 
 For feature work:
 ```bash
-cd /home/dan/src/trap
-git worktree add /home/dan/src/trap-worktrees/fix/<ticket-id> -b fix/<ticket-id>
-cd /home/dan/src/trap-worktrees/fix/<ticket-id>
+cd /home/dan/src/openclutch
+git worktree add /home/dan/src/openclutch-worktrees/fix/<ticket-id> -b fix/<ticket-id>
+cd /home/dan/src/openclutch-worktrees/fix/<ticket-id>
 # ... work ...
 ```
 

--- a/systemd/trap-auto-deploy.service
+++ b/systemd/trap-auto-deploy.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Trap auto-deploy (pull/build/restart) from /home/dan/src/openclutch
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=oneshot
+WorkingDirectory=/home/dan/src/openclutch
+ExecStart=/home/dan/.local/bin/trap-auto-deploy.sh
+# Keep output in journal
+StandardOutput=journal
+StandardError=journal

--- a/systemd/trap-bridge.service
+++ b/systemd/trap-bridge.service
@@ -6,8 +6,8 @@ Wants=trap-server.service
 
 [Service]
 Type=simple
-WorkingDirectory=/home/dan/src/trap
-EnvironmentFile=/home/dan/src/trap/.env.local
+WorkingDirectory=/home/dan/src/openclutch
+EnvironmentFile=/home/dan/src/openclutch/.env.local
 ExecStart=/home/dan/.volta/tools/image/node/22.22.0/bin/node ./node_modules/tsx/dist/cli.cjs worker/chat-bridge.ts
 Restart=on-failure
 RestartSec=5

--- a/systemd/trap-loop.service
+++ b/systemd/trap-loop.service
@@ -6,8 +6,8 @@ Wants=trap-server.service
 
 [Service]
 Type=simple
-WorkingDirectory=/home/dan/src/trap
-EnvironmentFile=/home/dan/src/trap/.env.local
+WorkingDirectory=/home/dan/src/openclutch
+EnvironmentFile=/home/dan/src/openclutch/.env.local
 ExecStart=/home/dan/.volta/tools/image/node/22.22.0/bin/node ./node_modules/tsx/dist/cli.cjs worker/loop.ts
 Restart=on-failure
 RestartSec=5

--- a/systemd/trap-server.service
+++ b/systemd/trap-server.service
@@ -5,8 +5,8 @@ After=network.target
 
 [Service]
 Type=simple
-WorkingDirectory=/home/dan/src/trap
-EnvironmentFile=/home/dan/src/trap/.env.local
+WorkingDirectory=/home/dan/src/openclutch
+EnvironmentFile=/home/dan/src/openclutch/.env.local
 Environment=NODE_ENV=production
 Environment=PORT=3002
 ExecStart=/home/dan/.volta/tools/image/node/22.22.0/bin/node ./node_modules/next/dist/bin/next start -p 3002

--- a/systemd/trap-session-watcher.service
+++ b/systemd/trap-session-watcher.service
@@ -7,8 +7,8 @@ Wants=trap-server.service
 [Service]
 Type=simple
 User=dan
-WorkingDirectory=/home/dan/src/trap
-EnvironmentFile=/home/dan/src/trap/.env.local
+WorkingDirectory=/home/dan/src/openclutch
+EnvironmentFile=/home/dan/src/openclutch/.env.local
 ExecStart=/home/dan/.volta/tools/image/node/22.22.0/bin/node ./node_modules/.bin/tsx worker/session-watcher.ts
 Restart=on-failure
 RestartSec=5


### PR DESCRIPTION
Ticket: 50b2930c-a36d-4db3-b942-653512fc494e

Updates in-repo references (systemd unit templates, docs) from /home/dan/src/trap -> /home/dan/src/openclutch, and introduces a systemd unit template for trap-auto-deploy to match the installed unit.

NOTE: The actual directory move + updating installed systemd units, .env.local, and Convex/OpenClaw config must be done last and is intentionally not performed in this PR.