### PR TITLE
feat(cli): support --description from stdin to avoid shell escaping

### DIFF
--- a/bin/clutch-cli.ts
+++ b/bin/clutch-cli.ts
@@ -184,6 +184,7 @@ Task Create Options:
 Task Update Options:
   --title "..."             New title
   --description "..."       New description (supports \\n for newlines)
+  --description -           Read description from stdin (pipe mode)
   --status <status>         New status
   --priority <level>        New priority
   --role <role>             New role
@@ -206,6 +207,8 @@ Examples:
   clutch tasks update abc123 --branch fix/xyz Update task branch
   clutch tasks update abc123 --pr-number 42   Update task PR number
   clutch tasks comment abc123 "Progress"      Add comment to task
+  echo 'Use the \`pr_number\` field' | \
+    clutch tasks comment abc123 -               Add comment from stdin
   clutch tasks move abc123 done               Move task to done
   clutch agents list                          Show all active agents
   clutch agents get agent:main:clutch:dev:abc Get agent details
@@ -1104,8 +1107,19 @@ async function cmdTasksUpdate(
   }
 
   if (typeof flags.description === "string") {
-    updates.description = unescapeString(flags.description)
-    updatedFields.push(`description: updated`)
+    if (flags.description === "-") {
+      // Explicit "-" means read from stdin
+      const stdin = await readStdin()
+      if (stdin === null) {
+        console.error("Error: --description - requires piped input")
+        process.exit(1)
+      }
+      updates.description = stdin
+      updatedFields.push(`description: updated (from stdin)`)
+    } else {
+      updates.description = unescapeString(flags.description)
+      updatedFields.push(`description: updated`)
+    }
   }
 
   if (typeof flags.status === "string") {
@@ -1189,9 +1203,25 @@ async function cmdTasksComment(
 
   const { task } = resolved
 
-  if (!message) {
-    console.error("Error: Message is required")
-    process.exit(1)
+  // Handle message: explicit value (may be "-" for stdin), or piped stdin when no message
+  let finalMessage = message
+  if (message === "-") {
+    // Explicit "-" means read from stdin
+    const stdin = await readStdin()
+    if (stdin === null) {
+      console.error("Error: Message '-' requires piped input")
+      process.exit(1)
+    }
+    finalMessage = stdin
+  } else if (!message) {
+    // No message provided: check if stdin is piped
+    const stdin = await readStdin()
+    if (stdin !== null) {
+      finalMessage = stdin
+    } else {
+      console.error("Error: Message is required")
+      process.exit(1)
+    }
   }
 
   const author = typeof flags.author === "string" ? flags.author : "agent"
@@ -1199,7 +1229,7 @@ async function cmdTasksComment(
   const type = typeof flags.type === "string" ? flags.type : "message"
 
   await apiPost(`/tasks/${task.id}/comments`, {
-    content: unescapeString(message),
+    content: unescapeString(finalMessage),
     author,
     author_type: authorType,
     type,


### PR DESCRIPTION
Ticket: b1b05155-f7a2-400c-979c-7b68f77b23c0

## Summary
Adds stdin reading support to the clutch CLI for task descriptions and comments. This prevents zsh from interpreting backticks as command substitution when agents use markdown code references like `pr_number`.

## Changes
- `tasks create --description -` reads from stdin (explicit or auto-detected pipe)
- `tasks update --description -` reads from stdin  
- `tasks comment <id> -` reads message from stdin
- Updated help text with examples

## Testing
- Tested creating, updating, and commenting on tasks with backtick-containing text via stdin
- All pre-commit checks (typecheck, lint) pass