### PR TITLE
feat: replace reapFinished() with Convex-based agent lifecycle and remove in-memory Map

### DIFF
--- a/worker/phases/cleanup.ts
+++ b/worker/phases/cleanup.ts
@@ -21,7 +21,6 @@
 import { execFileSync } from "node:child_process"
 import type { ConvexHttpClient } from "convex/browser"
 import { api } from "../../convex/_generated/api"
-import type { AgentManager } from "../agent-manager"
 import type { Task } from "../../lib/types"
 
 // ============================================
@@ -53,7 +52,6 @@ interface ProjectInfo {
 
 interface CleanupContext {
   convex: ConvexHttpClient
-  agents: AgentManager
   cycle: number
   project: ProjectInfo
   log: (params: LogRunParams) => Promise<void>


### PR DESCRIPTION
Ticket: d7ad05d1-2344-408f-9aba-67bdc84142d5

## Summary

Completes the migration from in-memory agent tracking to Convex-based agent lifecycle management. This eliminates the dual source of truth between the AgentManager's in-memory Map and the Convex database.

## Changes

- **Remove agents Map from AgentManager** - no more in-memory state tracking
- **Remove completedQueue and drainCompleted()** - no longer needed since there's no in-memory state to lose
- **Remove AgentHandle interface** - simplifies architecture 
- **Rewrite reapFinished()** to query Convex for active tasks instead of iterating the Map
- **Update loop.ts** to remove drainCompleted() call and use Convex-sourced reap results
- **Update phase files** (work.ts, review.ts, cleanup.ts) to query Convex directly for agent counts
- **Add getAllActiveAgentTasks query** to get all active agents across all projects
- **Simplify spawn()** to return sessionKey only - Convex tracks the full state
- **Use agent_spawned_at from Convex** for grace period instead of handle.spawnedAt

## Benefits

- **Restart safety**: After restart, reap immediately finds all active tasks from Convex and resumes monitoring
- **Atomic updates**: Convex mutations prevent race conditions and partial state updates  
- **Single source of truth**: All agent state lives in the database, not split between memory and DB
- **Simplified architecture**: Removes complex in-memory tracking and queue management

## Testing

- ✅ 
> clutch@0.1.0 typecheck /home/dan/src/clutch-worktrees/fix/d7ad05d1
> tsc --noEmit passes
- ✅ 
> clutch@0.1.0 lint /home/dan/src/clutch-worktrees/fix/d7ad05d1
> eslint


/home/dan/src/clutch-worktrees/fix/d7ad05d1/app/api/prompts/seed/route.ts
  16:28  warning  '_request' is defined but never used  @typescript-eslint/no-unused-vars

/home/dan/src/clutch-worktrees/fix/d7ad05d1/app/projects/[slug]/chat/page.tsx
  378:9  warning  The 'currentMessages' conditional could make the dependencies of useEffect Hook (at line 393) change on every render. To fix this, wrap the initialization of 'currentMessages' in its own useMemo() Hook  react-hooks/exhaustive-deps

/home/dan/src/clutch-worktrees/fix/d7ad05d1/app/projects/[slug]/sessions/[sessionKey]/page.tsx
  153:6  warning  React Hook useEffect has a missing dependency: 'slug'. Either include it or remove the dependency array  react-hooks/exhaustive-deps

/home/dan/src/clutch-worktrees/fix/d7ad05d1/components/agents/agent-status.tsx
  107:10  warning  'formatCost' is defined but never used  @typescript-eslint/no-unused-vars

/home/dan/src/clutch-worktrees/fix/d7ad05d1/components/agents/create-agent-wizard.tsx
   10:62  warning  'Code' is defined but never used                 @typescript-eslint/no-unused-vars
   10:68  warning  'Users' is defined but never used                @typescript-eslint/no-unused-vars
   10:75  warning  'Eye' is defined but never used                  @typescript-eslint/no-unused-vars
  245:9   warning  'canProceed' is assigned a value but never used  @typescript-eslint/no-unused-vars

/home/dan/src/clutch-worktrees/fix/d7ad05d1/components/chat/chat-input.tsx
   62:10  warning  'contextUpdateTrigger' is assigned a value but never used                                                                                                                                                                                                                                @typescript-eslint/no-unused-vars
  309:6   warning  React Hook useEffect has a missing dependency: 'images'. Either include it or remove the dependency array                                                                                                                                                                                react-hooks/exhaustive-deps
  321:17  warning  Using `<img>` could result in slower LCP and higher bandwidth. Consider using `<Image />` from `next/image` or a custom image loader to automatically optimize images. This may incur additional usage or cost from your provider. See: https://nextjs.org/docs/messages/no-img-element  @next/next/no-img-element

/home/dan/src/clutch-worktrees/fix/d7ad05d1/components/chat/markdown-content.tsx
  220:15  warning  Using `<img>` could result in slower LCP and higher bandwidth. Consider using `<Image />` from `next/image` or a custom image loader to automatically optimize images. This may incur additional usage or cost from your provider. See: https://nextjs.org/docs/messages/no-img-element  @next/next/no-img-element
  241:15  warning  Using `<img>` could result in slower LCP and higher bandwidth. Consider using `<Image />` from `next/image` or a custom image loader to automatically optimize images. This may incur additional usage or cost from your provider. See: https://nextjs.org/docs/messages/no-img-element  @next/next/no-img-element

/home/dan/src/clutch-worktrees/fix/d7ad05d1/components/chat/new-issue-dialog.tsx
  362:23  warning  Using `<img>` could result in slower LCP and higher bandwidth. Consider using `<Image />` from `next/image` or a custom image loader to automatically optimize images. This may incur additional usage or cost from your provider. See: https://nextjs.org/docs/messages/no-img-element  @next/next/no-img-element

/home/dan/src/clutch-worktrees/fix/d7ad05d1/components/feature-builder/steps/task-breakdown-step.tsx
  603:6  warning  React Hook useCallback has a missing dependency: 'data.qaValidation'. Either include it or remove the dependency array  react-hooks/exhaustive-deps

/home/dan/src/clutch-worktrees/fix/d7ad05d1/components/session-provider.tsx
  24:22  warning  '_refreshIntervalMs' is defined but never used  @typescript-eslint/no-unused-vars

/home/dan/src/clutch-worktrees/fix/d7ad05d1/components/sessions/session-table.tsx
   13:10  warning  'useRouter' is defined but never used                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      @typescript-eslint/no-unused-vars
   38:3   warning  Unused eslint-disable directive (no problems were reported from 'react-hooks/exhaustive-deps')
   41:6   warning  React Hook useMemo has an unnecessary dependency: 'tickingTime'. Either exclude it or remove the dependency array                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          react-hooks/exhaustive-deps
   53:67  warning  'ExternalLink' is defined but never used                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   @typescript-eslint/no-unused-vars
  609:17  warning  Compilation Skipped: Use of incompatible library

This API returns functions which cannot be memoized without leading to stale UI. To prevent this, by default React Compiler will skip memoizing this component/hook. However, you may see issues if values from this API are passed to other components/hooks that are memoized.

/home/dan/src/clutch-worktrees/fix/d7ad05d1/components/sessions/session-table.tsx:609:17
  607 |   const columns = getColumns(tickingTime);
  608 |
> 609 |   const table = useReactTable({
      |                 ^^^^^^^^^^^^^ TanStack Table's `useReactTable()` API returns functions that cannot be memoized safely
  610 |     data,
  611 |     columns,
  612 |     state: {  react-hooks/incompatible-library

/home/dan/src/clutch-worktrees/fix/d7ad05d1/components/sessions/sessions-list.tsx
  21:15  warning  'Session' is defined but never used    @typescript-eslint/no-unused-vars
  91:3   warning  'projectId' is defined but never used  @typescript-eslint/no-unused-vars

/home/dan/src/clutch-worktrees/fix/d7ad05d1/components/sessions/transcript-message.tsx
  3:10  warning  'formatDistanceToNow' is defined but never used  @typescript-eslint/no-unused-vars

/home/dan/src/clutch-worktrees/fix/d7ad05d1/components/ui/avatar.tsx
  25:7  warning  Using `<img>` could result in slower LCP and higher bandwidth. Consider using `<Image />` from `next/image` or a custom image loader to automatically optimize images. This may incur additional usage or cost from your provider. See: https://nextjs.org/docs/messages/no-img-element  @next/next/no-img-element

/home/dan/src/clutch-worktrees/fix/d7ad05d1/components/ui/tabs.tsx
  3:37  warning  'useState' is defined but never used  @typescript-eslint/no-unused-vars

/home/dan/src/clutch-worktrees/fix/d7ad05d1/convex/_generated/api.js
  1:1  warning  Unused eslint-disable directive (no problems were reported)

/home/dan/src/clutch-worktrees/fix/d7ad05d1/convex/_generated/dataModel.d.ts
  1:1  warning  Unused eslint-disable directive (no problems were reported)

/home/dan/src/clutch-worktrees/fix/d7ad05d1/convex/_generated/server.d.ts
  1:1  warning  Unused eslint-disable directive (no problems were reported)

/home/dan/src/clutch-worktrees/fix/d7ad05d1/convex/_generated/server.js
  1:1  warning  Unused eslint-disable directive (no problems were reported)

/home/dan/src/clutch-worktrees/fix/d7ad05d1/convex/analytics.ts
  100:10  warning  'calculateCost' is defined but never used  @typescript-eslint/no-unused-vars

/home/dan/src/clutch-worktrees/fix/d7ad05d1/convex/promptMetrics.ts
  333:3  warning  '_computedAt' is defined but never used  @typescript-eslint/no-unused-vars

/home/dan/src/clutch-worktrees/fix/d7ad05d1/instrumentation.ts
  6:10  warning  'getConvexClient' is defined but never used  @typescript-eslint/no-unused-vars
  7:10  warning  'api' is defined but never used              @typescript-eslint/no-unused-vars

/home/dan/src/clutch-worktrees/fix/d7ad05d1/lib/hooks/use-openclaw-http.ts
   26:32  warning  '_refreshIntervalMs' is assigned a value but never used  @typescript-eslint/no-unused-vars
   26:60  warning  '_shouldPoll' is assigned a value but never used         @typescript-eslint/no-unused-vars
  180:39  warning  '_agentId' is defined but never used                     @typescript-eslint/no-unused-vars
  184:43  warning  '_agentId' is defined but never used                     @typescript-eslint/no-unused-vars
  188:46  warning  '_agentId' is defined but never used                     @typescript-eslint/no-unused-vars
  188:64  warning  '_content' is defined but never used                     @typescript-eslint/no-unused-vars
  192:50  warning  '_agentId' is defined but never used                     @typescript-eslint/no-unused-vars
  196:49  warning  '_agentId' is defined but never used                     @typescript-eslint/no-unused-vars
  196:67  warning  '_filePath' is defined but never used                    @typescript-eslint/no-unused-vars
  200:52  warning  '_agentId' is defined but never used                     @typescript-eslint/no-unused-vars
  200:70  warning  '_filePath' is defined but never used                    @typescript-eslint/no-unused-vars
  200:89  warning  '_content' is defined but never used                     @typescript-eslint/no-unused-vars
  204:42  warning  '_params' is defined but never used                      @typescript-eslint/no-unused-vars
  208:48  warning  '_agentId' is defined but never used                     @typescript-eslint/no-unused-vars
  208:66  warning  '_config' is defined but never used                      @typescript-eslint/no-unused-vars

/home/dan/src/clutch-worktrees/fix/d7ad05d1/lib/openclaw/api.ts
   99:10  warning  'calculateContextPercentage' is defined but never used  @typescript-eslint/no-unused-vars
  162:12  warning  '_error' is defined but never used                      @typescript-eslint/no-unused-vars

/home/dan/src/clutch-worktrees/fix/d7ad05d1/lib/slash-commands.ts
  170:36  warning  'sessionKey' is defined but never used             @typescript-eslint/no-unused-vars
  296:10  warning  'getModelContextWindow' is defined but never used  @typescript-eslint/no-unused-vars

/home/dan/src/clutch-worktrees/fix/d7ad05d1/lib/stores/project-store.ts
  35:59  warning  'get' is defined but never used  @typescript-eslint/no-unused-vars

/home/dan/src/clutch-worktrees/fix/d7ad05d1/lib/stores/session-store.ts
  108:30  warning  '_isInitialLoad' is assigned a value but never used  @typescript-eslint/no-unused-vars

/home/dan/src/clutch-worktrees/fix/d7ad05d1/worker/gateway-client.ts
   55:7   warning  'RECONNECT_DELAY_MS' is assigned a value but never used  @typescript-eslint/no-unused-vars
  359:16  warning  'req' is assigned a value but never used                 @typescript-eslint/no-unused-vars

/home/dan/src/clutch-worktrees/fix/d7ad05d1/worker/loop.ts
  104:10  warning  'getPRStatus' is defined but never used  @typescript-eslint/no-unused-vars

/home/dan/src/clutch-worktrees/fix/d7ad05d1/worker/phases/review.ts
  181:3  warning  'allActiveTasks' is defined but never used  @typescript-eslint/no-unused-vars

✖ 59 problems (0 errors, 59 warnings)
  0 errors and 5 warnings potentially fixable with the `--fix` option. passes (warnings only, no errors)  
- ✅ 
> clutch@0.1.0 test /home/dan/src/clutch-worktrees/fix/d7ad05d1
> vitest


[1m[46m RUN [49m[22m [36mv4.0.18 [39m[90m/home/dan/src/clutch-worktrees/fix/d7ad05d1[39m

 [32m✓[39m worker/__tests__/decide.test.ts [2m([22m[2m36 tests[22m[2m)[22m[32m 3[2mms[22m[39m
 [32m✓[39m worker/children.test.ts [2m([22m[2m22 tests[22m[2m)[22m[32m 15[2mms[22m[39m
 [32m✓[39m worker/__tests__/prompt-fetcher.test.ts [2m([22m[2m17 tests[22m[2m)[22m[32m 6[2mms[22m[39m
 [32m✓[39m app/api/feature-builder/session/route.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 9[2mms[22m[39m
 [32m✓[39m bin/clutch-cli.test.ts [2m([22m[2m8 tests[22m[2m)[22m[33m 854[2mms[22m[39m
     [33m[2m✓[22m[39m tasks list --json prints valid JSON [32m 300[2mms[22m[39m
     [33m[2m✓[22m[39m tasks get <id> --json prints valid JSON [33m 551[2mms[22m[39m
 [32m✓[39m test/role-selector.test.tsx [2m([22m[2m13 tests[22m[2m | [22m[33m4 skipped[39m[2m)[22m[32m 179[2mms[22m[39m

[2m Test Files [22m [1m[32m6 passed[39m[22m[90m (6)[39m
[2m      Tests [22m [1m[32m97 passed[39m[22m[2m | [22m[33m4 skipped[39m[90m (101)[39m
[2m   Start at [22m 12:35:43
[2m   Duration [22m 1.24s[2m (transform 449ms, setup 194ms, import 1.09s, tests 1.07s, environment 1.32s)[22m passes (97 tests)
- ✅ Pre-commit hooks pass