### PR TITLE
feat: add PR links to task cards and detail views

### DIFF
--- a/app/projects/[slug]/board/page.tsx
+++ b/app/projects/[slug]/board/page.tsx
@@ -80,6 +80,7 @@ function BoardPageInner({ slug }: { slug: string }) {
       <Board
         projectId={project.id}
         projectSlug={slug}
+        githubRepo={project.github_repo}
         onTaskClick={handleTaskClick}
         onAddTask={handleAddTask}
       />
@@ -95,6 +96,7 @@ function BoardPageInner({ slug }: { slug: string }) {
         task={selectedTask}
         open={taskModalOpen}
         onOpenChange={setTaskModalOpen}
+        githubRepo={project.github_repo}
       />
     </div>
   )

--- a/components/board/board.tsx
+++ b/components/board/board.tsx
@@ -19,6 +19,7 @@ import { Button } from "@/components/ui/button"
 interface BoardProps {
   projectId: string
   projectSlug: string
+  githubRepo?: string | null
   onTaskClick: (task: Task) => void
   onAddTask: (status: TaskStatus) => void
 }
@@ -62,7 +63,7 @@ function getInitialVisibility(projectSlug: string): Record<TaskStatus, boolean> 
 // Pending optimistic move: taskId → target status
 type PendingMoves = Map<string, TaskStatus>
 
-export function Board({ projectId, projectSlug, onTaskClick, onAddTask }: BoardProps) {
+export function Board({ projectId, projectSlug, githubRepo, onTaskClick, onAddTask }: BoardProps) {
   // Use paginated Convex hook for reactive task data with per-column pagination
   const { tasksByStatus, totalCounts, isLoading, hasMore, loadMore } = usePaginatedBoardTasks(projectId)
   
@@ -291,6 +292,7 @@ export function Board({ projectId, projectSlug, onTaskClick, onAddTask }: BoardP
         columnVisibility={columnVisibility}
         onToggleColumn={updateColumnVisibility}
         projectId={projectId}
+        githubRepo={githubRepo}
         totalCounts={totalCounts}
         hasMore={hasMore}
         onLoadMore={loadMore}
@@ -400,6 +402,7 @@ export function Board({ projectId, projectSlug, onTaskClick, onAddTask }: BoardP
               showAddButton={col.showAdd}
               isMobile={true}
               projectId={projectId}
+              githubRepo={githubRepo}
               totalCount={totalCounts[col.status]}
               hasMore={hasMore[col.status]}
               onLoadMore={() => loadMore(col.status)}
@@ -419,6 +422,7 @@ export function Board({ projectId, projectSlug, onTaskClick, onAddTask }: BoardP
               onAddTask={() => onAddTask(col.status)}
               showAddButton={col.showAdd}
               projectId={projectId}
+              githubRepo={githubRepo}
               totalCount={totalCounts[col.status]}
               hasMore={hasMore[col.status]}
               onLoadMore={() => loadMore(col.status)}

--- a/components/board/column.tsx
+++ b/components/board/column.tsx
@@ -16,6 +16,7 @@ interface ColumnProps {
   showAddButton?: boolean
   isMobile?: boolean
   projectId: string
+  githubRepo?: string | null
   totalCount?: number
   hasMore?: boolean
   onLoadMore?: () => void
@@ -31,6 +32,7 @@ export function Column({
   showAddButton = false,
   isMobile = false,
   projectId,
+  githubRepo,
   totalCount,
   hasMore,
   onLoadMore,
@@ -81,6 +83,7 @@ export function Column({
                 isMobile={isMobile}
                 projectId={projectId}
                 columnTasks={tasks}
+                githubRepo={githubRepo}
               />
             ))}
             {provided.placeholder}

--- a/components/board/mobile-board.tsx
+++ b/components/board/mobile-board.tsx
@@ -22,6 +22,7 @@ interface MobileBoardProps {
   columnVisibility: Record<TaskStatus, boolean>
   onToggleColumn: (status: TaskStatus, visible: boolean) => void
   projectId: string
+  githubRepo?: string | null
   totalCounts?: Record<TaskStatus, number>
   hasMore?: Record<TaskStatus, boolean>
   onLoadMore?: (status: TaskStatus) => void
@@ -36,6 +37,7 @@ export function MobileBoard({
   columnVisibility,
   onToggleColumn,
   projectId,
+  githubRepo,
   totalCounts,
   hasMore,
   onLoadMore,
@@ -284,6 +286,7 @@ export function MobileBoard({
             showAddButton={activeColumn.showAdd}
             isMobile={true}
             projectId={projectId}
+            githubRepo={githubRepo}
             totalCount={totalCounts?.[activeColumn.status]}
             hasMore={hasMore?.[activeColumn.status]}
             onLoadMore={onLoadMore ? () => onLoadMore(activeColumn.status) : undefined}

--- a/components/board/task-card.tsx
+++ b/components/board/task-card.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from "react"
 import { Draggable } from "@hello-pangea/dnd"
-import { Link2, Lock } from "lucide-react"
+import { Link2, Lock, GitPullRequest } from "lucide-react"
 import type { Task } from "@/lib/types"
 import { useDependencies } from "@/lib/hooks/use-dependencies"
 import { formatCompactTime } from "@/lib/utils"
@@ -16,6 +16,7 @@ interface TaskCardProps {
   isMobile?: boolean
   projectId: string
   columnTasks: Task[]
+  githubRepo?: string | null
 }
 
 const PRIORITY_COLORS: Record<string, string> = {
@@ -67,7 +68,7 @@ function getStatusAgeColor(ageMs: number, status: string): string {
   return '#9ca3af'
 }
 
-export function TaskCard({ task, index, onClick, isMobile = false, projectId, columnTasks }: TaskCardProps) {
+export function TaskCard({ task, index, onClick, isMobile = false, projectId, columnTasks, githubRepo }: TaskCardProps) {
   // Track current time for live updates - use lazy initializer to avoid impure function during render
   const [now, setNow] = useState(() => Date.now())
 
@@ -207,6 +208,21 @@ export function TaskCard({ task, index, onClick, isMobile = false, projectId, co
               >
                 {ROLE_LABELS[task.role] || task.role}
               </span>
+            )}
+
+            {/* PR Link */}
+            {task.pr_number && githubRepo && (
+              <a
+                href={`https://github.com/${githubRepo}/pull/${task.pr_number}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={(e) => e.stopPropagation()}
+                className="flex items-center gap-1 px-1.5 py-0.5 text-xs rounded bg-[var(--bg-tertiary)] text-[var(--accent-blue)] hover:text-[var(--accent-blue)]/80 hover:underline flex-shrink-0"
+                title={`View PR #${task.pr_number}`}
+              >
+                <GitPullRequest className="h-3 w-3" />
+                #{task.pr_number}
+              </a>
             )}
 
             {task.assignee && (

--- a/components/board/task-modal.tsx
+++ b/components/board/task-modal.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useState, useEffect, useCallback } from "react"
-import { X, Trash2, Clock, Calendar, MessageSquare, Send, Loader2, Link2, CheckCircle2, Circle, Plus, BarChart3, Pencil, History, OctagonX } from "lucide-react"
+import { X, Trash2, Clock, Calendar, MessageSquare, Send, Loader2, Link2, CheckCircle2, Circle, Plus, BarChart3, Pencil, History, OctagonX, GitPullRequest } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import {
   AlertDialog,
@@ -32,6 +32,7 @@ interface TaskModalProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   onDelete?: (taskId: string) => void
+  githubRepo?: string | null
 }
 
 const STATUS_OPTIONS: { value: TaskStatus; label: string; color: string }[] = [
@@ -65,7 +66,7 @@ const AGENT_OPTIONS = [
   { value: "haiku-triage", label: "Haiku (Scanner)" },
 ]
 
-export function TaskModal({ task, open, onOpenChange, onDelete }: TaskModalProps) {
+export function TaskModal({ task, open, onOpenChange, onDelete, githubRepo }: TaskModalProps) {
   const [title, setTitle] = useState("")
   const [description, setDescription] = useState("")
   const [status, setStatus] = useState<TaskStatus>("backlog")
@@ -702,6 +703,24 @@ export function TaskModal({ task, open, onOpenChange, onDelete }: TaskModalProps
                     Needs human review
                   </label>
                 </div>
+
+                {/* Pull Request */}
+                {task.pr_number && githubRepo && (
+                  <div className="border-t border-[var(--border)] pt-4">
+                    <label className="text-sm font-medium text-[var(--text-secondary)] mb-2 block">
+                      Pull Request
+                    </label>
+                    <a
+                      href={`https://github.com/${githubRepo}/pull/${task.pr_number}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="flex items-center gap-2 px-3 py-2 rounded bg-[var(--bg-primary)] border border-[var(--border)] text-sm text-[var(--accent-blue)] hover:text-[var(--accent-blue)]/80 hover:border-[var(--accent-blue)]/50 transition-colors"
+                    >
+                      <GitPullRequest className="h-4 w-4" />
+                      <span>#{task.pr_number}</span>
+                    </a>
+                  </div>
+                )}
 
                 {/* Timestamps */}
                 <div className="border-t border-[var(--border)] pt-4 space-y-2 text-xs text-[var(--text-muted)]">


### PR DESCRIPTION
Ticket: aa7cb2e8-2e0b-4ab6-bed6-03d1b34f8821

## Summary
Adds clickable GitHub PR links to task cards on the board and in the task detail modal.

## Changes
- Task cards show PR badge with GitHub icon and PR number when  is set
- Task detail modal shows PR link in the sidebar
- Links open in new tab to avoid disrupting workflow
- githubRepo passed through component hierarchy: Board → Column → TaskCard
- Both desktop and mobile board views supported

## Testing
- TypeScript compiles without errors
- Lint passes with no new warnings