### PR TITLE
rename: plugins from trap to clutch

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,8 +358,8 @@ trap/
 │   ├── task_events.ts            # Event logging
 │   └── ...
 ├── plugins/                      # OpenClaw plugins
-│   ├── trap-channel.ts           # Channel plugin for chat
-│   └── trap-signal.ts            # Signal plugin for notifications
+│   ├── clutch-channel.ts         # Channel plugin for chat
+│   └── clutch-signal.ts          # Signal plugin for notifications
 ├── bin/                          # CLI tools
 │   └── clutch-cli.ts               # OpenClutch CLI
 ├── scripts/                      # Utility scripts

--- a/app/api/feature-builder/question/route.ts
+++ b/app/api/feature-builder/question/route.ts
@@ -158,7 +158,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     const agentMessage = buildAgentMessage(featureDescription, conversation, projectId)
 
     // Spawn PM agent via OpenClaw with Kimi model
-    const sessionKey = `trap:feature-builder:${Date.now()}`
+    const sessionKey = `clutch:feature-builder:${Date.now()}`
     
     try {
       const result = await openclawRpc<{

--- a/app/api/projects/[id]/context/route.ts
+++ b/app/api/projects/[id]/context/route.ts
@@ -32,7 +32,8 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     return NextResponse.json({
       context,
       formatted,
-      sessionKeyPrefix: `trap:${project.slug}`,
+      sessionKeyPrefix: `clutch:${project.slug}`,
+
     })
   } catch (error) {
     console.error("[Projects API] Error fetching project context:", error)

--- a/app/projects/[slug]/chat/page.tsx
+++ b/app/projects/[slug]/chat/page.tsx
@@ -73,16 +73,16 @@ export default function ChatPage({ params }: PageProps) {
   }, [activeChat?.id])
 
   // Generate session key based on project and active chat
-  // Format: trap:{projectSlug}:{chatId} - includes project for context
+  // Format: clutch:{projectSlug}:{chatId} - includes project for context
   // Use stored session_key if available, otherwise generate dynamically
   const sessionKey = activeChat
-    ? (activeChat.session_key || `trap:${slug}:${activeChat.id}`)
+    ? (activeChat.session_key || `clutch:${slug}:${activeChat.id}`)
     : "main"
 
   // ==========================================================================
   // OpenClaw Integration (HTTP-only)
   // - HTTP POST for sending messages (reliable, works during gateway restarts)
-  // - Message persistence handled server-side by trap-channel plugin
+  // - Message persistence handled server-side by clutch-channel plugin
   // - Convex reactive queries update the UI automatically
   // ==========================================================================
 
@@ -286,7 +286,7 @@ export default function ChatPage({ params }: PageProps) {
     }
 
     // Send to OpenClaw via HTTP POST
-    // Response persistence is handled by the trap-channel plugin (agent_end hook)
+    // Response persistence is handled by the clutch-channel plugin (agent_end hook)
     try {
       await sendChatMessage(sessionKey, openClawMessage)
     } catch (error) {

--- a/components/board/task-timeline.tsx
+++ b/components/board/task-timeline.tsx
@@ -126,7 +126,7 @@ function parseEventData(data: string | null): EventData {
 }
 
 function getSessionUrl(sessionKey: string, projectSlug: string): string {
-  // Session key format: agent:main:trap:{role}:{taskShortId}
+  // Session key format: agent:main:clutch:{role}:{taskShortId}
   // Link to project sessions page with the session key
   return `/projects/${projectSlug}/sessions/${encodeURIComponent(sessionKey)}`
 }
@@ -137,7 +137,7 @@ function isAgentActor(actor: string): boolean {
 
 function formatActorName(actor: string): string {
   if (actor.startsWith("agent:")) {
-    // agent:main:trap:role:taskId -> role agent
+    // agent:main:clutch:role:taskId -> role agent
     const parts = actor.split(":")
     const role = parts[3] || "agent"
     return `Agent (${role})`

--- a/components/chat/chat-sidebar.tsx
+++ b/components/chat/chat-sidebar.tsx
@@ -107,7 +107,7 @@ export function ChatSidebar({ projectId, projectSlug, isOpen = true, onClose, is
 
   // Load active agents expanded state from localStorage on mount
   useEffect(() => {
-    const stored = localStorage.getItem('trap:activeAgentsExpanded')
+    const stored = localStorage.getItem('clutch:activeAgentsExpanded')
     if (stored !== null) {
       setActiveAgentsExpanded(stored === 'true')
     }
@@ -115,7 +115,7 @@ export function ChatSidebar({ projectId, projectSlug, isOpen = true, onClose, is
 
   // Persist active agents expanded state to localStorage
   useEffect(() => {
-    localStorage.setItem('trap:activeAgentsExpanded', String(activeAgentsExpanded))
+    localStorage.setItem('clutch:activeAgentsExpanded', String(activeAgentsExpanded))
   }, [activeAgentsExpanded])
 
   // Blocked tasks section expanded state (persisted in localStorage)
@@ -123,7 +123,7 @@ export function ChatSidebar({ projectId, projectSlug, isOpen = true, onClose, is
 
   // Load blocked expanded state from localStorage on mount
   useEffect(() => {
-    const stored = localStorage.getItem('trap:blockedExpanded')
+    const stored = localStorage.getItem('clutch:blockedExpanded')
     if (stored !== null) {
       setBlockedExpanded(stored === 'true')
     }
@@ -131,7 +131,7 @@ export function ChatSidebar({ projectId, projectSlug, isOpen = true, onClose, is
 
   // Persist blocked expanded state to localStorage
   useEffect(() => {
-    localStorage.setItem('trap:blockedExpanded', String(blockedExpanded))
+    localStorage.setItem('clutch:blockedExpanded', String(blockedExpanded))
   }, [blockedExpanded])
 
   // Task modal state

--- a/components/chat/session-info-dropdown.tsx
+++ b/components/chat/session-info-dropdown.tsx
@@ -202,7 +202,7 @@ export function SessionInfoDropdown({
 
   // Extract short session ID for display
   const getShortSessionId = (key: string) => {
-    if (key.startsWith('trap:')) {
+    if (key.startsWith('clutch:')) {
       const parts = key.split(':')
       const lastPart = parts[parts.length - 1]
       return lastPart.substring(0, 8)

--- a/convex/chats.ts
+++ b/convex/chats.ts
@@ -137,8 +137,8 @@ export const findBySessionKey = query({
       }
     }
 
-    // Try to extract chat UUID from session key format: trap:projectSlug:chatId
-    const match = args.sessionKey.match(/^trap:[^:]+:(.+)$/)
+    // Try to extract chat UUID from session key format: clutch:projectSlug:chatId
+    const match = args.sessionKey.match(/^clutch:[^:]+:(.+)$/)
     if (match) {
       const chatUuid = match[1]
       const exists = await ctx.db

--- a/convex/sessions.ts
+++ b/convex/sessions.ts
@@ -71,14 +71,14 @@ export interface SessionInput {
 
 /**
  * Extract project_slug from session_key.
- * Pattern: agent:main:trap:{slug}:{chatId} -> slug
+ * Pattern: agent:main:clutch:{slug}:{chatId} -> slug
  * Falls back to undefined if pattern doesn't match.
  */
 function extractProjectSlug(sessionKey: string): string | undefined {
-  // Pattern: agent:main:trap:{slug}:{chatId} or similar trap:slug patterns
-  const trapMatch = sessionKey.match(/:trap:([^:]+)/)
-  if (trapMatch) {
-    return trapMatch[1]
+  // Pattern: agent:main:clutch:{slug}:{chatId} or similar clutch:slug patterns
+  const clutchMatch = sessionKey.match(/:clutch:([^:]+)/)
+  if (clutchMatch) {
+    return clutchMatch[1]
   }
   return undefined
 }

--- a/lib/dispatch/context.ts
+++ b/lib/dispatch/context.ts
@@ -76,5 +76,5 @@ ${task.description || "_No description provided_"}
  * Build a task label for session tracking
  */
 export function buildTaskLabel(task: Task): string {
-  return `trap-task-${task.id.slice(0, 8)}`
+  return `clutch-task-${task.id.slice(0, 8)}`
 }

--- a/lib/hooks/use-session.ts
+++ b/lib/hooks/use-session.ts
@@ -12,7 +12,7 @@ export type { Session }
  * Returns the session data updated in real-time whenever the session
  * is updated in Convex.
  *
- * @param sessionKey - The session key to subscribe to (e.g., "trap:project:chat123")
+ * @param sessionKey - The session key to subscribe to (e.g., "clutch:project:chat123")
  */
 export function useSession(sessionKey: string): {
   session: Session | null

--- a/lib/hooks/use-settings.ts
+++ b/lib/hooks/use-settings.ts
@@ -10,7 +10,7 @@ interface ChatSettings {
 const DEFAULT_SETTINGS: ChatSettings = {
 }
 
-const SETTINGS_KEY = 'trap-chat-settings'
+const SETTINGS_KEY = 'clutch-chat-settings'
 
 function getInitialSettings(): ChatSettings {
   if (typeof window === 'undefined') {

--- a/lib/openclaw/api.ts
+++ b/lib/openclaw/api.ts
@@ -263,7 +263,7 @@ export interface ChatSendResult {
 /**
  * Send a chat message to a session.
  *
- * @param sessionKey - The target session key (e.g., 'agent:main', 'trap:myproject:chat123')
+ * @param sessionKey - The target session key (e.g., 'agent:main', 'clutch:myproject:chat123')
  * @param message - The message content
  * @returns Promise with runId and status
  */

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -1,10 +1,10 @@
-# Trap OpenClaw Plugins
+# Clutch OpenClaw Plugins
 
-OpenClaw plugins that enable AI agents to communicate with The Trap.
+OpenClaw plugins that enable AI agents to communicate with OpenClutch.
 
 ## Available Plugins
 
-### trap-signal.ts
+### clutch-signal.ts
 
 Provides two tools for agent-to-coordinator communication:
 
@@ -22,7 +22,7 @@ Provides two tools for agent-to-coordinator communication:
 mkdir -p ~/.openclaw/extensions
 
 # Symlink the plugin
-ln -s /path/to/trap/plugins/trap-signal.ts ~/.openclaw/extensions/trap-signal.ts
+ln -s /path/to/clutch/plugins/clutch-signal.ts ~/.openclaw/extensions/clutch-signal.ts
 
 # Restart OpenClaw gateway
 openclaw gateway restart
@@ -34,22 +34,22 @@ Add to your `openclaw.json`:
 
 ```json
 {
-  "plugins": ["/path/to/trap/plugins/trap-signal.ts"]
+  "plugins": ["/path/to/clutch/plugins/clutch-signal.ts"]
 }
 ```
 
 ### Option 3: Copy to extensions
 
 ```bash
-cp /path/to/trap/plugins/trap-signal.ts ~/.openclaw/extensions/
+cp /path/to/clutch/plugins/clutch-signal.ts ~/.openclaw/extensions/
 ```
 
 ## Configuration
 
-Set the `TRAP_URL` environment variable to point to your Trap instance:
+Set the `CLUTCH_URL` environment variable to point to your OpenClutch instance:
 
 ```bash
-export TRAP_URL=http://localhost:3002
+export CLUTCH_URL=http://localhost:3002
 ```
 
 Or add to your shell profile / OpenClaw environment config.
@@ -74,7 +74,7 @@ signal({
 
 // Report a blocker
 signal({
-  taskId: "task-123", 
+  taskId: "task-123",
   kind: "blocker",
   message: "CI is failing on unrelated test, need help"
 })
@@ -90,7 +90,7 @@ signal({
 // FYI (non-blocking)
 signal({
   taskId: "task-123",
-  kind: "fyi", 
+  kind: "fyi",
   message: "Refactored auth module while fixing the bug"
 })
 ```
@@ -131,8 +131,8 @@ mark_complete({
 
 ## How It Works
 
-1. Agent calls `signal()` → creates record in Trap database
-2. Trap's gate API returns `needsAttention: true`
+1. Agent calls `signal()` → creates record in the database
+2. OpenClutch gate API returns `needsAttention: true`
 3. Coordinator (Ada) wakes up, sees pending signal
 4. Coordinator responds via `/api/signal/:id/respond`
 5. Response is routed back to agent's session via `sessionKey`
@@ -144,7 +144,7 @@ The `sessionKey` and `agentId` are automatically injected by OpenClaw — agents
 
 To modify the plugin:
 
-1. Edit `plugins/trap-signal.ts`
+1. Edit `plugins/clutch-signal.ts`
 2. Gateway hot-reloads on save (in dev mode)
 3. Or restart gateway: `openclaw gateway restart`
 
@@ -160,8 +160,8 @@ ls -la ~/.openclaw/extensions/
 ```
 
 **Connection refused:**
-- Verify Trap is running: `curl http://localhost:3002/api/gate`
-- Check `TRAP_URL` is set correctly
+- Verify the app is running: `curl http://localhost:3002/api/gate`
+- Check `CLUTCH_URL` is set correctly
 
 **Tool not available:**
 - Restart gateway after installing plugin

--- a/plugins/clutch-channel.ts
+++ b/plugins/clutch-channel.ts
@@ -1,30 +1,30 @@
 /**
- * Trap Channel Plugin for OpenClaw
- * 
- * Enables bidirectional communication between OpenClaw and the Trap UI.
- * 
+ * Clutch Channel Plugin for OpenClaw
+ *
+ * Enables bidirectional communication between OpenClaw and the Clutch UI.
+ *
  * How it works:
- *   1. Trap frontend sends messages via OpenClaw WebSocket (chat.send RPC)
+ *   1. Clutch frontend sends messages via OpenClaw WebSocket (chat.send RPC)
  *   2. OpenClaw processes the message in the agent session
- *   3. On agent_end, this plugin detects trap:* session keys
- *   4. Extracts the assistant response and POSTs it to Trap API → Convex
- *   5. Convex reactive query updates the Trap UI
- * 
- * Session key format: trap:{projectSlug}:{chatId}
+ *   3. On agent_end, this plugin detects clutch:* session keys
+ *   4. Extracts the assistant response and POSTs it to Clutch API → Convex
+ *   5. Convex reactive query updates the Clutch UI
+ *
+ * Session key format: clutch:{projectSlug}:{chatId}
  */
 
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 
-function getTrapUrl(api: OpenClawPluginApi): string {
-  return api.config.env?.TRAP_URL || api.config.env?.TRAP_API_URL || "http://localhost:3002";
+function getClutchUrl(api: OpenClawPluginApi): string {
+  return api.config.env?.CLUTCH_URL || api.config.env?.CLUTCH_API_URL || "http://localhost:3002";
 }
 
 /**
- * Parse a trap session key into its components.
- * Format: trap:{projectSlug}:{chatId}
+ * Parse a clutch session key into its components.
+ * Format: clutch:{projectSlug}:{chatId}
  */
-function parseTrapSessionKey(sessionKey: string): { projectSlug: string; chatId: string } | null {
-  const match = sessionKey.match(/^trap:([^:]+):(.+)$/);
+function parseClutchSessionKey(sessionKey: string): { projectSlug: string; chatId: string } | null {
+  const match = sessionKey.match(/^clutch:([^:]+):(.+)$/);
   if (!match) return null;
   return { projectSlug: match[1], chatId: match[2] };
 }
@@ -35,25 +35,26 @@ function parseTrapSessionKey(sessionKey: string): { projectSlug: string; chatId:
  */
 function extractTextContent(message: unknown): string {
   if (!message || typeof message !== "object") return "";
-  
+
   const msg = message as Record<string, unknown>;
   const content = msg.content;
-  
+
   if (typeof content === "string") return content;
-  
+
   if (Array.isArray(content)) {
     return content
-      .filter((c): c is { type: string; text: string } => 
-        c && typeof c === "object" && c.type === "text" && typeof c.text === "string"
+      .filter(
+        (c): c is { type: string; text: string } =>
+          c && typeof c === "object" && c.type === "text" && typeof c.text === "string"
       )
-      .map(c => c.text)
+      .map((c) => c.text)
       .join("\n\n");
   }
-  
+
   return "";
 }
 
-async function sendToTrap(
+async function sendToClutch(
   api: OpenClawPluginApi,
   chatId: string,
   content: string,
@@ -64,20 +65,20 @@ async function sendToTrap(
     isAutomated?: boolean;
   }
 ): Promise<{ ok: boolean; messageId?: string; error?: string }> {
-  const trapUrl = getTrapUrl(api);
+  const clutchUrl = getClutchUrl(api);
   const { runId, sessionKey, mediaUrl, isAutomated } = options || {};
-  
+
   try {
     const body: Record<string, unknown> = {
       author: "ada",
       content: mediaUrl ? `${content}\n\n📎 ${mediaUrl}` : content,
       is_automated: isAutomated ?? false,
     };
-    
+
     if (runId) body.run_id = runId;
     if (sessionKey) body.session_key = sessionKey;
-    
-    const response = await fetch(`${trapUrl}/api/chats/${chatId}/messages`, {
+
+    const response = await fetch(`${clutchUrl}/api/chats/${chatId}/messages`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(body),
@@ -85,7 +86,7 @@ async function sendToTrap(
 
     if (response.status === 409) {
       // Duplicate run_id — message already saved (e.g. by frontend polling)
-      api.logger.info(`Trap: message already saved (duplicate run_id: ${runId})`);
+      api.logger.info(`Clutch: message already saved (duplicate run_id: ${runId})`);
       return { ok: true };
     }
 
@@ -97,47 +98,47 @@ async function sendToTrap(
     const data = await response.json();
     return { ok: true, messageId: data.message?.id };
   } catch (error) {
-    return { 
-      ok: false, 
-      error: error instanceof Error ? error.message : "Failed to send to Trap" 
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : "Failed to send to Clutch",
     };
   }
 }
 
 export default function register(api: OpenClawPluginApi) {
   // =========================================================================
-  // agent_end hook — persist assistant responses to Trap/Convex
+  // agent_end hook — persist assistant responses to Clutch/Convex
   // =========================================================================
   api.on("agent_end", async (event, ctx) => {
     const sessionKey = ctx.sessionKey;
     if (!sessionKey) return;
-    
-    // Only handle trap:* sessions
-    const parsed = parseTrapSessionKey(sessionKey);
+
+    // Only handle clutch:* sessions
+    const parsed = parseClutchSessionKey(sessionKey);
     if (!parsed) return;
-    
+
     const { chatId } = parsed;
-    
+
     if (!event.success) {
-      api.logger.warn(`Trap: agent_end failed for chat ${chatId}: ${event.error}`);
+      api.logger.warn(`Clutch: agent_end failed for chat ${chatId}: ${event.error}`);
       // Still clear typing indicator even on failure/abort
-      const trapUrl = getTrapUrl(api);
+      const clutchUrl = getClutchUrl(api);
       try {
-        await fetch(`${trapUrl}/api/chats/${chatId}/typing`, {
+        await fetch(`${clutchUrl}/api/chats/${chatId}/typing`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ typing: false, author: "ada" }),
         });
       } catch (error) {
-        api.logger.warn(`Trap: failed to clear typing after abort for chat ${chatId}: ${error}`);
+        api.logger.warn(`Clutch: failed to clear typing after abort for chat ${chatId}: ${error}`);
       }
       return;
     }
-    
+
     // Find the last assistant message in the transcript
     const messages = event.messages || [];
     let lastAssistantContent = "";
-    
+
     for (let i = messages.length - 1; i >= 0; i--) {
       const msg = messages[i] as Record<string, unknown>;
       if (msg?.role === "assistant") {
@@ -145,45 +146,49 @@ export default function register(api: OpenClawPluginApi) {
         break;
       }
     }
-    
+
     const trimmed = lastAssistantContent.trim();
     if (!trimmed || trimmed === "NO_REPLY" || trimmed === "HEARTBEAT_OK") {
-      api.logger.info(`Trap: no assistant content to save for chat ${chatId}`);
+      api.logger.info(`Clutch: no assistant content to save for chat ${chatId}`);
       // Still clear typing indicator
-      const trapUrl2 = getTrapUrl(api);
+      const clutchUrl2 = getClutchUrl(api);
       try {
-        await fetch(`${trapUrl2}/api/chats/${chatId}/typing`, {
+        await fetch(`${clutchUrl2}/api/chats/${chatId}/typing`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ typing: false, author: "ada" }),
         });
-      } catch { /* ignore */ }
+      } catch {
+        /* ignore */
+      }
       return;
     }
-    
-    // POST the response to Trap API → Convex
-    api.logger.info(`Trap: saving assistant response to chat ${chatId} (${lastAssistantContent.length} chars)`);
-    const result = await sendToTrap(api, chatId, lastAssistantContent.trim(), {
+
+    // POST the response to Clutch API → Convex
+    api.logger.info(
+      `Clutch: saving assistant response to chat ${chatId} (${lastAssistantContent.length} chars)`
+    );
+    const result = await sendToClutch(api, chatId, lastAssistantContent.trim(), {
       sessionKey,
       isAutomated: false,
     });
-    
+
     if (result.ok) {
-      api.logger.info(`Trap: response saved to chat ${chatId}`);
+      api.logger.info(`Clutch: response saved to chat ${chatId}`);
     } else {
-      api.logger.warn(`Trap: failed to save response to chat ${chatId}: ${result.error}`);
+      api.logger.warn(`Clutch: failed to save response to chat ${chatId}: ${result.error}`);
     }
 
     // Clear typing indicator after response is saved
-    const trapUrl = getTrapUrl(api);
+    const clutchUrl = getClutchUrl(api);
     try {
-      await fetch(`${trapUrl}/api/chats/${chatId}/typing`, {
+      await fetch(`${clutchUrl}/api/chats/${chatId}/typing`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ typing: false, author: "ada" }),
       });
     } catch (error) {
-      api.logger.warn(`Trap: failed to clear typing indicator for chat ${chatId}: ${error}`);
+      api.logger.warn(`Clutch: failed to clear typing indicator for chat ${chatId}: ${error}`);
     }
   });
 
@@ -192,13 +197,13 @@ export default function register(api: OpenClawPluginApi) {
   // =========================================================================
   api.registerChannel({
     plugin: {
-      id: "trap",
+      id: "clutch",
       meta: {
-        id: "trap",
+        id: "clutch",
         label: "OpenClutch",
         selectionLabel: "OpenClutch",
         detailLabel: "OpenClutch Orchestration",
-        docsPath: "/channels/trap",
+        docsPath: "/channels/clutch",
         blurb: "AI agent orchestration UI",
         order: 50,
       },
@@ -211,51 +216,62 @@ export default function register(api: OpenClawPluginApi) {
       },
       outbound: {
         deliveryMode: "direct",
-        
+
         sendTypingIndicator: async (ctx) => {
           const { to, isTyping } = ctx;
           if (!to) return { ok: false, error: "No chat ID (to) provided" };
 
-          const trapUrl = getTrapUrl(api);
+          const clutchUrl = getClutchUrl(api);
           try {
-            const response = await fetch(`${trapUrl}/api/chats/${to}/typing`, {
+            const response = await fetch(`${clutchUrl}/api/chats/${to}/typing`, {
               method: "POST",
               headers: { "Content-Type": "application/json" },
               body: JSON.stringify({ typing: isTyping, author: "ada" }),
             });
             if (!response.ok) {
-              api.logger.warn(`Trap: typing indicator failed - ${response.status}`);
+              api.logger.warn(`Clutch: typing indicator failed - ${response.status}`);
               return { ok: false, error: `HTTP ${response.status}` };
             }
             return { ok: true };
           } catch (error) {
-            api.logger.warn(`Trap: typing indicator error - ${error}`);
-            return { ok: false, error: error instanceof Error ? error.message : "Unknown error" };
+            api.logger.warn(`Clutch: typing indicator error - ${error}`);
+            return {
+              ok: false,
+              error: error instanceof Error ? error.message : "Unknown error",
+            };
           }
         },
-        
+
         sendText: async (ctx) => {
           const { to, text } = ctx;
           if (!to) return { ok: false, error: "No chat ID (to) provided" };
 
-          api.logger.info(`Trap: sendText to chat ${to}`);
-          const result = await sendToTrap(api, to, text);
-          if (!result.ok) api.logger.warn(`Trap: sendText failed - ${result.error}`);
-          return { ok: result.ok, messageId: result.messageId, error: result.error ? new Error(result.error) : undefined };
+          api.logger.info(`Clutch: sendText to chat ${to}`);
+          const result = await sendToClutch(api, to, text);
+          if (!result.ok) api.logger.warn(`Clutch: sendText failed - ${result.error}`);
+          return {
+            ok: result.ok,
+            messageId: result.messageId,
+            error: result.error ? new Error(result.error) : undefined,
+          };
         },
-        
+
         sendMedia: async (ctx) => {
           const { to, text, mediaUrl } = ctx;
           if (!to) return { ok: false, error: "No chat ID (to) provided" };
 
-          api.logger.info(`Trap: sendMedia to chat ${to}`);
-          const result = await sendToTrap(api, to, text || "📎 Attachment", { mediaUrl });
-          if (!result.ok) api.logger.warn(`Trap: sendMedia failed - ${result.error}`);
-          return { ok: result.ok, messageId: result.messageId, error: result.error ? new Error(result.error) : undefined };
+          api.logger.info(`Clutch: sendMedia to chat ${to}`);
+          const result = await sendToClutch(api, to, text || "📎 Attachment", { mediaUrl });
+          if (!result.ok) api.logger.warn(`Clutch: sendMedia failed - ${result.error}`);
+          return {
+            ok: result.ok,
+            messageId: result.messageId,
+            error: result.error ? new Error(result.error) : undefined,
+          };
         },
       },
     },
   });
 
-  api.logger.info("Trap channel plugin loaded (with agent_end hook)");
+  api.logger.info("Clutch channel plugin loaded (with agent_end hook)");
 }

--- a/worker/agent-manager.ts
+++ b/worker/agent-manager.ts
@@ -79,7 +79,7 @@ export class AgentManager {
     // Ensure gateway connection
     await this.gateway.connect()
 
-    const sessionKey = `agent:main:trap:${params.role}:${params.taskId.slice(0, 8)}`
+    const sessionKey = `agent:main:clutch:${params.role}:${params.taskId.slice(0, 8)}`
     const now = Date.now()
 
     // Create the long-running RPC promise

--- a/worker/session-watcher.ts
+++ b/worker/session-watcher.ts
@@ -80,18 +80,18 @@ function detectSessionType(sessionKey: string): SessionType {
     return "main"
   }
 
-  // agent:main:trap:{slug}:{chatId} → type chat
-  if (sessionKey.match(/^agent:main:trap:[^:]+:/)) {
+  // agent:main:clutch:{slug}:{chatId} → type chat
+  if (sessionKey.match(/^agent:main:clutch:[^:]+:/)) {
     return "chat"
   }
 
-  // agent:main:cron:*:trap-{taskIdPrefix} → type agent (work loop agent)
-  if (sessionKey.match(/^agent:main:cron:.*:trap-/)) {
+  // agent:main:cron:*:clutch-{taskIdPrefix} → type agent (work loop agent)
+  if (sessionKey.match(/^agent:main:cron:.*:clutch-/)) {
     return "agent"
   }
 
-  // agent:main:cron:*:trap-pr-review-* → type agent (reviewer)
-  if (sessionKey.match(/^agent:main:cron:.*:trap-pr-review-/)) {
+  // agent:main:cron:*:clutch-pr-review-* → type agent (reviewer)
+  if (sessionKey.match(/^agent:main:cron:.*:clutch-pr-review-/)) {
     return "agent"
   }
 
@@ -108,8 +108,8 @@ function detectSessionType(sessionKey: string): SessionType {
  * Extract project slug from session key (for chat/agent types).
  */
 function extractProjectSlug(sessionKey: string): string | undefined {
-  // agent:main:trap:{slug}:{chatId}
-  const match = sessionKey.match(/^agent:main:trap:([^:]+):/)
+  // agent:main:clutch:{slug}:{chatId}
+  const match = sessionKey.match(/^agent:main:clutch:([^:]+):/)
   if (match) {
     return match[1]
   }
@@ -120,14 +120,14 @@ function extractProjectSlug(sessionKey: string): string | undefined {
  * Extract task ID from session key (for agent types).
  */
 function extractTaskId(sessionKey: string): string | undefined {
-  // agent:main:cron:*:trap-{taskId}
-  const match = sessionKey.match(/:trap-([a-f0-9-]+)$/)
+  // agent:main:cron:*:clutch-{taskId}
+  const match = sessionKey.match(/:clutch-([a-f0-9-]+)$/)
   if (match) {
     return match[1]
   }
 
-  // agent:main:cron:*:trap-pr-review-{taskId}
-  const reviewMatch = sessionKey.match(/:trap-pr-review-([a-f0-9-]+)$/)
+  // agent:main:cron:*:clutch-pr-review-{taskId}
+  const reviewMatch = sessionKey.match(/:clutch-pr-review-([a-f0-9-]+)$/)
   if (reviewMatch) {
     return reviewMatch[1]
   }


### PR DESCRIPTION
Renames OpenClaw plugins from trap-* to clutch-* and updates session key prefixes + internal references.

- plugins/trap-channel.ts -> plugins/clutch-channel.ts
- plugins/trap-signal.ts -> plugins/clutch-signal.ts
- Updated docs and internal IDs/strings to clutch
- Updated session key prefix handling from trap:* to clutch:* (frontend + worker + convex)

Notes:
- Also copied clutch-channel.ts to ~/.openclaw/extensions/clutch-channel.ts and removed ~/.openclaw/extensions/trap-channel.ts (local-only; gateway config update is separate).