### PR TITLE
fix: agent idle/stuck timers in sidebar should be 10m, not 5m

### DIFF
--- a/components/agents/agent-card.tsx
+++ b/components/agents/agent-card.tsx
@@ -83,9 +83,9 @@ function formatModelShort(model: string | null | undefined): string {
 
 // Get color for idle time indicator
 function getIdleColor(minutes: number): string {
-  if (minutes < 1) return "text-green-400" // < 1m: green
-  if (minutes < 5) return "text-yellow-400" // 1-5m: yellow
-  return "text-red-400" // > 5m: red (possibly stuck)
+  if (minutes < 3) return "text-green-400" // < 3m: green
+  if (minutes < 10) return "text-yellow-400" // 3-10m: yellow (warning)
+  return "text-red-400" // >= 10m: red (possibly stuck)
 }
 
 export function AgentCard({ task, projectSlug }: AgentCardProps) {
@@ -130,7 +130,7 @@ export function AgentCard({ task, projectSlug }: AgentCardProps) {
       idleMinutes,
       totalTokens,
       contextPercent,
-      isStuck: idleMinutes >= 5,
+      isStuck: idleMinutes >= 10,
       model,
       status: session?.status ?? 'idle',
     }


### PR DESCRIPTION
Ticket: 9f8cf897-7492-499b-90c6-8510fcb83a9c

## Summary
The chat sidebar agent cards were flagging agents as "stuck" after only 5 minutes of no activity. This is too aggressive — agents regularly take 5+ minutes on complex tasks.

## Changes
- Changed `isStuck` threshold from `>= 5` to `>= 10` minutes
- Updated `getIdleColor()` red threshold from `> 5` to `>= 10` minutes  
- Adjusted yellow warning zone from 1-5m to 3-10m range
- Now consistent with `isAgentStale()` in `agent-status.tsx` (already 10m)

## Verification
- [x] TypeScript compiles (`pnpm typecheck`)
- [x] Lint passes (`pnpm lint`)
- [x] Matches backend stale timeout (10m)
- [x] Aligns with work loop stale threshold (15m)