### PR TITLE
fix: unreadable black text on Analytics chart tooltips

### DIFF
--- a/components/observatory/analytics/cost-breakdown-chart.tsx
+++ b/components/observatory/analytics/cost-breakdown-chart.tsx
@@ -55,7 +55,7 @@ function CustomTooltip({
   const data = payload[0]
 
   return (
-    <div className="bg-popover border rounded-lg shadow-lg p-3 text-sm">
+    <div className="bg-popover text-popover-foreground border rounded-lg shadow-lg p-3 text-sm">
       <div className="font-medium mb-2">{data.name}</div>
       <div className="space-y-1">
         <div className="flex justify-between gap-4">

--- a/components/observatory/analytics/cycle-time-chart.tsx
+++ b/components/observatory/analytics/cycle-time-chart.tsx
@@ -95,7 +95,7 @@ function CustomTooltip({
   const data = payload[0].payload
 
   return (
-    <div className="bg-popover border rounded-lg shadow-lg p-3 text-sm">
+    <div className="bg-popover text-popover-foreground border rounded-lg shadow-lg p-3 text-sm">
       <div className="font-medium mb-2">{data.name}</div>
       <div className="space-y-1">
         <div className="flex justify-between gap-4">

--- a/components/observatory/analytics/throughput-chart.tsx
+++ b/components/observatory/analytics/throughput-chart.tsx
@@ -63,7 +63,7 @@ function CustomTooltip({
   if (!active || !payload || !payload.length) return null
 
   return (
-    <div className="bg-popover border rounded-lg shadow-lg p-3 text-sm">
+    <div className="bg-popover text-popover-foreground border rounded-lg shadow-lg p-3 text-sm">
       <div className="font-medium mb-2">{label}</div>
       {payload.map((entry, index) => (
         <div key={index} className="flex items-center gap-2">


### PR DESCRIPTION
Fix Observatory Analytics chart tooltips having black text on blue backgrounds in dark theme.

**Changes:**
- Added "text-popover-foreground" class to all chart tooltip components
- Fixes unreadable text in dark mode

**Files modified:**
- components/observatory/analytics/cost-breakdown-chart.tsx
- components/observatory/analytics/throughput-chart.tsx
- components/observatory/analytics/cycle-time-chart.tsx

Ticket: 3e0580cb-7af7-492a-b514-43433d4cc305