### PR TITLE
rename: CLI from trap to clutch

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ trap/
 │   ├── trap-channel.ts           # Channel plugin for chat
 │   └── trap-signal.ts            # Signal plugin for notifications
 ├── bin/                          # CLI tools
-│   └── trap-cli.ts               # OpenClutch CLI
+│   └── clutch-cli.ts               # OpenClutch CLI
 ├── scripts/                      # Utility scripts
 ├── systemd/                      # Systemd service files
 ├── run.sh                        # Process management script

--- a/bin/clutch-cli-gate.sh
+++ b/bin/clutch-cli-gate.sh
@@ -1,17 +1,17 @@
 #!/bin/bash
-# trap-cli-gate.sh — Gate script for OpenClaw cron
+# clutch-cli-gate.sh — Gate script for OpenClaw cron
 #
 # Returns 0 (wake) if coordinator should process work
 # Returns 1 (sleep) if nothing needs attention
 #
-# Usage: TRAP_URL=http://localhost:3002 ./trap-cli-gate.sh
+# Usage: CLUTCH_URL=http://localhost:3002 ./clutch-cli-gate.sh
 
 set -e
 
-TRAP_URL="${TRAP_URL:-http://localhost:3002}"
+CLUTCH_URL="${CLUTCH_URL:-http://localhost:3002}"
 
 # Fetch gate status
-response=$(curl -s --max-time 5 "$TRAP_URL/api/gate" 2>/dev/null || echo '{"needsAttention":false,"error":"failed to connect"}')
+response=$(curl -s --max-time 5 "$CLUTCH_URL/api/gate" 2>/dev/null || echo '{"needsAttention":false,"error":"failed to connect"}')
 
 # Check for errors
 if echo "$response" | jq -e '.error' > /dev/null 2>&1; then

--- a/bin/clutch-cli.ts
+++ b/bin/clutch-cli.ts
@@ -1,18 +1,18 @@
 #!/usr/bin/env tsx
 /**
- * Trap CLI - Command line interface for Trap operations
+ * Clutch CLI - Command line interface for Clutch operations
  *
  * Usage:
- *   trap agents list                           List active agents and their tasks
- *   trap agents get <session-key>              Get agent detail + last output
- *   trap sessions list [--active]              List sessions
- *   trap sessions status                       OpenClaw session status
- *   trap dispatch pending [--project <slug>]   Show pending dispatch queue
- *   trap metrics [--project <slug>]            Task metrics / velocity
- *   trap signals list [--pending]              Pending signals
- *   trap signals respond <id> "msg"            Respond to a signal
- *   trap deploy convex [--project <slug>]      Deploy Convex for a project
- *   trap deploy check [--project <slug>]       Check if convex/ is dirty vs deployed
+ *   clutch agents list                           List active agents and their tasks
+ *   clutch agents get <session-key>              Get agent detail + last output
+ *   clutch sessions list [--active]              List sessions
+ *   clutch sessions status                       OpenClaw session status
+ *   clutch dispatch pending [--project <slug>]   Show pending dispatch queue
+ *   clutch metrics [--project <slug>]            Task metrics / velocity
+ *   clutch signals list [--pending]              Pending signals
+ *   clutch signals respond <id> "msg"            Respond to a signal
+ *   clutch deploy convex [--project <slug>]      Deploy Convex for a project
+ *   clutch deploy check [--project <slug>]       Check if convex/ is dirty vs deployed
  */
 
 import { execFileSync } from "node:child_process"
@@ -121,7 +121,7 @@ function showHelp(): void {
 OpenClutch CLI - Manage your OpenClutch projects
 
 Usage:
-  trap <command> [options]
+  clutch <command> [options]
 
 Agent Commands:
   agents list                         List active agents and their tasks
@@ -146,17 +146,17 @@ Deploy Commands:
   deploy check [--project <slug>]     Check if convex/ is dirty vs deployed
 
 Options:
-  --project <slug>    Target project slug (defaults to "trap" or auto-detected)
+  --project <slug>    Target project slug (defaults to "clutch" or auto-detected)
   --help, -h          Show this help message
 
 Examples:
-  trap agents list                          Show all active agents
-  trap agents get agent:main:trap:dev:abc   Get agent details
-  trap sessions list --active               Show only active sessions
-  trap dispatch pending --project trader    Show pending for trader project
-  trap signals list --pending               Show pending signals
-  trap signals respond abc-123 "LGTM"       Respond to a signal
-  trap metrics --project trap               Show metrics for trap project
+  clutch agents list                          Show all active agents
+  clutch agents get agent:main:clutch:dev:abc   Get agent details
+  clutch sessions list --active               Show only active sessions
+  clutch dispatch pending --project trader    Show pending for trader project
+  clutch signals list --pending               Show pending signals
+  clutch signals respond abc-123 "LGTM"       Respond to a signal
+  clutch metrics --project clutch               Show metrics for clutch project
 `)
 }
 
@@ -242,10 +242,10 @@ async function resolveProject(
     }
   }
 
-  // Fall back to "trap" project
-  const trapProject = await convex.query(api.projects.getBySlug, { slug: "trap" })
-  if (trapProject) {
-    return trapProject
+  // Fall back to "clutch" project
+  const clutchProject = await convex.query(api.projects.getBySlug, { slug: "clutch" })
+  if (clutchProject) {
+    return clutchProject
   }
 
   // Last resort: return first project with local_path
@@ -721,7 +721,7 @@ async function cmdDeployCheck(
     for (const file of convexFiles) {
       console.log(`  - ${file}`)
     }
-    console.log("\nRun 'trap deploy convex' to deploy these changes.")
+    console.log("\nRun 'clutch deploy convex' to deploy these changes.")
     process.exit(1)
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
@@ -815,7 +815,7 @@ async function main(): Promise<void> {
 
     default:
       console.error(`Unknown command: ${command}`)
-      console.error("Run 'trap --help' for usage information.")
+      console.error("Run 'clutch --help' for usage information.")
       process.exit(1)
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "bin": {
-    "clutch": "./bin/trap-cli.ts",
-    "clutch-cli": "./bin/trap-cli.ts"
+    "clutch": "./bin/clutch-cli.ts",
+    "clutch-cli": "./bin/clutch-cli.ts"
   },
   "scripts": {
     "dev": "volta run node ./node_modules/next/dist/bin/next dev -p 3002",


### PR DESCRIPTION
Renames the Trap CLI entrypoints to Clutch.

Changes:
- bin/trap-cli.ts -> bin/clutch-cli.ts
- bin/trap-cli-gate.sh -> bin/clutch-cli-gate.sh
- Updates package.json bin paths and CLI help/usage strings

Notes:
- Kept TRAP_API_URL env var for now (will be updated later).

Checklist:
- [x] pnpm build
- [x] pnpm typecheck