### PR TITLE
feat: hide feature builder UI until ready

### DIFF
--- a/app/home-content.tsx
+++ b/app/home-content.tsx
@@ -4,7 +4,7 @@ import { useQuery } from "convex/react"
 import { api } from "@/convex/_generated/api"
 import { ProjectListRow } from "@/components/projects/project-list-row"
 import { CreateProjectModal } from "@/components/projects/create-project-modal"
-import { FeatureBuilderButton } from "@/components/feature-builder"
+// import { FeatureBuilderButton } from "@/components/feature-builder"  // HIDDEN: feature builder not ready
 import { Skeleton } from "@/components/ui/skeleton"
 
 export default function HomeContent() {
@@ -23,7 +23,7 @@ export default function HomeContent() {
           </p>
         </div>
         <div className="flex items-center gap-3">
-          <FeatureBuilderButton variant="outline" />
+          {/* <FeatureBuilderButton variant="outline" /> */}
           <CreateProjectModal />
         </div>
       </div>

--- a/app/projects/[slug]/layout.tsx
+++ b/app/projects/[slug]/layout.tsx
@@ -9,7 +9,7 @@ import { MobileProjectSwitcher } from "@/components/layout/mobile-project-switch
 import { DesktopProjectSwitcher } from "@/components/layout/desktop-project-switcher"
 import { useMobileDetection } from "@/components/board/use-mobile-detection"
 import { WorkLoopHeaderStatus } from "@/components/work-loop/work-loop-header-status"
-import { FeatureBuilderButton } from "@/components/feature-builder"
+// import { FeatureBuilderButton } from "@/components/feature-builder"  // HIDDEN: feature builder not ready
 
 type LayoutProps = {
   children: React.ReactNode
@@ -131,7 +131,7 @@ export default function ProjectLayout({ children, params }: LayoutProps) {
                 </nav>
               </div>
 
-              {/* Work loop status + Feature Builder button (mobile) */}
+              {/* Work loop status (mobile) */}
               <div className="flex items-center justify-between gap-2">
                 {project.work_loop_enabled === 1 && (
                   <WorkLoopHeaderStatus
@@ -139,12 +139,6 @@ export default function ProjectLayout({ children, params }: LayoutProps) {
                     workLoopEnabled={true}
                   />
                 )}
-                <FeatureBuilderButton
-                  defaultProjectId={project.id}
-                  variant="outline"
-                  size="sm"
-                  className="text-xs h-8 ml-auto"
-                />
               </div>
             </div>
           ) : (
@@ -165,11 +159,6 @@ export default function ProjectLayout({ children, params }: LayoutProps) {
                   />
                 </div>
                 <div className="flex items-center gap-3">
-                  <FeatureBuilderButton
-                    defaultProjectId={project.id}
-                    variant="outline"
-                    size="sm"
-                  />
                   <WorkLoopHeaderStatus
                     projectId={project.id}
                     workLoopEnabled={project.work_loop_enabled === 1}


### PR DESCRIPTION
Ticket: 6b045890-56b9-412c-8377-42427553dbd1

## Summary
Comments out FeatureBuilderButton imports and usages to hide the feature builder from the UI until it's ready for production.

## Changes
- app/home-content.tsx: Commented out FeatureBuilderButton import and usage
- app/projects/[slug]/layout.tsx: Commented out FeatureBuilderButton import and usages (both mobile and desktop)

## Notes
- All feature builder code remains intact for future work
- The /feature-builder route still exists but is no longer linked from the UI
- Simply uncomment to re-enable when ready