### PR TITLE
fix: reviewer prompt - pass PR number and make merge explicit

### DIFF
--- a/worker/phases/review.ts
+++ b/worker/phases/review.ts
@@ -428,6 +428,7 @@ async function processTask(ctx: ReviewContext, task: Task): Promise<TaskProcessR
       projectId: project.id,
       repoDir: project.local_path!,
       worktreeDir: worktreePath,
+      prNumber: pr.number,
       comments,
     }, { convex })
   } catch (promptError) {


### PR DESCRIPTION
Ticket: 786be14e-1482-4644-ab2b-932c8a0c629b

Fixes reviewers finishing without merging by making merge an explicit numbered step with the actual PR number.