### PR TITLE
fix: replace in-memory ghost detection with sessions-table liveness checks

### DIFF
--- a/convex/tasks.ts
+++ b/convex/tasks.ts
@@ -858,6 +858,7 @@ export const move = mutation({
       v.literal('discarded'),
       v.literal('merged')
     )),
+    reason: v.optional(v.string()),
   },
   handler: async (ctx, args): Promise<Task> => {
     const existing = await ctx.db
@@ -874,7 +875,7 @@ export const move = mutation({
       return reorderTask(ctx, existing._id, args.status, args.position)
     }
 
-    // Log the status change event BEFORE the actual move
+    // Capture status change for event logging
     const fromStatus = existing.status
     const toStatus = args.status
 
@@ -963,8 +964,8 @@ export const move = mutation({
       ctx,
       args.id,
       'status_changed',
-      'system', // Could be enhanced to track actual actor (user session key, etc.)
-      { from_status: fromStatus, to_status: toStatus }
+      'work-loop',
+      { from_status: fromStatus, to_status: toStatus, ...(args.reason && { reason: args.reason }) }
     )
 
     return toTask(updated as Parameters<typeof toTask>[0])

--- a/worker/phases/work.ts
+++ b/worker/phases/work.ts
@@ -122,6 +122,7 @@ async function claimTask(
     const result = await convex.mutation(api.tasks.move, {
       id: taskId,
       status: "in_progress",
+      reason: "task_claimed",
     })
     return result
   } catch (error) {
@@ -455,14 +456,8 @@ export async function runWork(ctx: WorkContext): Promise<WorkPhaseResult> {
           model,
           role,
         })
-        // Log status change event (ready -> in_progress)
-        await convex.mutation(api.task_events.logStatusChange, {
-          taskId: task.id,
-          from: 'ready',
-          to: 'in_progress',
-          actor: 'work-loop',
-          reason: 'task_claimed',
-        })
+        // Status change event (ready -> in_progress) is logged by tasks.move
+        // with reason="task_claimed" - no duplicate logging needed
       } catch (updateError) {
         console.error(`[WorkPhase] Failed to update task agent info:`, updateError)
       }


### PR DESCRIPTION
Ticket: 20bcfe20-f5cb-4282-8b54-2c2df4a89c7d

## Summary

Replace AgentManager in-memory map with sessions table as source of truth for agent liveness detection. Fixes task status flip-flopping after loop restart.

## Changes

1. **convex/sessions.ts**: Add \"getLiveStatus\" query to check session liveness by session_key
2. **convex/tasks.ts**: Add optional \"reason\" parameter to tasks.move mutation, log status change with reason
3. **worker/phases/cleanup.ts**: Use sessions table instead of AgentManager.has() for ghost detection
   - Add 2-minute grace period for new sessions to appear
   - Ghost tasks move to \"blocked\" for triage instead of \"ready\"
   - Add explanatory comments when blocking ghost tasks
4. **worker/phases/work.ts**: Remove duplicate status_changed event logging

## Behavior Changes

- **Before**: Loop restart → all in_progress tasks reset to ready → re-claimed (flip-flopping)
- **After**: Loop restart → check sessions table → only move to blocked if session actually completed/stale
- **Ghost handling**: Ghost tasks now go to \"blocked\" for human triage instead of silently resetting to \"ready\"
- **Status events**: Each claim now produces exactly ONE status_changed event (was producing two)

## Testing

- TypeScript compiles ✓
- Lint passes ✓
- Worker tests pass ✓