### PR TITLE
rename: worker and scripts from Trap to OpenClutch

### DIFF
--- a/scripts/qa-smoke-agent-browser.sh
+++ b/scripts/qa-smoke-agent-browser.sh
@@ -1,16 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Smoke test the Trap UI for a given project using Vercel agent-browser.
+# Smoke test the OpenClutch UI for a given project using Vercel agent-browser.
 #
 # Usage:
 #   ./scripts/qa-smoke-agent-browser.sh <project-slug> [base-url]
 #
 # Example:
-#   ./scripts/qa-smoke-agent-browser.sh the-trap http://192.168.7.200:3002
+#   ./scripts/qa-smoke-agent-browser.sh the-clutch http://192.168.7.200:3002
 
 SLUG="${1:-}"
-BASE_URL="${2:-${TRAP_URL:-http://192.168.7.200:3002}}"
+BASE_URL="${2:-${CLUTCH_URL:-http://192.168.7.200:3002}}"
 
 if [[ -z "$SLUG" ]]; then
   echo "Usage: $0 <project-slug> [base-url]" >&2
@@ -61,7 +61,7 @@ ab find role button click --name "Create Task" >/dev/null
 ab wait --text "${TITLE}" >/dev/null
 
 # 6) Screenshot for evidence
-OUT="/tmp/trap-qa-smoke-${SLUG}.png"
+OUT="/tmp/clutch-qa-smoke-${SLUG}.png"
 ab screenshot "$OUT" >/dev/null
 
 echo "OK: smoke test passed for project '${SLUG}'"

--- a/worker/chat-bridge.ts
+++ b/worker/chat-bridge.ts
@@ -40,7 +40,7 @@ async function main() {
       })
 
       if (!chat) {
-        // Not a Trap chat session, ignore
+        // Not an OpenClutch chat session, ignore
         return
       }
 

--- a/worker/phases/cleanup.ts
+++ b/worker/phases/cleanup.ts
@@ -234,8 +234,8 @@ async function cleanStaleBrowserTabs(ctx: BrowserCleanupContext): Promise<number
 
     const tabs = data.tabs ?? []
 
-    // Close tabs that look like agent-opened pages (localhost:3002, trap URLs)
-    // Keep about:blank, chrome://, extension pages, and non-trap URLs
+    // Close tabs that look like agent-opened pages (localhost:3002, clutch URLs)
+    // Keep about:blank, chrome://, extension pages, and non-clutch URLs
     const stalePatterns = [
       /localhost:3002/,
       /192\.168\.7\.200:3002/,

--- a/worker/phases/review.ts
+++ b/worker/phases/review.ts
@@ -64,7 +64,7 @@ interface PRInfo {
  * reviewer sub-agents to review them.
  *
  * Logic:
- * 1. Query tasks with status=in_review from Trap API
+ * 1. Query tasks with status=in_review from OpenClutch API
  * 2. For each task:
  *    a. Derive branch name: fix/<task-id-prefix> (first 8 chars)
  *    b. Check if open PR exists via gh CLI

--- a/worker/phases/triage.ts
+++ b/worker/phases/triage.ts
@@ -165,7 +165,7 @@ export async function runTriage(ctx: TriageContext): Promise<TriageResult> {
     // Send to Ada's main session via HTTP RPC (WS client hangs on sessions.send)
     try {
       console.log(`[Triage] Sending triage for task ${task.id.slice(0, 8)} "${task.title}" to Ada (attempt ${triageCount + 1})`)
-      const proxyUrl = process.env.TRAP_URL || "http://127.0.0.1:3002"
+      const proxyUrl = process.env.CLUTCH_URL || "http://127.0.0.1:3002"
       const resp = await fetch(`${proxyUrl}/api/openclaw/rpc`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -314,7 +314,7 @@ async function escalateTask(
     // table that nobody reads.
     try {
       const triageCount = task.auto_triage_count ?? 0
-      const proxyUrl = process.env.TRAP_URL || "http://127.0.0.1:3002"
+      const proxyUrl = process.env.CLUTCH_URL || "http://127.0.0.1:3002"
       await fetch(`${proxyUrl}/api/openclaw/rpc`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -431,7 +431,7 @@ async function buildTriageMessage(
   sections.push(``)
   sections.push(`## Available Actions`)
   sections.push(``)
-  sections.push(`You can take action via the Trap API. Here are the available options:`)
+  sections.push(`You can take action via the OpenClutch API. Here are the available options:`)
   sections.push(``)
 
   // Build curl examples using regular string concatenation to avoid escaping issues


### PR DESCRIPTION
## Summary

Renames remaining `trap`/`Trap` references in worker code, run.sh, and scripts to `clutch`/`OpenClutch`.

### Changes

**worker/phases/cleanup.ts** — comments: trap URLs → clutch URLs
**worker/phases/triage.ts** — `TRAP_URL` env var → `CLUTCH_URL`, "Trap API" → "OpenClutch API"
**worker/phases/review.ts** — comment: "Trap API" → "OpenClutch API"
**worker/chat-bridge.ts** — comment: "Trap chat session" → "OpenClutch chat session"
**run.sh** — all `[trap]` log prefixes → `[clutch]`, header comment, status banner, tmp file paths
**scripts/qa-smoke-agent-browser.sh** — comment, `TRAP_URL` → `CLUTCH_URL`, tmp file path

### Not changed (deferred to Wave 3 systemd ticket)
- Systemd service name variables (`trap-server`, `trap-loop`, etc.) in run.sh
- Bash `trap` builtin calls (not product references)

### Verification
- `grep -rni "trap" worker/ --include="*.ts"` → zero results ✅
- `grep -ri "trap" run.sh` → only systemd service names + bash trap builtin ✅
- `grep -ri "trap" scripts/` → only bash trap builtin ✅
- `pnpm build` ✅
- `pnpm typecheck` ✅