### PR TITLE
Remove cost/price display from chat sidebar agent status

### DIFF
--- a/components/agents/agent-status.tsx
+++ b/components/agents/agent-status.tsx
@@ -154,7 +154,6 @@ export function AgentStatus({
   const displayStatus = getDisplayStatus(session)
   const modelName = formatModelShort(session?.model)
   const totalTokens = session?.tokens_total ?? 0
-  const cost = session?.cost_total
 
   if (variant === "compact") {
     // Compact variant for sidebar (single line)
@@ -173,12 +172,6 @@ export function AgentStatus({
             <>
               {" · "}
               {formatTokenCount(totalTokens)} tokens
-            </>
-          )}
-          {cost && cost > 0 && (
-            <>
-              {" · "}
-              {formatCost(cost)}
             </>
           )}
         </span>
@@ -200,12 +193,6 @@ export function AgentStatus({
           <>
             {" · "}
             {formatTokenCount(totalTokens)} tokens
-          </>
-        )}
-        {cost && cost > 0 && (
-          <>
-            {" · "}
-            {formatCost(cost)}
           </>
         )}
         {session?.last_active_at && (


### PR DESCRIPTION
Ticket: 9905c251-9000-4c80-b731-f6916fe373c5

## Changes
- Removed cost rendering from compact variant (sidebar)
- Removed cost rendering from full variant (board task cards)
- Kept `formatCost` function (may be used elsewhere)
- Token count and model name still displayed as before

## Acceptance Criteria
- [x] No price/cost shown in sidebar agent status cards
- [x] No price/cost shown in board task card agent status
- [x] Token count still displayed
- [x] Model name still displayed