### PR TITLE
docs: rewrite README for public open-source audience

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,56 @@
+# Contributing to OpenClutch
+
+Thank you for your interest in contributing to OpenClutch!
+
+## Getting Started
+
+1. Fork the repository
+2. Clone your fork: `git clone https://github.com/YOUR_USERNAME/clutch.git`
+3. Follow the [Quick Start](./README.md#quick-start) guide to set up your development environment
+
+## Development Workflow
+
+### Branching
+
+Use git worktrees for feature development:
+
+```bash
+git worktree add ../clutch-worktrees/fix/my-feature -b fix/my-feature
+cd ../clutch-worktrees/fix/my-feature
+```
+
+### Commit Messages
+
+Follow conventional commits:
+
+- `feat:` — New feature
+- `fix:` — Bug fix
+- `docs:` — Documentation changes
+- `refactor:` — Code refactoring
+- `test:` — Adding tests
+- `chore:` — Maintenance tasks
+
+### Before Submitting
+
+1. Run type checks: `pnpm typecheck`
+2. Run linter: `pnpm lint`
+3. Run tests: `pnpm test`
+4. Ensure pre-commit hooks pass (never use `--no-verify`)
+
+## Code Style
+
+- **No relative imports** — use absolute paths
+- **Module imports** — prefer `import * as module` over named imports
+- **Error handling** — let errors propagate, catch only at boundaries
+- **TypeScript** — strict mode enabled
+
+## Pull Request Process
+
+1. Update documentation for any changed functionality
+2. Ensure all CI checks pass
+3. Request review from maintainers
+4. Address review feedback
+
+## Questions?
+
+Open an issue or join the discussion in our community channels.


### PR DESCRIPTION
## Summary

Rewrites the README from internal-facing documentation to a public open-source format.

## Changes

- **Hero section** — Clear 1-2 sentence description with screenshot placeholder
- **Features** — Bullet list of key capabilities (agent orchestration, work loop, Observatory, etc.)
- **Architecture** — Clean mermaid-style diagram showing 4 processes + Convex + OpenClaw
- **Quick Start** — Generic prerequisites (Node 22, pnpm, Convex), clone/install/configure steps
- **Configuration** — Complete .env.example reference with all key variables
- **Work Loop** — Detailed phase/role/status documentation
- **Observatory** — Tab descriptions
- **CLI** — Full clutch command reference
- **Deployment** — Generic systemd + nginx instructions (no private IPs)
- **Development** — Dev server, testing, worktrees, pre-commit hooks
- **Contributing** — Link to CONTRIBUTING.md
- **License** — MIT reference

## Files Added/Modified

- 
README.md
 — Complete rewrite (~350 lines, public-facing)
- 
.env.example
 — New file with generic configuration template
- 
CONTRIBUTING.md
 — New basic contribution guidelines

## Verification

- [x] All private IPs removed (192.168.x.x)
- [x] All personal domains removed (ada.codesushi.com)
- [x] All hardcoded paths removed (/home/dan/...)
- [x] Generic placeholders used throughout
- [x] Links to external resources (OpenClaw repo)

Ticket: 055db27c-dc59-48ad-8cd8-26bb7d6c0fcb