### PR TITLE
rename: docs and planning files from Trap to OpenClutch

### DIFF
--- a/.planning/PLAN.md
+++ b/.planning/PLAN.md
@@ -1,4 +1,4 @@
-# The Trap — Comprehensive Build Plan
+# OpenClutch — Comprehensive Build Plan
 
 > AI Agent Orchestration Dashboard for OpenClaw
 > 
@@ -8,7 +8,7 @@
 
 ## Vision
 
-The Trap is the control center for a coordinated AI agent system. It's where:
+OpenClutch is the control center for a coordinated AI agent system. It's where:
 - **Ada** (the coordinator) manages work across projects
 - **Specialized agents** execute tasks with clear handoffs
 - **Dan** has full visibility into what's happening
@@ -40,7 +40,7 @@ The Trap is the control center for a coordinated AI agent system. It's where:
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
-│                        THE TRAP (UI)                            │
+│                     OPENCLUTCH (UI)                             │
 │  ┌─────────────────────────────────────────────────────────┐   │
 │  │                    Project View                          │   │
 │  │  ┌─────────┐  ┌─────────┐  ┌─────────┐  ┌─────────┐    │   │
@@ -424,7 +424,7 @@ These become OpenClaw tools available to agent sessions.
 **Goal**: Efficient heartbeat that only wakes when needed
 
 **Deliverables**:
-- `bin/trap-gate.sh` — Reads board state
+- `bin/clutch-gate.sh` — Reads board state
 - Wake conditions:
   - Tasks in Ready with no assignee
   - Comments requesting input
@@ -478,7 +478,7 @@ These become OpenClaw tools available to agent sessions.
 ## File Structure
 
 ```
-trap/
+clutch/
 ├── app/
 │   ├── api/
 │   │   ├── projects/
@@ -536,11 +536,11 @@ trap/
    - *Current thinking*: Single-user for now, add later if needed
 
 2. **Persistence**: SQLite file location?
-   - *Current thinking*: `~/.trap/trap.db`
+   - *Current thinking*: `~/.clutch/clutch.db`
 
 3. **Project context files**: Where do they live?
-   - *Current thinking*: `~/.trap/projects/{slug}/`
+   - *Current thinking*: `~/.clutch/projects/{slug}/`
 
 ---
 
-*This document is the source of truth for The Trap build.*
+*This document is the source of truth for the OpenClutch build.*

--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -1,4 +1,4 @@
-# The Trap
+# OpenClutch
 
 ## What This Is
 
@@ -42,7 +42,7 @@ See what OpenClaw is doing, kill what needs killing, and keep work organized —
 - **OpenClaw API**: Comprehensive WebSocket API on port 18789 with 80+ methods covering sessions, cron, chat, config, usage/costs, agents, nodes, and more. Also has OpenAI-compatible REST endpoints.
 - **Existing UI**: OpenClaw has a built-in Control UI (Lit/TypeScript, served from gateway). It's functional but ugly, slow, and missing key features like session cancellation and cost tracking.
 - **Plugin system**: OpenClaw has an extensible plugin architecture — plugins can register gateway methods, HTTP handlers, tools, channels, services, and CLI commands. This may be useful for the task/todo system.
-- **Task data question**: Tasks need to be accessible from any OpenClaw interface (chat, Slack, The Trap), not just The Trap. Options include OpenClaw's memory system, a dedicated plugin, or native OpenClaw task support. Research needed.
+- **Task data question**: Tasks need to be accessible from any OpenClaw interface (chat, Slack, OpenClutch), not just OpenClutch. Options include OpenClaw's memory system, a dedicated plugin, or native OpenClaw task support. Research needed.
 - **Project concept**: A "project" is an organizing layer that groups tasks, cron jobs, and chats. Things get associated via context (start a chat "in" a project) or manual tagging.
 - **OpenClaw source**: Available at ~/src/openclaw for reference.
 
@@ -52,7 +52,7 @@ See what OpenClaw is doing, kill what needs killing, and keep work organized —
 - **Data transport**: WebSocket client connecting to OpenClaw gateway (ws://localhost:18789)
 - **Hosting**: Local on byteFORCE initially
 - **Code quality**: Test coverage, CI, precommit hooks, documentation — built to release quality from day one
-- **Data ownership**: Prefer data to live in OpenClaw's domain (accessible from any interface) rather than siloed in The Trap's database
+- **Data ownership**: Prefer data to live in OpenClaw's domain (accessible from any interface) rather than siloed in OpenClutch's database
 
 ## Key Decisions
 

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -1,4 +1,4 @@
-# Requirements: The Trap
+# Requirements: OpenClutch
 
 **Defined:** 2026-02-02
 **Core Value:** See what OpenClaw is doing, kill what needs killing, and keep work organized — without juggling Discord, the built-in UI, and spreadsheets.

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -1,8 +1,8 @@
-# Roadmap: The Trap
+# Roadmap: OpenClutch
 
 ## Overview
 
-The Trap is a WebSocket-driven real-time dashboard for OpenClaw AI agents. The roadmap starts with foundation-first architecture (WebSocket lifecycle, state management, Next.js caching config) to prevent critical pitfalls, then builds core monitoring features (sessions, cron, analytics, chat), and finishes with differentiating features (task management, project organization) that tie everything together. Each phase delivers observable user capabilities backed by comprehensive infrastructure.
+OpenClutch is a WebSocket-driven real-time dashboard for OpenClaw AI agents. The roadmap starts with foundation-first architecture (WebSocket lifecycle, state management, Next.js caching config) to prevent critical pitfalls, then builds core monitoring features (sessions, cron, analytics, chat), and finishes with differentiating features (task management, project organization) that tie everything together. Each phase delivers observable user capabilities backed by comprehensive infrastructure.
 
 ## Phases
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -54,7 +54,7 @@ None yet.
 
 **From research:**
 - Phase 5 (Analytics): Recharts performance with real OpenClaw data volume is uncertain - may need to prototype early or research alternatives if performance ceiling is hit
-- Phase 7 (Task Management): Integration approach with OpenClaw needs research - how to store tasks in OpenClaw domain so they're accessible from any interface (chat, Slack, The Trap)
+- Phase 7 (Task Management): Integration approach with OpenClaw needs research - how to store tasks in OpenClaw domain so they're accessible from any interface (chat, Slack, OpenClutch)
 - Overall: Deployment target unknown (Vercel edge vs self-hosted vs client-only) - affects database choice for task/project persistence
 
 ## Session Continuity

--- a/.planning/codebase/ARCHITECTURE.md
+++ b/.planning/codebase/ARCHITECTURE.md
@@ -143,7 +143,7 @@
 
 **Background worker / CLI:**
 - Work loop process: `worker/loop.ts` (run standalone via `npx tsx worker/loop.ts`)
-- CLI tool: `bin/trap.ts` (registered as `trap` bin in `package.json`)
+- CLI tool: `bin/clutch.ts` (registered as `clutch` bin in `package.json`)
 
 ## Error Handling
 

--- a/.planning/codebase/INTEGRATIONS.md
+++ b/.planning/codebase/INTEGRATIONS.md
@@ -62,8 +62,8 @@
 - None detected (no Sentry/etc in `package.json`; logging uses `console.*` across server/worker code)
 
 **Logs:**
-- Next.js server logs: stdout/stderr (managed by `run.sh` into `/tmp/trap-prod.log`)
-- Worker logs: stdout/stderr (managed by `run.sh` into `/tmp/trap-loop.log` and `/tmp/trap-bridge.log`)
+- Next.js server logs: stdout/stderr (managed by `run.sh` into `/tmp/clutch-prod.log`)
+- Worker logs: stdout/stderr (managed by `run.sh` into `/tmp/clutch-loop.log` and `/tmp/clutch-bridge.log`)
 
 ## CI/CD & Deployment
 
@@ -79,7 +79,7 @@
 
 **Required env vars:**
 - Convex:
-  - `CONVEX_URL` (server/worker Convex HTTP client) used in `lib/convex/server.ts`, `worker/loop.ts`, `worker/chat-bridge.ts`, `bin/trap.ts`
+  - `CONVEX_URL` (server/worker Convex HTTP client) used in `lib/convex/server.ts`, `worker/loop.ts`, `worker/chat-bridge.ts`, `bin/clutch.ts`
   - `NEXT_PUBLIC_CONVEX_URL` (browser Convex React client) used in `lib/convex/client.ts`
   - `CONVEX_SELF_HOSTED_URL` / `NEXT_PUBLIC_CONVEX_SELF_HOSTED_URL` (alternate Convex config) used in `lib/convex-server.ts`
 - OpenClaw:
@@ -91,25 +91,25 @@
   - `NEXT_PUBLIC_OPENCLAW_API_URL` (OpenClaw REST API base) used in `lib/api/client.ts`
 - Work loop:
   - `WORK_LOOP_ENABLED`, `WORK_LOOP_CYCLE_MS`, `WORK_LOOP_MAX_AGENTS_PER_PROJECT`, `WORK_LOOP_MAX_AGENTS`, `WORK_LOOP_MAX_DEV_AGENTS`, `WORK_LOOP_MAX_REVIEWER_AGENTS`, `WORK_LOOP_STALE_TASK_MINUTES`, `WORK_LOOP_STALE_REVIEW_MINUTES` used in `worker/config.ts`
-- Trap (used by OpenClaw plugins / scripts):
-  - `TRAP_URL` (base URL for Trap) used in `plugins/trap-signal.ts`, `bin/trap-gate.sh`, `scripts/qa-smoke-agent-browser.sh`
-  - `TRAP_API_URL` (alternate name) used in `plugins/trap-channel.ts`
+- OpenClutch (used by OpenClaw plugins / scripts):
+  - `CLUTCH_URL` (base URL for OpenClutch) used in `plugins/clutch-signal.ts`, `bin/clutch-gate.sh`, `scripts/qa-smoke-agent-browser.sh`
+  - `CLUTCH_API_URL` (alternate name) used in `plugins/clutch-channel.ts`
 
 **Secrets location:**
 - Local development uses `.env.local` (loaded by `run.sh`; referenced in `README.md`).
-- OpenClaw plugin environment uses OpenClaw config env (`plugins/trap-channel.ts` reads `api.config.env`).
+- OpenClaw plugin environment uses OpenClaw config env (`plugins/clutch-channel.ts` reads `api.config.env`).
 
 ## Webhooks & Callbacks
 
 **Incoming:**
-- OpenClaw → Trap (plugin callbacks via HTTP POST):
-  - Persist assistant responses: `plugins/trap-channel.ts` → `POST /api/chats/:chatId/messages` (implemented by `app/api/chats/[id]/messages/route.ts`)
-  - Typing indicator updates: `plugins/trap-channel.ts` → `POST /api/chats/:chatId/typing` (implemented by `app/api/chats/[id]/typing/route.ts`)
-  - Agent signals and completion: `plugins/trap-signal.ts` → `POST /api/signal` and `POST /api/tasks/:id/complete` (implemented by `app/api/signal/route.ts`, `app/api/tasks/[id]/complete/route.ts`)
+- OpenClaw → OpenClutch (plugin callbacks via HTTP POST):
+  - Persist assistant responses: `plugins/clutch-channel.ts` → `POST /api/chats/:chatId/messages` (implemented by `app/api/chats/[id]/messages/route.ts`)
+  - Typing indicator updates: `plugins/clutch-channel.ts` → `POST /api/chats/:chatId/typing` (implemented by `app/api/chats/[id]/typing/route.ts`)
+  - Agent signals and completion: `plugins/clutch-signal.ts` → `POST /api/signal` and `POST /api/tasks/:id/complete` (implemented by `app/api/signal/route.ts`, `app/api/tasks/[id]/complete/route.ts`)
 
 **Outgoing:**
-- Trap → GitHub public API for repo validation: `app/api/validate/github/route.ts`
-- Trap → OpenClaw gateway WS RPC via proxy: `app/api/openclaw/rpc/route.ts` → `lib/openclaw/client.ts`
+- OpenClutch → GitHub public API for repo validation: `app/api/validate/github/route.ts`
+- OpenClutch → OpenClaw gateway WS RPC via proxy: `app/api/openclaw/rpc/route.ts` → `lib/openclaw/client.ts`
 
 ---
 

--- a/.planning/codebase/STACK.md
+++ b/.planning/codebase/STACK.md
@@ -5,11 +5,11 @@
 ## Languages
 
 **Primary:**
-- TypeScript (TS/TSX) - Application code in `app/**`, `components/**`, `lib/**`, `worker/**`, `convex/**`, `bin/trap.ts`
+- TypeScript (TS/TSX) - Application code in `app/**`, `components/**`, `lib/**`, `worker/**`, `convex/**`, `bin/clutch.ts`
 
 **Secondary:**
 - CSS - Global styles in `app/globals.css` (Tailwind v4 + tw-animate)
-- Shell (bash/sh) - Ops scripts in `run.sh`, `bin/trap-gate.sh`, `scripts/qa-smoke-agent-browser.sh`
+- Shell (bash/sh) - Ops scripts in `run.sh`, `bin/clutch-gate.sh`, `scripts/qa-smoke-agent-browser.sh`
 
 ## Runtime
 
@@ -47,7 +47,7 @@
 - `zustand` ^5.0.11 - client state management (stores in `lib/stores/**`)
 
 **Infrastructure:**
-- `tsx` ^4.21.0 - run TS worker/CLI processes (used by `bin/trap.ts` shebang and `run.sh` to run `worker/loop.ts` / `worker/chat-bridge.ts`)
+- `tsx` ^4.21.0 - run TS worker/CLI processes (used by `bin/clutch.ts` shebang and `run.sh` to run `worker/loop.ts` / `worker/chat-bridge.ts`)
 - `tailwindcss` ^4 + `tailwind-merge` ^3.4.0 - styling utilities (`app/globals.css`, `components.json`)
 - shadcn/ui (generated components) - UI primitives in `components/ui/**` and config in `components.json`
 - `radix-ui` ^1.4.3 - UI primitives used by shadcn components (dependency in `package.json`)

--- a/.planning/codebase/STRUCTURE.md
+++ b/.planning/codebase/STRUCTURE.md
@@ -28,7 +28,7 @@
 │   └── types/           # Type definitions grouped by domain
 ├── worker/              # Background work-loop process + gateway client + phases
 │   └── phases/          # Phase implementations (work/review/analyze/cleanup/notify/signals)
-├── bin/                 # Executables (e.g., trap CLI)
+├── bin/                 # Executables (e.g., clutch CLI)
 ├── plugins/             # Optional plugin integrations (excluded from TS project build)
 ├── test/                # Vitest tests + setup
 ├── public/              # Static assets served by Next.js
@@ -93,11 +93,11 @@
 
 **`bin/`:**
 - Purpose: executable entry points.
-- Key files: `bin/trap.ts` (registered as `trap` in `package.json`).
+- Key files: `bin/clutch.ts` (registered as `clutch` in `package.json`).
 
 **`plugins/`:**
 - Purpose: optional plugin integrations.
-- Key files: `plugins/trap-channel.ts`, `plugins/trap-signal.ts`.
+- Key files: `plugins/clutch-channel.ts`, `plugins/clutch-signal.ts`.
 - Note: excluded from main TS config (`tsconfig.json` excludes `plugins`).
 
 **`test/`:**
@@ -110,7 +110,7 @@
 - `app/layout.tsx`: root HTML shell + providers.
 - `app/page.tsx`: root page (client-only wrapper for `app/home-content.tsx`).
 - `worker/loop.ts`: work-loop process entry (standalone or imported).
-- `bin/trap.ts`: CLI entry.
+- `bin/clutch.ts`: CLI entry.
 
 **Configuration:**
 - `next.config.ts`: Next.js config.

--- a/.planning/research/ARCHITECTURE.md
+++ b/.planning/research/ARCHITECTURE.md
@@ -6,7 +6,7 @@
 
 ## Recommended Architecture
 
-The Trap is fundamentally a **WebSocket-first client application** that consumes OpenClaw's gateway API. Unlike typical Next.js CRUD apps that rely on server-side rendering and database queries, The Trap's primary data source is a persistent WebSocket connection delivering real-time events and handling 80+ RPC methods.
+OpenClutch is fundamentally a **WebSocket-first client application** that consumes OpenClaw's gateway API. Unlike typical Next.js CRUD apps that rely on server-side rendering and database queries, OpenClutch's primary data source is a persistent WebSocket connection delivering real-time events and handling 80+ RPC methods.
 
 ### System Overview
 
@@ -575,7 +575,7 @@ src/
 
 **Why last:** Requires coordination with OpenClaw architecture, may need upstream changes.
 
-**Validation:** Ada creates task via chat, appears in The Trap's task board.
+**Validation:** Ada creates task via chat, appears in the OpenClutch board.
 
 ---
 

--- a/.planning/research/FEATURES.md
+++ b/.planning/research/FEATURES.md
@@ -11,7 +11,7 @@ AI agent dashboards in 2026 fall into two categories:
 1. **Multi-tenant observability platforms** (LangSmith, AgentOps, Helicone) - Focus on production monitoring, team collaboration, usage analytics
 2. **Single-user control centers** (OpenAI Dashboard, local dev tools) - Focus on direct control, session management, and real-time interaction
 
-The Trap falls into category 2 but with unique characteristics: it's a **single-user operational dashboard** that combines observability features (cost tracking, session monitoring) with direct control features (kill sessions, manage cron jobs, chat interface). The project-based organization pattern is differentiating - most dashboards organize by time/user/model, not by logical project groupings.
+OpenClutch falls into category 2 but with unique characteristics: it's a **single-user operational dashboard** that combines observability features (cost tracking, session monitoring) with direct control features (kill sessions, manage cron jobs, chat interface). The project-based organization pattern is differentiating - most dashboards organize by time/user/model, not by logical project groupings.
 
 Key insight: **Table stakes have shifted dramatically in 2026**. Session tracing, cost tracking, and real-time monitoring were differentiators in 2024-2025 but are now expected. Differentiators in 2026 are: AI-powered insights, bidirectional task management, advanced failure recovery, and rich interactive UIs beyond text-only chat.
 
@@ -109,7 +109,7 @@ Features users expect. Missing these = product feels broken or incomplete.
 
 ## Differentiators
 
-Features that set The Trap apart. Not expected, but highly valued. These create competitive advantage.
+Features that set OpenClutch apart. Not expected, but highly valued. These create competitive advantage.
 
 ### Project-Based Organization
 
@@ -213,12 +213,12 @@ Features to explicitly **NOT** build. Common mistakes in this domain.
 
 | Anti-Feature | Why Avoid | What to Do Instead |
 |--------------|-----------|-------------------|
-| **User authentication system** | Trap is single-user; auth adds complexity with zero value | Assume localhost access = trusted user |
+| **User authentication system** | OpenClutch is single-user; auth adds complexity with zero value | Assume localhost access = trusted user |
 | **Role-based access control** | No multi-user means no roles needed | Single global permission level (full control) |
 | **Team collaboration features** | Not a team tool; adding this dilutes focus | Keep it single-user, suggest LangSmith for teams |
 | **Public sharing of sessions** | Security risk; no use case for single user | Sessions are private by default, no sharing |
 
-**Rationale:** LangSmith, AgentOps, Helicone are multi-tenant SaaS platforms. Their complexity stems from supporting teams. The Trap is explicitly single-user, local-first. Adding auth/teams would be **massive scope creep** and compete with established platforms. Stay in the lane of "personal dev dashboard."
+**Rationale:** LangSmith, AgentOps, Helicone are multi-tenant SaaS platforms. Their complexity stems from supporting teams. OpenClutch is explicitly single-user, local-first. Adding auth/teams would be **massive scope creep** and compete with established platforms. Stay in the lane of "personal dev dashboard."
 
 **Sources:**
 - [Personal Dashboards - Awesome Self-hosted](https://awesome-selfhosted.net/tags/personal-dashboards.html)
@@ -233,7 +233,7 @@ Features to explicitly **NOT** build. Common mistakes in this domain.
 | **Custom alerting rules engine** | Complex feature with low ROI for single user | Simple threshold alerts (e.g., cost > $X) hardcoded |
 | **Log aggregation across services** | No microservices architecture here | Single log stream from OpenClaw, display in UI |
 
-**Rationale:** Production observability platforms (Datadog, New Relic, Dynatrace) handle distributed systems with thousands of services. The Trap is a single-user app on one machine. Don't import enterprise complexity. Keep it simple: SQLite for storage, WebSocket for real-time updates, basic charts.
+**Rationale:** Production observability platforms (Datadog, New Relic, Dynatrace) handle distributed systems with thousands of services. OpenClutch is a single-user app on one machine. Don't import enterprise complexity. Keep it simple: SQLite for storage, WebSocket for real-time updates, basic charts.
 
 **Sources:**
 - [AI Observability Anti-Patterns 2026](https://composio.dev/blog/why-ai-agent-pilots-fail-2026-integration-roadmap)
@@ -248,7 +248,7 @@ Features to explicitly **NOT** build. Common mistakes in this domain.
 | **White-label/theming engine** | Not a product for resale | Single default theme, maybe dark mode toggle |
 | **API for third-party integrations** | No third parties in single-user app | Direct DB access if automation needed |
 
-**Rationale:** These are features for **platforms** (products other people build on). The Trap is a **tool** (single purpose, single user). Generalization costs time and creates maintenance burden. Build exactly what's needed for OpenClaw, no more.
+**Rationale:** These are features for **platforms** (products other people build on). OpenClutch is a **tool** (single purpose, single user). Generalization costs time and creates maintenance burden. Build exactly what's needed for OpenClaw, no more.
 
 ### "Dumb RAG" - Bad Memory Management
 
@@ -393,7 +393,7 @@ These unknowns should be answered in **Phase 1: OpenClaw Integration Research**.
 - Monolithic agents (shifting to specialized micro-agents)
 - No observability (2026 requires built-in monitoring)
 
-**Strategic positioning:** The Trap should embrace 2026 trends (project-based organization, bidirectional tasks) while nailing table stakes. Avoid competing on features where LangSmith/AgentOps already excel (multi-tenant observability, team collaboration). Double down on **single-user dev experience** with **project-centric workflow**.
+**Strategic positioning:** OpenClutch should embrace 2026 trends (project-based organization, bidirectional tasks) while nailing table stakes. Avoid competing on features where LangSmith/AgentOps already excel (multi-tenant observability, team collaboration). Double down on **single-user dev experience** with **project-centric workflow**.
 
 ---
 

--- a/.planning/research/PITFALLS.md
+++ b/.planning/research/PITFALLS.md
@@ -205,7 +205,7 @@ const handleKill = useCallback((sessionId) => {
 **Prevention:**
 ```typescript
 // Pattern 1: Use BroadcastChannel API for cross-tab sync
-const channel = new BroadcastChannel('trap-state');
+const channel = new BroadcastChannel('clutch-state');
 
 channel.addEventListener('message', (event) => {
   // Update local state when other tabs broadcast changes

--- a/.planning/research/STACK.md
+++ b/.planning/research/STACK.md
@@ -1,6 +1,6 @@
 # Technology Stack
 
-**Project:** The Trap - Real-time AI Agent Dashboard
+**Project:** OpenClutch - Real-time AI Agent Dashboard
 **Researched:** 2026-02-02
 **Overall Confidence:** HIGH
 
@@ -166,7 +166,7 @@ npm install -D vite-tsconfig-paths  # For TypeScript path mapping
 
 ### Next.js 15 + WebSocket
 
-**IMPORTANT:** Next.js doesn't support hosting WebSocket servers on Vercel. However, **connecting to external WebSocket servers from the client works fine**. For The Trap:
+**IMPORTANT:** Next.js doesn't support hosting WebSocket servers on Vercel. However, **connecting to external WebSocket servers from the client works fine**. For OpenClutch:
 - OpenClaw gateway runs separately (WebSocket server)
 - Next.js dashboard connects via native browser WebSocket API (client-side)
 - No Next.js server involvement needed

--- a/.planning/research/SUMMARY.md
+++ b/.planning/research/SUMMARY.md
@@ -1,13 +1,13 @@
 # Project Research Summary
 
-**Project:** The Trap - Real-time AI Agent Dashboard
+**Project:** OpenClutch - Real-time AI Agent Dashboard
 **Domain:** Real-time dashboard/control center with WebSocket-driven architecture
 **Researched:** 2026-02-02
 **Confidence:** HIGH
 
 ## Executive Summary
 
-The Trap is a single-user operational dashboard for OpenClaw AI agents, fundamentally different from typical Next.js CRUD apps. Unlike multi-tenant observability platforms (LangSmith, AgentOps), The Trap combines real-time monitoring with direct control in a project-centric workflow. The architecture centers on a persistent WebSocket connection to OpenClaw's gateway (80+ RPC methods, real-time event streams), not traditional REST APIs or database queries.
+OpenClutch is a single-user operational dashboard for OpenClaw AI agents, fundamentally different from typical Next.js CRUD apps. Unlike multi-tenant observability platforms (LangSmith, AgentOps), OpenClutch combines real-time monitoring with direct control in a project-centric workflow. The architecture centers on a persistent WebSocket connection to OpenClaw's gateway (80+ RPC methods, real-time event streams), not traditional REST APIs or database queries.
 
 The recommended approach: Build a **WebSocket-first client application** using Next.js 15 App Router with a clear client/server boundary. Use native browser WebSocket API (not Socket.IO) for the OpenClaw connection, TanStack Query for server state caching, Zustand for local UI state, and Vercel AI Elements for chat with rich widgets. The foundation (WebSocket singleton, reconnection logic, event dispatcher) must be solid before building features, as everything depends on real-time data flows.
 
@@ -17,7 +17,7 @@ Key risks center on WebSocket lifecycle management: memory leaks from improper c
 
 ### Recommended Stack
 
-The stack is optimized for **WebSocket-driven real-time updates** with structured AI chat, not traditional server-side rendered pages. Critical insight: Next.js limitations on hosting WebSocket servers don't matter because OpenClaw runs its own gateway - The Trap only needs to connect as a client.
+The stack is optimized for **WebSocket-driven real-time updates** with structured AI chat, not traditional server-side rendered pages. Critical insight: Next.js limitations on hosting WebSocket servers don't matter because OpenClaw runs its own gateway - OpenClutch only needs to connect as a client.
 
 **Core technologies:**
 - **Next.js 15 (App Router):** Web framework - Server Components for static shell, Client Components for real-time views. Use `dynamic = 'force-dynamic'` to prevent over-caching.
@@ -62,7 +62,7 @@ Research reveals a sharp divide between **table stakes** (expected by 2026) and 
 
 ### Architecture Approach
 
-The Trap is a **client-island architecture** where Server Components provide static shell/layout, and a single Client Component island manages the WebSocket connection with event distribution to child components. Unlike REST-based dashboards that refetch on navigation, The Trap maintains persistent connection state and updates views reactively via events.
+OpenClutch is a **client-island architecture** where Server Components provide static shell/layout, and a single Client Component island manages the WebSocket connection with event distribution to child components. Unlike REST-based dashboards that refetch on navigation, OpenClutch maintains persistent connection state and updates views reactively via events.
 
 **Major components:**
 1. **WebSocketProvider (singleton)** — Manages single WebSocket connection lifecycle, reconnection with exponential backoff (1s to 30s), heartbeat monitoring. Created once in root layout, shared via Context. ALL data flows through this component.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,10 @@
-# AGENTS.md - Trap Workspace
+# AGENTS.md - OpenClutch Workspace
 
 ## Dev Server
 - **Running on port 3002** — do NOT start another
 - Turbopack hot-reloads on save
 - Check status: `curl -s -o /dev/null -w "%{http_code}" http://localhost:3002/`
-- If dead: `rm -f .next/dev/lock && PORT=3002 nohup pnpm dev > /tmp/trap-next.log 2>&1 &`
+- If dead: `rm -f .next/dev/lock && PORT=3002 nohup pnpm dev > /tmp/clutch-next.log 2>&1 &`
 
 ## Commands
 - `pnpm build` — production build

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -595,7 +595,7 @@ export default defineSchema({
   // Sessions - unified tracking for all OpenClaw sessions (main, chat, agent, cron)
   sessions: defineTable({
     id: v.string(), // UUID primary key
-    session_key: v.optional(v.string()), // e.g. "agent:main:main", "agent:main:trap:the-trap:xxx"
+    session_key: v.optional(v.string()), // e.g. "agent:main:main", "agent:main:clutch:clutch:xxx"
     session_id: v.string(), // UUID from sessions.json
     session_type: v.union(
       v.literal("main"),

--- a/docs/WORK-LOOP-V2.md
+++ b/docs/WORK-LOOP-V2.md
@@ -63,7 +63,7 @@ The loop becomes a dumb state machine. All intelligence moves to the agents (who
 
 ## Agent Signal Contract
 
-Agents communicate via the Trap API. Every agent MUST do one of these before finishing:
+Agents communicate via the OpenClutch API. Every agent MUST do one of these before finishing:
 
 ### 1. Done — task complete
 ```bash

--- a/docs/agent-roles.md
+++ b/docs/agent-roles.md
@@ -1,6 +1,6 @@
 # Agent Roles System
 
-Trap supports specialized agent roles through SOUL templates that define behavior, expertise, and decision-making patterns for ephemeral agents.
+OpenClutch supports specialized agent roles through SOUL templates that define behavior, expertise, and decision-making patterns for ephemeral agents.
 
 ## Available Roles
 
@@ -13,7 +13,7 @@ Role templates are stored in `/home/dan/clawd/roles/` and can be injected into a
 | **QA Engineer** | `qa.md` | Testing strategy, bug identification, quality validation |
 | **Research Specialist** | `researcher.md` | Market research, technical investigation, competitive analysis |
 
-## Usage in Trap
+## Usage in OpenClutch
 
 ### Role Assignment
 When spawning agents, specify role template to inject specialized behavior:
@@ -45,7 +45,7 @@ Each role defines specific quality bars that must be met before work progresses:
 ## Integration Points
 
 ### Task Routing
-Trap can automatically route work to appropriate role agents based on task type:
+OpenClutch can automatically route work to appropriate role agents based on task type:
 - Code architecture → PE role
 - Feature breakdown → PM role
 - Testing requirements → QA role

--- a/docs/cron-deprecation.md
+++ b/docs/cron-deprecation.md
@@ -7,22 +7,22 @@ The old cron-based work loop system has been replaced by the persistent worker (
 | Component | Old (cron-based) | New (persistent worker) |
 |-----------|-------------------|------------------------|
 | Scheduling | OpenClaw cron job every 30s | Persistent Node.js process |
-| Gate script | `~/bin/trap-gate.sh` | `worker/loop.ts` with phases |
+| Gate script | `~/bin/clutch-gate.sh` | `worker/loop.ts` with phases |
 | Agent spawn | Cron script resolver → sub-agent | `GatewayRpcClient` → real sessions |
-| Worktree cleanup | `~/bin/trap-worktree-cleanup.sh` | `worker/phases/cleanup.ts` |
+| Worktree cleanup | `~/bin/clutch-worktree-cleanup.sh` | `worker/phases/cleanup.ts` |
 | Review routing | Gate script section 3 | `worker/phases/review.ts` |
 
 ## Archived Files
 
-- `~/bin/archive/trap-gate.sh.deprecated` — original gate script
-- `~/bin/archive/trap-worktree-cleanup.sh.deprecated` — original cleanup script
+- `~/bin/archive/clutch-gate.sh.deprecated` — original gate script
+- `~/bin/archive/clutch-worktree-cleanup.sh.deprecated` — original cleanup script
 
 Stub scripts remain at the old paths with deprecation notices, so any accidental invocation returns a no-op.
 
 ## Cron Jobs Removed
 
-- `trap-work-loop` (ID `a4512186-e8a2-468b-b0ff-c5525469a628`) — deleted from OpenClaw cron
-- No `trap-qa-loop` job existed
+- `clutch-work-loop` (ID `a4512186-e8a2-468b-b0ff-c5525469a628`) — deleted from OpenClaw cron
+- No `clutch-qa-loop` job existed
 
 ## Why
 

--- a/hooks/use-observatory-filters.ts
+++ b/hooks/use-observatory-filters.ts
@@ -24,7 +24,7 @@ const DEFAULT_TIME_RANGE: TimeRange = "7d"
  * Hook for managing Observatory filter state (project + time range).
  * 
  * Persists filter state to URL search params:
- * - `?project=the-trap&range=7d`
+ * - `?project=clutch&range=7d`
  * - `?range=24h` (no project = All Projects)
  * 
  * Use this hook across all Observatory tabs to maintain filter

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -9,7 +9,7 @@ import { api } from "@/convex/_generated/api"
 export async function register() {
   // Only run on server
   if (process.env.NEXT_RUNTIME === 'nodejs') {
-    console.log('[Trap] Server ready (no background services)')
+    console.log('[OpenClutch] Server ready (no background services)')
 
     // OpenClaw WebSocket client and work loop both run as separate processes
     // to keep the Next.js event loop clean for serving pages.


### PR DESCRIPTION
This PR renames all references from "Trap" to "OpenClutch" in documentation and planning files.

## Changes
- Updated product name from "The Trap" to "OpenClutch" in all docs
- Changed slug references from "the-trap" to "clutch"
- Updated API references from "Trap API" to "OpenClutch API"
- Renamed CLI references from "trap-cli" to "clutch-cli"
- Updated systemd service names to clutch-* pattern
- Changed file path references in log files and configs

## Files Updated
- **docs/**: agent-roles.md, WORK-LOOP-V2.md, cron-deprecation.md
- **AGENTS.md**: Root agent guide
- **.planning/**: All planning files (PLAN.md, PROJECT.md, REQUIREMENTS.md, ROADMAP.md, STATE.md)
- **.planning/codebase/**: All codebase documentation
- **.planning/research/**: All research files
- **convex/schema.ts**: Session key example comment
- **hooks/use-observatory-filters.ts**: URL example comment
- **instrumentation.ts**: Console log message

## Preserved
- File paths like `/home/dan/src/trap` remain unchanged (directory hasn't moved yet)
- General terms like "project management trap" unchanged

## Verification
- ✅ `pnpm build` passes
- ✅ `pnpm typecheck` passes  
- ✅ Only file path references to /src/trap remain (as intended)
- ✅ All product/brand references updated to OpenClutch