### PR TITLE
feat: add gateway acknowledgment and delivery status tracking

### DIFF
--- a/app/api/chats/[id]/latest-human-message/route.ts
+++ b/app/api/chats/[id]/latest-human-message/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from "next/server"
+import { getConvexClient } from "@/lib/convex/server"
+import { api } from "@/convex/_generated/api"
+
+type RouteParams = { params: Promise<{ id: string }> }
+
+// GET /api/chats/[id]/latest-human-message — Get the most recent human message in a chat
+export async function GET(request: NextRequest, { params }: RouteParams) {
+  const { id } = await params
+  
+  try {
+    const convex = getConvexClient()
+
+    // Verify chat exists
+    const chat = await convex.query(api.chats.getById, { id })
+    if (!chat) {
+      return NextResponse.json(
+        { error: "Chat not found" },
+        { status: 404 }
+      )
+    }
+
+    // Get the latest human message (non-ada message)
+    const message = await convex.query(api.chats.getLatestHumanMessage, {
+      chat_id: id,
+    })
+
+    return NextResponse.json({ 
+      message: message,
+      chat_id: id 
+    })
+  } catch (error) {
+    console.error("[Latest Human Message API] Error fetching message:", error)
+    return NextResponse.json(
+      { error: "Failed to fetch latest human message" },
+      { status: 500 }
+    )
+  }
+}

--- a/app/api/chats/[id]/messages/[messageId]/status/route.ts
+++ b/app/api/chats/[id]/messages/[messageId]/status/route.ts
@@ -1,0 +1,69 @@
+import { NextRequest, NextResponse } from "next/server"
+import { getConvexClient } from "@/lib/convex/server"
+import { api } from "@/convex/_generated/api"
+
+type RouteParams = { 
+  params: Promise<{ id: string; messageId: string }> 
+}
+
+// PATCH /api/chats/[id]/messages/[messageId]/status — Update message delivery status
+export async function PATCH(request: NextRequest, { params }: RouteParams) {
+  const { id, messageId } = await params
+  const body = await request.json()
+  
+  const { delivery_status } = body
+  
+  if (!delivery_status) {
+    return NextResponse.json(
+      { error: "delivery_status is required" },
+      { status: 400 }
+    )
+  }
+
+  const validStatuses = ["sent", "delivered", "processing", "responded", "failed"]
+  if (!validStatuses.includes(delivery_status)) {
+    return NextResponse.json(
+      { error: `delivery_status must be one of: ${validStatuses.join(", ")}` },
+      { status: 400 }
+    )
+  }
+
+  try {
+    const convex = getConvexClient()
+
+    // Verify chat exists
+    const chat = await convex.query(api.chats.getById, { id })
+    if (!chat) {
+      return NextResponse.json(
+        { error: "Chat not found" },
+        { status: 404 }
+      )
+    }
+
+    // Update the message delivery status
+    const updatedMessage = await convex.mutation(api.chats.updateDeliveryStatus, {
+      message_id: messageId,
+      delivery_status,
+    })
+
+    return NextResponse.json({ 
+      message: updatedMessage,
+      success: true 
+    })
+  } catch (error) {
+    console.error("[Message Status API] Error updating delivery status:", error)
+    
+    // Handle specific error cases
+    if (error instanceof Error && error.message === "Message not found") {
+      return NextResponse.json(
+        { error: "Message not found" },
+        { status: 404 }
+      )
+    }
+    
+    return NextResponse.json(
+      { error: "Failed to update message status" },
+      { status: 500 }
+    )
+  }
+}

--- a/app/api/chats/messages/stuck/route.ts
+++ b/app/api/chats/messages/stuck/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from "next/server"
+import { getConvexClient } from "@/lib/convex/server"
+import { api } from "@/convex/_generated/api"
+
+// GET /api/chats/messages/stuck — Get messages stuck in transitional delivery states
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams
+  const limit = Math.min(parseInt(searchParams.get("limit") || "100"), 500)
+  
+  try {
+    const convex = getConvexClient()
+
+    // Get messages stuck in "sent" or "delivered" states
+    const [sentMessages, deliveredMessages] = await Promise.all([
+      convex.query(api.chats.getMessagesByDeliveryStatus, {
+        delivery_status: "sent",
+        limit: Math.floor(limit / 2),
+      }),
+      convex.query(api.chats.getMessagesByDeliveryStatus, {
+        delivery_status: "delivered", 
+        limit: Math.floor(limit / 2),
+      })
+    ])
+
+    // Combine and sort by creation time (oldest first)
+    const allMessages = [...sentMessages, ...deliveredMessages]
+      .sort((a, b) => a.created_at - b.created_at)
+
+    // Only return human messages (author !== "ada") as these are the ones that should progress
+    const humanMessages = allMessages.filter(msg => msg.author !== "ada")
+
+    return NextResponse.json({ 
+      messages: humanMessages,
+      total: humanMessages.length
+    })
+  } catch (error) {
+    console.error("[Stuck Messages API] Error fetching stuck messages:", error)
+    return NextResponse.json(
+      { error: "Failed to fetch stuck messages" },
+      { status: 500 }
+    )
+  }
+}


### PR DESCRIPTION
Ticket: a7953e3a-3bb2-41b7-97ee-7fb4e1fd88fe

## Summary

Adds delivery status tracking to the clutch-channel plugin, enabling real-time visibility into message processing state.

## Changes

### API
- **New endpoint**: `PATCH /api/chats/[id]/messages/[messageId]/status`
  - Updates `delivery_status` field via Convex `updateDeliveryStatus` mutation
  - Validates status values: `sent`, `delivered`, `processing`, `responded`, `failed`

### Plugin (`plugins/clutch-channel.ts`)
- **`updateStatus()`**: New helper for delivery status transitions via PATCH API
- **`messageIdMap`**: Maps gateway message IDs to Clutch message IDs for correlation
- **`agent_start` hook**:
  - Handles stuck messages from previous gateway restarts
  - Updates status to `processing`
  - Sets typing indicator to "thinking"
- **`agent_end` hook**:
  - On success: updates triggering message to `responded`
  - On failure: updates to `failed` with error details
  - Clears typing indicator
- **`message_received` hook**: Logs message receipt for tracking
- **`sendText`/`sendMedia`**: Support `gatewayMessageId` parameter for correlation

## Status Flow

```
user sends message -> "sent" (set by Convex on create)
  |
  v
OpenClaw receives -> "delivered" (via message_received)
  |
  v
agent starts -> "processing" (via agent_start)
  |
  v
agent responds -> "responded" (via agent_end)
  └─ or on error -> "failed"
```

## Resilience

On plugin init (agent_start), queries for messages stuck in `sent` or `delivered` status and marks them as `failed` with a restart note. This prevents messages from appearing "in flight" forever after a gateway restart.

## Testing

- `pnpm typecheck` pass
- `pnpm lint` pass (59 pre-existing warnings, 0 errors)
