### PR TITLE
fix: Observatory Models tab empty despite active model usage

### DIFF
--- a/components/observatory/models/models-tab.tsx
+++ b/components/observatory/models/models-tab.tsx
@@ -65,11 +65,8 @@ export function ModelsTab({ timeRange, lockedProjectId }: ModelsTabProps) {
   const dateRange = useMemo(() => timeRangeToDates(timeRange), [timeRange])
 
   // Fetch model comparison data from Convex
-  // Note: modelAnalytics.modelComparison query is defined in convex/modelAnalytics.ts
-  // The api object will have modelAnalytics after convex codegen is run
   const modelData = useQuery(
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (api as any).modelAnalytics?.modelComparison,
+    api.modelAnalytics.modelComparison,
     {
       projectId: selectedProject || undefined,
       startDate: dateRange.startDate,


### PR DESCRIPTION
Ticket: 6089c305-d56f-4acf-9ecb-b091f5522c3c

## Problem
The Models tab in Observatory was completely empty because the query was looking for `tasks.agent_model` which does not exist in the schema.

## Solution
- Fix unsafe optional chaining in models-tab.tsx (removed `as any`)
- Update modelAnalytics.ts to get model data from sessions table instead of the non-existent tasks.agent_model field
- Add proper TaskWithModel interface for type safety
- Update all three queries: modelComparison, getModelSummary, getModelUsageStats

## How it works now
The query now joins with the sessions table (which has model info and task_id) to get the model for each completed task.

## Testing
- TypeScript compiles clean
- Lint passes (no new errors)