### PR TITLE
feat: improve markdown rendering quality in chat messages

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -203,6 +203,22 @@
     max-width: 100%;
     height: auto;
   }
+
+  /* Nested lists indentation */
+  .markdown-content li > ul,
+  .markdown-content li > ol {
+    margin-top: 0.25rem;
+    margin-bottom: 0.25rem;
+  }
+
+  /* Paragraphs inside list items */
+  .markdown-content li > p {
+    margin-bottom: 0.25rem;
+  }
+
+  .markdown-content li > p:last-child {
+    margin-bottom: 0;
+  }
 }
 
 /* Hide scrollbars for mobile column navigation */
@@ -215,58 +231,82 @@
   display: none;  /* Chrome, Safari, Opera */
 }
 
-/* Highlight.js theme for syntax highlighting in dark theme */
+/* Highlight.js theme for syntax highlighting in dark theme (GitHub Dark inspired) */
 .hljs {
-  color: #e3e3e3;
+  color: #e6edf3;
   background: transparent;
 }
 
-.hljs-keyword,
-.hljs-selector-tag,
-.hljs-literal,
-.hljs-section,
-.hljs-link {
-  color: #dcc6e0;
-}
-
-.hljs-function .hljs-keyword {
-  color: #dcc6e0;
-}
-
-.hljs-subst {
-  color: #e3e3e3;
-}
-
-.hljs-string,
-.hljs-title,
-.hljs-name,
-.hljs-type,
-.hljs-attribute,
-.hljs-symbol,
-.hljs-bullet,
-.hljs-built_in,
-.hljs-addition,
-.hljs-variable,
-.hljs-template-tag,
-.hljs-template-variable {
-  color: #8cc8ff;
-}
-
+/* Comments */
 .hljs-comment,
 .hljs-quote,
 .hljs-deletion,
 .hljs-meta {
-  color: #777;
+  color: #8b949e;
+  font-style: italic;
 }
 
+/* Keywords */
 .hljs-keyword,
 .hljs-selector-tag,
 .hljs-literal,
-.hljs-title,
 .hljs-section,
 .hljs-doctag,
 .hljs-type,
+.hljs-function .hljs-keyword {
+  color: #ff7b72;
+  font-weight: normal;
+}
+
+/* Strings */
+.hljs-string,
+.hljs-regexp,
+.hljs-addition,
+.hljs-attribute,
+.hljs-template-tag,
+.hljs-template-variable {
+  color: #a5d6ff;
+}
+
+/* Names, classes, tags */
+.hljs-title,
 .hljs-name,
+.hljs-tag,
+.hljs-built_in,
+.hljs-selector-id,
+.hljs-selector-class {
+  color: #d2a8ff;
+}
+
+/* Variables and parameters */
+.hljs-variable,
+.hljs-params,
+.hljs-property {
+  color: #e6edf3;
+}
+
+/* Functions and methods */
+.hljs-function .hljs-title,
+.hljs-method,
+.hljs-selector-pseudo {
+  color: #d2a8ff;
+}
+
+/* Numbers, booleans */
+.hljs-number,
+.hljs-literal,
+.hljs-bullet,
+.hljs-link {
+  color: #79c0ff;
+}
+
+/* Operators */
+.hljs-operator,
+.hljs-punctuation {
+  color: #e6edf3;
+}
+
+/* Emphasis and strong */
 .hljs-strong {
   font-weight: bold;
 }
@@ -275,12 +315,20 @@
   font-style: italic;
 }
 
-.hljs-number {
-  color: #fc9867;
+/* Language-specific */
+.hljs-subst {
+  color: #e6edf3;
 }
 
-.hljs-regexp {
-  color: #ffcc99;
+/* Diff */
+.hljs-diff .hljs-deletion {
+  color: #ffdcd7;
+  background-color: #67060c;
+}
+
+.hljs-diff .hljs-addition {
+  color: #aff5b4;
+  background-color: #033a16;
 }
 
 /* Live indicator pulse */

--- a/components/chat/markdown-content.tsx
+++ b/components/chat/markdown-content.tsx
@@ -108,25 +108,25 @@ export function MarkdownContent({ content, className = "", variant = "chat" }: M
           code: ({ className, children, ...props }) => {
             const match = /language-(\w+)/.exec(className || "")
             if (match) {
-              // Block code (fenced)
+              // Block code (fenced) - use bg-secondary for better contrast
               return isDocument ? (
-                <pre className="bg-[var(--bg-tertiary)] border border-[var(--border)] rounded-lg p-4 my-4 overflow-x-auto text-sm max-w-full min-w-0">
+                <pre className="bg-[var(--bg-secondary)] border border-[var(--border)] rounded-lg p-4 my-4 overflow-x-auto text-sm max-w-full min-w-0">
                   <code className={className} {...props}>
                     {children}
                   </code>
                 </pre>
               ) : (
-                <pre className="bg-[var(--bg-primary)] border border-[var(--border)] rounded p-3 my-2 overflow-x-auto text-xs max-w-full min-w-0">
+                <pre className="bg-[var(--bg-secondary)] border border-[var(--border)] rounded-md p-3 my-2 overflow-x-auto text-sm max-w-full min-w-0">
                   <code className={className} {...props}>
                     {children}
                   </code>
                 </pre>
               )
             } else {
-              // Inline code
+              // Inline code - use bg-secondary with lighter border for better visibility
               return (
                 <code
-                  className={`bg-[var(--bg-primary)] border border-[var(--border)] rounded font-mono break-all ${isDocument ? "px-1.5 py-0.5 text-sm" : "px-1.5 py-0.5 text-xs"}`}
+                  className={`bg-[var(--bg-secondary)] border border-[var(--border)]/60 rounded font-mono break-all ${isDocument ? "px-1.5 py-0.5 text-sm" : "px-1.5 py-0.5 text-sm"}`}
                   {...props}
                 >
                   {children}
@@ -135,19 +135,19 @@ export function MarkdownContent({ content, className = "", variant = "chat" }: M
             }
           },
 
-          // Lists
-          ul: ({ children }) => (
-            <ul className={`list-disc ${isDocument ? "ml-5 mb-4 space-y-2" : "list-inside mb-2 space-y-1"}`}>
+          // Lists - use list-outside for proper bullet/number alignment with text
+          ul: ({ children, ...props }) => (
+            <ul className={`list-disc list-outside ${isDocument ? "ml-5 mb-4 space-y-1.5" : "ml-4 mb-2 space-y-1"}`} {...props}>
               {children}
             </ul>
           ),
-          ol: ({ children }) => (
-            <ol className={`list-decimal ${isDocument ? "ml-5 mb-4 space-y-2" : "list-inside mb-2 space-y-1"}`}>
+          ol: ({ children, ...props }) => (
+            <ol className={`list-decimal list-outside ${isDocument ? "ml-5 mb-4 space-y-1.5" : "ml-4 mb-2 space-y-1"}`} {...props}>
               {children}
             </ol>
           ),
           li: ({ children }) => (
-            <li className={`leading-relaxed font-normal ${isDocument ? "text-base pl-1" : "text-base"}`}>
+            <li className="leading-relaxed font-normal text-base pl-1">
               {children}
             </li>
           ),
@@ -171,7 +171,7 @@ export function MarkdownContent({ content, className = "", variant = "chat" }: M
             </blockquote>
           ),
 
-          // Tables
+          // Tables - consistent text-sm sizing for readability
           table: ({ children }) => isDocument ? (
             <div className="my-4 overflow-x-auto max-w-full min-w-0 rounded-lg border border-[var(--border)]">
               <table className="min-w-full text-sm">
@@ -179,8 +179,8 @@ export function MarkdownContent({ content, className = "", variant = "chat" }: M
               </table>
             </div>
           ) : (
-            <div className="my-2 overflow-x-auto max-w-full min-w-0">
-              <table className="min-w-full border border-[var(--border)] text-xs">
+            <div className="my-2 overflow-x-auto max-w-full min-w-0 rounded border border-[var(--border)]">
+              <table className="min-w-full text-sm">
                 {children}
               </table>
             </div>
@@ -191,11 +191,11 @@ export function MarkdownContent({ content, className = "", variant = "chat" }: M
             </thead>
           ),
           th: ({ children }) => isDocument ? (
-            <th className="border-b border-[var(--border)] px-4 py-2 text-left font-semibold">
+            <th className="border-b border-[var(--border)] px-4 py-2 text-left font-semibold bg-[var(--bg-tertiary)]">
               {children}
             </th>
           ) : (
-            <th className="border border-[var(--border)] px-2 py-1 text-left font-medium">
+            <th className="border-b border-[var(--border)] px-3 py-1.5 text-left font-semibold bg-[var(--bg-tertiary)]">
               {children}
             </th>
           ),
@@ -204,7 +204,7 @@ export function MarkdownContent({ content, className = "", variant = "chat" }: M
               {children}
             </td>
           ) : (
-            <td className="border border-[var(--border)] px-2 py-1">
+            <td className="border-b border-[var(--border)] px-3 py-1.5">
               {children}
             </td>
           ),


### PR DESCRIPTION
Ticket: a73adc19-77d8-4601-abb5-b2997c682fe6

## Changes

### Code blocks & inline code
- Changed background from \bg-primary\ (#0a0a0b) to \bg-secondary\ (#141415) for better contrast against chat bubble background
- Consistent \text-sm\ sizing for both block and inline code (was \text-xs\ for chat)
- Rounded-md for block code in chat for consistency

### Lists
- Changed from \list-inside\ to \list-outside\ for proper bullet/number alignment with text
- Added proper left margins for indentation
- Better spacing between items
- Added CSS rules for nested lists and paragraphs inside list items

### Tables  
- Consistent \text-sm\ sizing (was \text-xs\ for chat)
- Consistent border styling with rounded corners
- Headers use \bg-tertiary\ background for distinction

### Syntax highlighting
- Enhanced highlight.js theme with GitHub Dark-inspired colors
- Better token differentiation (keywords, strings, functions, comments, etc.)

## Testing
- TypeScript compiles without errors
- Lint passes (pre-existing warnings only)
- Needs browser QA for visual verification