### PR TITLE
rename: app title and UI chrome from Trap to OpenClutch

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -24,7 +24,7 @@ const inter = Inter({
 });
 
 export const metadata: Metadata = {
-  title: "The Trap - OpenClaw Dashboard",
+  title: "OpenClutch",
   description: "Real-time dashboard for OpenClaw AI agents",
 };
 

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -203,7 +203,7 @@ export default function SettingsPage() {
           <div className="space-y-1">
             <Label className="text-sm font-medium text-[var(--text-primary)]">Description</Label>
             <p className="text-sm text-[var(--text-secondary)]">
-              The Trap — AI Agent Dashboard for OpenClaw
+              OpenClutch — AI Agent Dashboard for OpenClaw
             </p>
           </div>
 

--- a/bin/trap-cli.ts
+++ b/bin/trap-cli.ts
@@ -118,7 +118,7 @@ function parseArgs(): { command: string; args: string[]; flags: Record<string, s
 
 function showHelp(): void {
   console.log(`
-Trap CLI - Manage your Trap projects
+OpenClutch CLI - Manage your OpenClutch projects
 
 Usage:
   trap <command> [options]

--- a/components/layout/mobile-nav.tsx
+++ b/components/layout/mobile-nav.tsx
@@ -92,7 +92,7 @@ export function MobileNav({ isOpen, onToggle, onClose }: MobileNavProps) {
             <div className="text-2xl">🦞</div>
             <div>
               <h1 className="text-lg font-bold text-[var(--text-primary)]">
-                The Trap
+                OpenClutch
               </h1>
               <p className="text-xs text-[var(--text-secondary)]">
                 AI Agent Dashboard

--- a/components/layout/sidebar.tsx
+++ b/components/layout/sidebar.tsx
@@ -41,7 +41,7 @@ export function Sidebar() {
           <div className="text-2xl">🦞</div>
           <div>
             <h1 className="text-lg font-bold text-[var(--text-primary)]">
-              The Trap
+              OpenClutch
             </h1>
             <p className="text-xs text-[var(--text-secondary)]">
               AI Agent Dashboard

--- a/lib/openclaw/client.ts
+++ b/lib/openclaw/client.ts
@@ -81,7 +81,7 @@ class OpenClawClient {
             maxProtocol: 3,
             client: {
               id: 'gateway-client',
-              displayName: 'Trap Backend',
+              displayName: 'OpenClutch Backend',
               version: '1.0.0',
               platform: 'nodejs',
               mode: 'backend',

--- a/plugins/trap-channel.ts
+++ b/plugins/trap-channel.ts
@@ -195,9 +195,9 @@ export default function register(api: OpenClawPluginApi) {
       id: "trap",
       meta: {
         id: "trap",
-        label: "Trap",
-        selectionLabel: "Trap",
-        detailLabel: "Trap Orchestration",
+        label: "OpenClutch",
+        selectionLabel: "OpenClutch",
+        detailLabel: "OpenClutch Orchestration",
         docsPath: "/channels/trap",
         blurb: "AI agent orchestration UI",
         order: 50,

--- a/worker/gateway-client.ts
+++ b/worker/gateway-client.ts
@@ -115,7 +115,7 @@ export class GatewayRpcClient {
             maxProtocol: PROTOCOL_VERSION,
             client: {
               id: "gateway-client",
-              displayName: "Trap Work Loop",
+              displayName: "OpenClutch Work Loop",
               version: "1.0.0",
               platform: "linux",
               mode: "backend",


### PR DESCRIPTION
Renames UI-visible app chrome from "Trap"/"The Trap" to "OpenClutch".

Changes:
- Next.js metadata title now "OpenClutch" (tab title)
- Sidebar & mobile nav header now "OpenClutch"
- Settings About description updated
- OpenClaw gateway client display names updated
- Trap channel plugin labels updated to "OpenClutch"

Verification:
- pnpm build
- pnpm typecheck

Notes:
- needs browser QA