### PR TITLE
fix: show from→to status on task history status_changed events

### DIFF
--- a/convex/analytics.ts
+++ b/convex/analytics.ts
@@ -277,7 +277,7 @@ export const cycleTimes = query({
         const data = event.data ? JSON.parse(event.data) as StatusChangedData : null
         if (!data) continue
 
-        const toStatus = data.to
+        const toStatus = data.to_status
 
         // If we have a previous status, calculate time spent in that status
         if (lastStatus && lastTimestamp) {
@@ -364,7 +364,7 @@ export const successRate = query({
       // Check if task ever hit blocked status
       const hitBlocked = statusEvents.some((e) => {
         const data = e.data ? JSON.parse(e.data) as StatusChangedData : null
-        return data?.to === 'blocked'
+        return data?.to_status === 'blocked'
       })
 
       // Check if task was killed via triage (has triage_sent_at and ended up in backlog)

--- a/convex/task_events.ts
+++ b/convex/task_events.ts
@@ -28,8 +28,8 @@ export interface TaskEvent {
 
 // Event-specific data types
 export interface StatusChangedData {
-  from: string
-  to: string
+  from_status: string
+  to_status: string
   reason?: string
 }
 
@@ -293,8 +293,8 @@ export const logStatusChange = mutation({
   },
   handler: async (ctx, args): Promise<TaskEvent | null> => {
     const data: StatusChangedData = {
-      from: args.from,
-      to: args.to,
+      from_status: args.from,
+      to_status: args.to,
       ...(args.reason && { reason: args.reason }),
     }
 

--- a/convex/tasks.ts
+++ b/convex/tasks.ts
@@ -954,7 +954,7 @@ export const move = mutation({
       args.id,
       'status_changed',
       'system', // Could be enhanced to track actual actor (user session key, etc.)
-      { from: fromStatus, to: toStatus }
+      { from_status: fromStatus, to_status: toStatus }
     )
 
     return toTask(updated as Parameters<typeof toTask>[0])

--- a/convex/triage.ts
+++ b/convex/triage.ts
@@ -26,6 +26,8 @@ export interface TriageQueueResult {
 export interface TriageResolvedData {
   action: 'unblock' | 'reassign' | 'split' | 'kill'
   actor: string
+  from_status: string
+  to_status: string
   newRole?: string
   newModel?: string
   subtaskIds?: string[]
@@ -34,6 +36,8 @@ export interface TriageResolvedData {
 
 export interface TriageEscalatedData {
   actor: string
+  from_status: string
+  to_status: string
   reason?: string
 }
 
@@ -259,6 +263,8 @@ export const triageUnblock = mutation({
     const data: TriageResolvedData = {
       action: 'unblock',
       actor: args.actor,
+      from_status: 'blocked',
+      to_status: 'ready',
     }
     await logTaskEvent(ctx, args.taskId, 'status_changed', args.actor, data)
 
@@ -317,6 +323,8 @@ export const triageReassign = mutation({
     const data: TriageResolvedData = {
       action: 'reassign',
       actor: args.actor,
+      from_status: 'blocked',
+      to_status: 'ready',
       ...(args.role && { newRole: args.role }),
       ...(args.agentModel && { newModel: args.agentModel }),
     }
@@ -414,6 +422,8 @@ export const triageSplit = mutation({
     const data: TriageResolvedData = {
       action: 'split',
       actor: args.actor,
+      from_status: 'blocked',
+      to_status: 'done',
       subtaskIds,
     }
     await logTaskEvent(ctx, args.taskId, 'status_changed', args.actor, data)
@@ -471,6 +481,8 @@ export const triageKill = mutation({
     const data: TriageResolvedData = {
       action: 'kill',
       actor: args.actor,
+      from_status: 'blocked',
+      to_status: 'backlog',
       reason: args.reason,
     }
     await logTaskEvent(ctx, args.taskId, 'status_changed', args.actor, data)
@@ -531,6 +543,8 @@ export const triageEscalate = mutation({
     // Log task event
     const data: TriageEscalatedData = {
       actor: args.actor,
+      from_status: 'blocked',
+      to_status: 'blocked',
       ...(args.reason && { reason: args.reason }),
     }
     await logTaskEvent(ctx, args.taskId, 'status_changed', args.actor, {


### PR DESCRIPTION
Ticket: f4603e42-9c37-4815-9f34-e150598b67de

## Problem
The task history timeline showed "Status changed" with no indication of what actually changed. The from_status and to_status fields were never populated.

## Root Cause
Two field-name mismatches:
1. \+convex/tasks.ts+ logged +{ from, to }+ but UI expected +{ from_status, to_status }+
2. \+convex/triage.ts+ status change events didn't include from/to status fields

## Changes
- Updated +StatusChangedData+ interface to use +from_status/to_status+
- Updated +tasks.move+ mutation to use new field names
- Added +from_status/to_status+ to all 5 triage status change events:
  - triageUnblock: blocked → ready
  - triageReassign: blocked → ready
  - triageSplit: blocked → done
  - triageKill: blocked → backlog
  - triageEscalate: blocked → blocked (no status change, just escalated flag)
- Updated +TriageResolvedData+ and +TriageEscalatedData+ interfaces
- Fixed +analytics.ts+ to use +to_status+ instead of +to+

## Verification
- TypeScript compiles (+pnpm typecheck+)
- Lint passes (+pnpm lint+)
- UI already handles the data correctly — no UI changes needed

Closes: f4603e42-9c37-4815-9f34-e150598b67de