### PR TITLE
fix: use project slug in agent session key instead of hardcoded 'clutch'

### DIFF
--- a/worker/agent-manager.ts
+++ b/worker/agent-manager.ts
@@ -44,6 +44,7 @@ export interface AgentOutcome {
 export interface SpawnAgentParams {
   taskId: string
   projectId: string
+  projectSlug: string
   role: string
   message: string
   model?: string
@@ -79,7 +80,7 @@ export class AgentManager {
     // Ensure gateway connection
     await this.gateway.connect()
 
-    const sessionKey = `agent:main:clutch:${params.role}:${params.taskId.slice(0, 8)}`
+    const sessionKey = `agent:main:${params.projectSlug}:${params.role}:${params.taskId.slice(0, 8)}`
     const now = Date.now()
 
     // Create the long-running RPC promise

--- a/worker/phases/review.ts
+++ b/worker/phases/review.ts
@@ -334,6 +334,7 @@ async function processTask(ctx: ReviewContext, task: Task): Promise<TaskProcessR
       const handle = await agents.spawn({
         taskId: task.id,
         projectId: project.id,
+        projectSlug: project.slug,
         role: "conflict_resolver",
         message: prompt,
         model: "kimi",  // Use Kimi for reliable execution
@@ -449,6 +450,7 @@ async function processTask(ctx: ReviewContext, task: Task): Promise<TaskProcessR
     const handle = await agents.spawn({
       taskId: task.id,
       projectId: project.id,
+      projectSlug: project.slug,
       role: "reviewer",
       message: prompt,
       model: "gpt",

--- a/worker/phases/work.ts
+++ b/worker/phases/work.ts
@@ -415,6 +415,7 @@ export async function runWork(ctx: WorkContext): Promise<WorkPhaseResult> {
       const handle = await agents.spawn({
         taskId: task.id,
         projectId: project.id,
+        projectSlug: project.slug,
         role,
         message: prompt,
         model,


### PR DESCRIPTION
**Problem:** All agent sessions used hardcoded 'clutch' in their session key, causing agents for other projects (like trader) to receive the wrong project context (AGENTS.md, working directory, coding standards).

**Solution:** Pass project.slug through SpawnAgentParams and use it in the session key construction.

**Changes:**
- Added projectSlug field to SpawnAgentParams interface
- Updated session key template to use params.projectSlug instead of hardcoded 'clutch'
- Updated all three spawn sites: work.ts, review.ts (×2)

**Testing:**
- TypeScript compiles clean
- All existing lint warnings are pre-existing (59 warnings, 0 errors)

Ticket: e880eb81-d616-4f15-b0f4-0a28734c2781