### PR TITLE
feat: two-column dashboard layout with OpenClaw sidebar

### DIFF
--- a/app/home-content.tsx
+++ b/app/home-content.tsx
@@ -6,12 +6,13 @@ import { ProjectListRow } from "@/components/projects/project-list-row"
 import { CreateProjectModal } from "@/components/projects/create-project-modal"
 // import { FeatureBuilderButton } from "@/components/feature-builder"  // HIDDEN: feature builder not ready
 import { Skeleton } from "@/components/ui/skeleton"
+import { OpenClawSidebar } from "@/components/dashboard/openclaw-sidebar"
 
 export default function HomeContent() {
   const projects = useQuery(api.projects.getAllWithStats, {})
 
   return (
-    <div className="container mx-auto py-12 px-4 max-w-5xl">
+    <div className="container mx-auto py-12 px-4 max-w-7xl">
       {/* Header */}
       <div className="flex items-center justify-between mb-6">
         <div>
@@ -28,56 +29,65 @@ export default function HomeContent() {
         </div>
       </div>
 
-      {/* Loading state */}
-      {projects === undefined && (
-        <div className="border border-[var(--border)] rounded-lg overflow-hidden">
-          {[1, 2, 3].map((i) => (
-            <div key={i} className="flex items-center gap-4 px-4 py-3 border-b border-[var(--border)] last:border-b-0">
-              <Skeleton className="w-2.5 h-2.5 rounded-full" />
-              <div className="flex-1 space-y-1.5">
-                <Skeleton className="h-4 w-40" />
-                <Skeleton className="h-3 w-60" />
-              </div>
-              <Skeleton className="h-4 w-32 hidden md:block" />
-              <Skeleton className="h-5 w-16 hidden lg:block" />
+      {/* Two-column layout */}
+      <div className="flex flex-col lg:flex-row gap-6 lg:gap-8">
+        {/* Left column: Project list */}
+        <div className="flex-1 min-w-0">
+          {/* Loading state */}
+          {projects === undefined && (
+            <div className="border border-[var(--border)] rounded-lg overflow-hidden">
+              {[1, 2, 3].map((i) => (
+                <div key={i} className="flex items-center gap-4 px-4 py-3 border-b border-[var(--border)] last:border-b-0">
+                  <Skeleton className="w-2.5 h-2.5 rounded-full" />
+                  <div className="flex-1 space-y-1.5">
+                    <Skeleton className="h-4 w-40" />
+                    <Skeleton className="h-3 w-60" />
+                  </div>
+                  <Skeleton className="h-4 w-32 hidden md:block" />
+                  <Skeleton className="h-5 w-16 hidden lg:block" />
+                </div>
+              ))}
             </div>
-          ))}
-        </div>
-      )}
+          )}
 
-      {/* Empty state */}
-      {projects !== undefined && projects.length === 0 && (
-        <div className="text-center py-16">
-          <div className="text-6xl mb-4">📋</div>
-          <h2 className="text-xl font-semibold text-[var(--text-primary)] mb-2">
-            No projects yet
-          </h2>
-          <p className="text-[var(--text-secondary)] mb-6">
-            Create your first project to start organizing work.
-          </p>
-          <CreateProjectModal />
-        </div>
-      )}
+          {/* Empty state */}
+          {projects !== undefined && projects.length === 0 && (
+            <div className="text-center py-16">
+              <div className="text-6xl mb-4">📋</div>
+              <h2 className="text-xl font-semibold text-[var(--text-primary)] mb-2">
+                No projects yet
+              </h2>
+              <p className="text-[var(--text-secondary)] mb-6">
+                Create your first project to start organizing work.
+              </p>
+              <CreateProjectModal />
+            </div>
+          )}
 
-      {/* Project list */}
-      {projects !== undefined && projects.length > 0 && (
-        <div className="border border-[var(--border)] rounded-lg overflow-hidden">
-          {/* Column headers */}
-          <div className="flex items-center gap-4 px-4 py-2 bg-[var(--bg-secondary)] border-b border-[var(--border)] text-xs font-medium text-[var(--text-muted)] uppercase tracking-wider">
-            <div className="flex-1">Project</div>
-            <div className="hidden md:block" style={{ minWidth: "180px" }}>Tickets</div>
-            <div className="flex md:hidden">Tasks</div>
-            <div className="hidden sm:block" style={{ minWidth: "90px" }}>Agents</div>
-            <div className="hidden lg:block" style={{ minWidth: "90px" }}>Loop</div>
-            <div className="hidden lg:block" style={{ minWidth: "70px" }}>Activity</div>
-            <div style={{ width: "56px" }} />
-          </div>
+          {/* Project list */}
+          {projects !== undefined && projects.length > 0 && (
+            <div className="border border-[var(--border)] rounded-lg overflow-hidden">
+              {/* Column headers */}
+              <div className="flex items-center gap-4 px-4 py-2 bg-[var(--bg-secondary)] border-b border-[var(--border)] text-xs font-medium text-[var(--text-muted)] uppercase tracking-wider">
+                <div className="flex-1">Project</div>
+                <div className="hidden md:block" style={{ minWidth: "180px" }}>Tickets</div>
+                <div className="flex md:hidden">Tasks</div>
+                <div className="hidden sm:block" style={{ minWidth: "90px" }}>Agents</div>
+                <div className="hidden lg:block" style={{ minWidth: "90px" }}>Loop</div>
+                <div className="hidden lg:block" style={{ minWidth: "70px" }}>Activity</div>
+                <div style={{ width: "56px" }} />
+              </div>
 
-          {projects.map((project) => (
-            <ProjectListRow key={project.id} project={project} />
-          ))}
+              {projects.map((project) => (
+                <ProjectListRow key={project.id} project={project} />
+              ))}
+            </div>
+          )}
         </div>
-      )}
+
+        {/* Right column: OpenClaw sidebar */}
+        <OpenClawSidebar />
+      </div>
     </div>
   )
 }

--- a/components/dashboard/openclaw-sidebar.tsx
+++ b/components/dashboard/openclaw-sidebar.tsx
@@ -1,0 +1,68 @@
+"use client"
+
+import { Activity } from "lucide-react"
+
+interface OpenClawSidebarProps {
+  children?: React.ReactNode
+}
+
+export function OpenClawSidebar({ children }: OpenClawSidebarProps) {
+  return (
+    <aside className="w-full lg:w-80 xl:w-88 flex-shrink-0 space-y-4">
+      {/* Header */}
+      <div className="flex items-center gap-2 px-1">
+        <Activity className="w-4 h-4 text-[var(--accent-green)]" />
+        <h2 className="text-sm font-semibold text-[var(--text-primary)] uppercase tracking-wider">
+          OpenClaw
+        </h2>
+        <span
+          className="w-2 h-2 rounded-full bg-[var(--accent-green)]"
+          style={{ animation: "pulse 2s ease-in-out infinite" }}
+          title="Connected"
+        />
+      </div>
+
+      {/* Widget container */}
+      <div className="space-y-3">
+        {children ?? (
+          <>
+            {/* Placeholder widget slots */}
+            <SidebarCard title="Gateway Status">
+              <p className="text-sm text-[var(--text-muted)]">
+                Widget coming soon
+              </p>
+            </SidebarCard>
+            <SidebarCard title="Active Sessions">
+              <p className="text-sm text-[var(--text-muted)]">
+                Widget coming soon
+              </p>
+            </SidebarCard>
+            <SidebarCard title="System Health">
+              <p className="text-sm text-[var(--text-muted)]">
+                Widget coming soon
+              </p>
+            </SidebarCard>
+          </>
+        )}
+      </div>
+    </aside>
+  )
+}
+
+interface SidebarCardProps {
+  title: string
+  children: React.ReactNode
+}
+
+function SidebarCard({ title, children }: SidebarCardProps) {
+  return (
+    <div className="border border-[var(--border)] rounded-lg bg-[var(--bg-primary)] hover:bg-[var(--bg-secondary)] transition-colors">
+      <div className="px-3 py-2 border-b border-[var(--border)]">
+        <h3 className="text-xs font-medium text-[var(--text-secondary)] uppercase tracking-wider">
+          {title}
+        </h3>
+      </div>
+      <div className="p-3">{children}</div>
+    </div>
+  )
+}


### PR DESCRIPTION
Ticket: b3458579-3187-48e0-a597-80ad7c071e8a

## Summary
Refactored the home page from a single centered column to a two-column layout with an OpenClaw status sidebar.

## Changes
- **Layout**: Changed from single column (max-w-5xl) to two-column (max-w-7xl)
- **Left column**: Existing project list with all current functionality preserved
- **Right column**: New OpenClaw sidebar component for status widgets
- **Responsive**: Sidebar stacks below project list on mobile/tablet (flex-col → flex-row)
- **Styling**: Card-based layout matching existing project list row design

## New Files
- components/dashboard/openclaw-sidebar.tsx - Shell component with header, status dot, and widget slots

## Notes
- Foundation ticket for all subsequent widget implementations
- UI changes included - needs browser QA verification

---
*Automated PR created by dev agent*