### PR TITLE
fix: remove hardcoded author 'dan' in New Issue decomposition flow

### DIFF
--- a/components/chat/chat-sidebar.tsx
+++ b/components/chat/chat-sidebar.tsx
@@ -6,6 +6,7 @@ import Link from "next/link"
 import { Button } from "@/components/ui/button"
 import { Skeleton } from "@/components/ui/skeleton"
 import { useChatStore, type ChatWithLastMessage } from "@/lib/stores/chat-store"
+import { DEFAULT_USER } from "@/lib/constants"
 import { TaskModal } from "@/components/board/task-modal"
 import { NewIssueDialog } from "@/components/chat/new-issue-dialog"
 import { useConvexTasks } from "@/lib/hooks/use-convex-tasks"
@@ -36,6 +37,7 @@ const AUTHOR_COLORS: Record<string, string> = {
   "sonnet-reviewer": "#22c55e",
   "haiku-triage": "#eab308",
   dan: "#64748b",
+  user: "#64748b",
 }
 
 const STATUS_COLORS: Record<string, string> = {
@@ -270,7 +272,7 @@ export function ChatSidebar({ projectId, projectSlug, isOpen = true, onClose, is
     }
 
     // Send the command as a message - the chat input will process it as a slash command
-    await sendMessage(activeChat.id, issueCommand, "dan")
+    await sendMessage(activeChat.id, issueCommand, DEFAULT_USER.name)
   }, [activeChat, sendMessage])
 
   useEffect(() => {

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,0 +1,19 @@
+/**
+ * Default user configuration
+ * 
+ * TODO: Replace with actual user authentication when multi-user support is added.
+ * For now, this centralizes the default username to avoid hardcoding "dan" 
+ * throughout the codebase.
+ */
+export const DEFAULT_USER = {
+  name: "user",
+  displayName: "User",
+} as const
+
+/**
+ * System authors/identities used for automated messages
+ */
+export const SYSTEM_AUTHORS = {
+  ada: "ada",
+  system: "system",
+} as const


### PR DESCRIPTION
Ticket: d28e65c0-ce64-4c00-8b57-4467a30ea059

## Changes

- Create `lib/constants.ts` with `DEFAULT_USER` config constant
- Update `handleDecompose` in `chat-sidebar.tsx` to use `DEFAULT_USER.name` instead of hardcoded "dan"
- Add 'user' to `AUTHOR_COLORS` map for proper display

## Why

The New Issue dialog's decomposition flow was hardcoding the author as "dan", which would be incorrect for any other user. This change centralizes the default username in a config constant, making it easier to replace with actual user authentication when multi-user support is added.