### PR TITLE
fix: dev agent completing in in_review is happy path, not blocked

### DIFF
--- a/worker/loop.ts
+++ b/worker/loop.ts
@@ -712,8 +712,9 @@ async function runProjectCycle(
         }
         // Case 3: Non-reviewer agent finished while task is in_review → block (security guard)
         // Only reviewers should be able to move tasks from in_review to done.
-        // If dev, conflict_resolver, or other roles finish here, something went wrong.
-        else if (currentStatus === "in_review") {
+        // If conflict_resolver, pm, or other non-dev roles finish here, something went wrong.
+        // Dev finishing in in_review is the happy path (created PR, moved to in_review, done).
+        else if (currentStatus === "in_review" && outcome.role !== "dev") {
           await convex.mutation(api.tasks.move, {
             id: outcome.taskId,
             status: "blocked",


### PR DESCRIPTION
**Problem:**
Case 3 in loop.ts incorrectly moved tasks to \blocked\ when a dev agent finished while the task was \in_review\. 

This is the **expected happy path**: dev creates PR, moves to in_review, session ends naturally. The old code was treating this as a security violation.

**Example from task 9f8cf897 (PR #561):**
- 22:27:42 dev moved task to in_review (correct)
- 22:28:05 dev session completed (expected)
- 22:28:05 Case 3 moved task to blocked (**WRONG**)

**Fix:**
Only block non-dev agents (conflict_resolver, pm, etc.) that finish in in_review. Dev agents finishing in in_review now correctly do nothing, allowing the review phase to spawn a reviewer.

**Changes:**
- worker/loop.ts: Added \