### PR TITLE
chore: remove obsolete test lockfile artifacts from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,7 +46,6 @@ next-env.d.ts
 
 # uploads
 /public/uploads/
-pnpm-lock_test.yaml
 
 # Generated systemd service files (from templates)
 /systemd/*.service


### PR DESCRIPTION
Ticket: a77db3ca-7248-4f55-9d58-eaecb4dde598

## Summary
- The test artifacts ( and ) were already removed in commit 5541858
- Removed the obsolete  entry from 
- Verified normal install/build flow works (Lockfile is up to date, resolution step is skipped
Already up to date

. prepare$ husky
. prepare: Done
╭ Warning ─────────────────────────────────────────────────────────────────────╮
│                                                                              │
│   Ignored build scripts: esbuild@0.27.0, esbuild@0.27.2, sharp@0.34.5,       │
│   unrs-resolver@1.11.1.                                                      │
│   Run "pnpm approve-builds" to pick which dependencies should be allowed     │
│   to run scripts.                                                            │
│                                                                              │
╰──────────────────────────────────────────────────────────────────────────────╯
Done in 455ms using pnpm v10.28.2, 
> clutch@0.1.0 typecheck /home/dan/src/clutch-worktrees/fix/a77db3ca
> tsc --noEmit, 
> clutch@0.1.0 lint /home/dan/src/clutch-worktrees/fix/a77db3ca
> eslint


/home/dan/src/clutch-worktrees/fix/a77db3ca/app/api/prompts/seed/route.ts
  16:28  warning  '_request' is defined but never used  @typescript-eslint/no-unused-vars

/home/dan/src/clutch-worktrees/fix/a77db3ca/app/projects/[slug]/chat/page.tsx
  378:9  warning  The 'currentMessages' conditional could make the dependencies of useEffect Hook (at line 393) change on every render. To fix this, wrap the initialization of 'currentMessages' in its own useMemo() Hook  react-hooks/exhaustive-deps

/home/dan/src/clutch-worktrees/fix/a77db3ca/app/projects/[slug]/sessions/[sessionKey]/page.tsx
  153:6  warning  React Hook useEffect has a missing dependency: 'slug'. Either include it or remove the dependency array  react-hooks/exhaustive-deps

/home/dan/src/clutch-worktrees/fix/a77db3ca/components/agents/agent-status.tsx
  107:10  warning  'formatCost' is defined but never used  @typescript-eslint/no-unused-vars

/home/dan/src/clutch-worktrees/fix/a77db3ca/components/agents/create-agent-wizard.tsx
   10:62  warning  'Code' is defined but never used                 @typescript-eslint/no-unused-vars
   10:68  warning  'Users' is defined but never used                @typescript-eslint/no-unused-vars
   10:75  warning  'Eye' is defined but never used                  @typescript-eslint/no-unused-vars
  245:9   warning  'canProceed' is assigned a value but never used  @typescript-eslint/no-unused-vars

/home/dan/src/clutch-worktrees/fix/a77db3ca/components/chat/chat-input.tsx
   62:10  warning  'contextUpdateTrigger' is assigned a value but never used                                                                                                                                                                                                                                @typescript-eslint/no-unused-vars
  309:6   warning  React Hook useEffect has a missing dependency: 'images'. Either include it or remove the dependency array                                                                                                                                                                                react-hooks/exhaustive-deps
  321:17  warning  Using `<img>` could result in slower LCP and higher bandwidth. Consider using `<Image />` from `next/image` or a custom image loader to automatically optimize images. This may incur additional usage or cost from your provider. See: https://nextjs.org/docs/messages/no-img-element  @next/next/no-img-element

/home/dan/src/clutch-worktrees/fix/a77db3ca/components/chat/markdown-content.tsx
  220:15  warning  Using `<img>` could result in slower LCP and higher bandwidth. Consider using `<Image />` from `next/image` or a custom image loader to automatically optimize images. This may incur additional usage or cost from your provider. See: https://nextjs.org/docs/messages/no-img-element  @next/next/no-img-element
  241:15  warning  Using `<img>` could result in slower LCP and higher bandwidth. Consider using `<Image />` from `next/image` or a custom image loader to automatically optimize images. This may incur additional usage or cost from your provider. See: https://nextjs.org/docs/messages/no-img-element  @next/next/no-img-element

/home/dan/src/clutch-worktrees/fix/a77db3ca/components/chat/new-issue-dialog.tsx
  472:23  warning  Using `<img>` could result in slower LCP and higher bandwidth. Consider using `<Image />` from `next/image` or a custom image loader to automatically optimize images. This may incur additional usage or cost from your provider. See: https://nextjs.org/docs/messages/no-img-element  @next/next/no-img-element

/home/dan/src/clutch-worktrees/fix/a77db3ca/components/feature-builder/steps/task-breakdown-step.tsx
  603:6  warning  React Hook useCallback has a missing dependency: 'data.qaValidation'. Either include it or remove the dependency array  react-hooks/exhaustive-deps

/home/dan/src/clutch-worktrees/fix/a77db3ca/components/session-provider.tsx
  24:22  warning  '_refreshIntervalMs' is defined but never used  @typescript-eslint/no-unused-vars

/home/dan/src/clutch-worktrees/fix/a77db3ca/components/sessions/session-table.tsx
   13:10  warning  'useRouter' is defined but never used                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      @typescript-eslint/no-unused-vars
   38:3   warning  Unused eslint-disable directive (no problems were reported from 'react-hooks/exhaustive-deps')
   41:6   warning  React Hook useMemo has an unnecessary dependency: 'tickingTime'. Either exclude it or remove the dependency array                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          react-hooks/exhaustive-deps
   53:67  warning  'ExternalLink' is defined but never used                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   @typescript-eslint/no-unused-vars
  609:17  warning  Compilation Skipped: Use of incompatible library

This API returns functions which cannot be memoized without leading to stale UI. To prevent this, by default React Compiler will skip memoizing this component/hook. However, you may see issues if values from this API are passed to other components/hooks that are memoized.

/home/dan/src/clutch-worktrees/fix/a77db3ca/components/sessions/session-table.tsx:609:17
  607 |   const columns = getColumns(tickingTime);
  608 |
> 609 |   const table = useReactTable({
      |                 ^^^^^^^^^^^^^ TanStack Table's `useReactTable()` API returns functions that cannot be memoized safely
  610 |     data,
  611 |     columns,
  612 |     state: {  react-hooks/incompatible-library

/home/dan/src/clutch-worktrees/fix/a77db3ca/components/sessions/sessions-list.tsx
  21:15  warning  'Session' is defined but never used    @typescript-eslint/no-unused-vars
  91:3   warning  'projectId' is defined but never used  @typescript-eslint/no-unused-vars

/home/dan/src/clutch-worktrees/fix/a77db3ca/components/sessions/transcript-message.tsx
  3:10  warning  'formatDistanceToNow' is defined but never used  @typescript-eslint/no-unused-vars

/home/dan/src/clutch-worktrees/fix/a77db3ca/components/ui/avatar.tsx
  25:7  warning  Using `<img>` could result in slower LCP and higher bandwidth. Consider using `<Image />` from `next/image` or a custom image loader to automatically optimize images. This may incur additional usage or cost from your provider. See: https://nextjs.org/docs/messages/no-img-element  @next/next/no-img-element

/home/dan/src/clutch-worktrees/fix/a77db3ca/components/ui/tabs.tsx
  3:37  warning  'useState' is defined but never used  @typescript-eslint/no-unused-vars

/home/dan/src/clutch-worktrees/fix/a77db3ca/convex/_generated/api.js
  1:1  warning  Unused eslint-disable directive (no problems were reported)

/home/dan/src/clutch-worktrees/fix/a77db3ca/convex/_generated/dataModel.d.ts
  1:1  warning  Unused eslint-disable directive (no problems were reported)

/home/dan/src/clutch-worktrees/fix/a77db3ca/convex/_generated/server.d.ts
  1:1  warning  Unused eslint-disable directive (no problems were reported)

/home/dan/src/clutch-worktrees/fix/a77db3ca/convex/_generated/server.js
  1:1  warning  Unused eslint-disable directive (no problems were reported)

/home/dan/src/clutch-worktrees/fix/a77db3ca/convex/analytics.ts
  100:10  warning  'calculateCost' is defined but never used  @typescript-eslint/no-unused-vars

/home/dan/src/clutch-worktrees/fix/a77db3ca/convex/promptMetrics.ts
  333:3  warning  '_computedAt' is defined but never used  @typescript-eslint/no-unused-vars

/home/dan/src/clutch-worktrees/fix/a77db3ca/instrumentation.ts
  6:10  warning  'getConvexClient' is defined but never used  @typescript-eslint/no-unused-vars
  7:10  warning  'api' is defined but never used              @typescript-eslint/no-unused-vars

/home/dan/src/clutch-worktrees/fix/a77db3ca/lib/hooks/use-openclaw-http.ts
   26:32  warning  '_refreshIntervalMs' is assigned a value but never used  @typescript-eslint/no-unused-vars
   26:60  warning  '_shouldPoll' is assigned a value but never used         @typescript-eslint/no-unused-vars
  180:39  warning  '_agentId' is defined but never used                     @typescript-eslint/no-unused-vars
  184:43  warning  '_agentId' is defined but never used                     @typescript-eslint/no-unused-vars
  188:46  warning  '_agentId' is defined but never used                     @typescript-eslint/no-unused-vars
  188:64  warning  '_content' is defined but never used                     @typescript-eslint/no-unused-vars
  192:50  warning  '_agentId' is defined but never used                     @typescript-eslint/no-unused-vars
  196:49  warning  '_agentId' is defined but never used                     @typescript-eslint/no-unused-vars
  196:67  warning  '_filePath' is defined but never used                    @typescript-eslint/no-unused-vars
  200:52  warning  '_agentId' is defined but never used                     @typescript-eslint/no-unused-vars
  200:70  warning  '_filePath' is defined but never used                    @typescript-eslint/no-unused-vars
  200:89  warning  '_content' is defined but never used                     @typescript-eslint/no-unused-vars
  204:42  warning  '_params' is defined but never used                      @typescript-eslint/no-unused-vars
  208:48  warning  '_agentId' is defined but never used                     @typescript-eslint/no-unused-vars
  208:66  warning  '_config' is defined but never used                      @typescript-eslint/no-unused-vars

/home/dan/src/clutch-worktrees/fix/a77db3ca/lib/openclaw/api.ts
   99:10  warning  'calculateContextPercentage' is defined but never used  @typescript-eslint/no-unused-vars
  162:12  warning  '_error' is defined but never used                      @typescript-eslint/no-unused-vars

/home/dan/src/clutch-worktrees/fix/a77db3ca/lib/slash-commands.ts
  182:36  warning  'sessionKey' is defined but never used             @typescript-eslint/no-unused-vars
  505:10  warning  'getModelContextWindow' is defined but never used  @typescript-eslint/no-unused-vars

/home/dan/src/clutch-worktrees/fix/a77db3ca/lib/stores/project-store.ts
  35:59  warning  'get' is defined but never used  @typescript-eslint/no-unused-vars

/home/dan/src/clutch-worktrees/fix/a77db3ca/lib/stores/session-store.ts
  108:30  warning  '_isInitialLoad' is assigned a value but never used  @typescript-eslint/no-unused-vars

/home/dan/src/clutch-worktrees/fix/a77db3ca/worker/gateway-client.ts
   55:7   warning  'RECONNECT_DELAY_MS' is assigned a value but never used  @typescript-eslint/no-unused-vars
  359:16  warning  'req' is assigned a value but never used                 @typescript-eslint/no-unused-vars

/home/dan/src/clutch-worktrees/fix/a77db3ca/worker/loop.ts
  105:10  warning  'getPRStatus' is defined but never used  @typescript-eslint/no-unused-vars

/home/dan/src/clutch-worktrees/fix/a77db3ca/worker/phases/review.ts
  173:3  warning  'allActiveTasks' is defined but never used  @typescript-eslint/no-unused-vars

✖ 59 problems (0 errors, 59 warnings)
  0 errors and 5 warnings potentially fixable with the `--fix` option. all pass)