### PR TITLE
chore: add certs/ to .gitignore to prevent tracking local TLS certificates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@
 .DS_Store
 *.pem
 
+# local development certificates
+certs/
+
 # debug
 npm-debug.log*
 yarn-debug.log*


### PR DESCRIPTION
## Summary

The `certs/` directory containing localhost TLS certificates was previously removed in commit 5541858 as the certificates were unused. This change explicitly adds `certs/` to `.gitignore` to prevent accidental commits of private key material in the future.

## Changes

- Add `certs/` directory to `.gitignore`
- No functional changes (dev server runs HTTP on port 3002)

## Verification

- [x] No cert files currently tracked in git
- [x] No references to `localhost.crt`, `localhost.key`, or `certs/` in codebase
- [x] Dev server uses HTTP (port 3002), not HTTPS
- [x] `*.pem` already in `.gitignore` (covers `.crt` and `.key` files)

Ticket: 10ffacf1-e3f7-4a41-a9cc-e1395c5c2fcf