### PR TITLE
fix: prevent API /complete endpoint from setting tasks to done

### DIFF
--- a/app/api/tasks/[id]/complete/route.ts
+++ b/app/api/tasks/[id]/complete/route.ts
@@ -34,8 +34,9 @@ export async function POST(
 
     const { task } = result
 
-    // Determine new status - 'review' if PR created, 'done' otherwise
-    const newStatus = prUrl ? "in_review" : "done"
+    // Always set to in_review - only the work loop should move to done
+    // (when PR is merged via review phase, cleanup phase, or auto-merge)
+    const newStatus = "in_review"
 
     // Build completion comment content
     let commentContent = `## Task Completed\n\n${summary}`
@@ -61,7 +62,7 @@ export async function POST(
     const updatedTask = await convex.mutation(api.tasks.move, {
       id,
       status: newStatus,
-      reason: `Task completed via API by ${author}${prUrl ? ' with PR' : ''}`
+      reason: `Task completion submitted by ${author} - moved to in_review${prUrl ? ' with PR' : ' (PR to be created)'}`
     })
 
     // Log event to events table


### PR DESCRIPTION
Ticket: 4ddeabee-01ed-47fa-be7a-614f3e35ec2e

## Summary

Changes the `/api/tasks/:id/complete` endpoint to always set task status to `in_review` instead of `done`.

## Problem

Dev agents could bypass the review flow by calling the complete endpoint directly, which would set tasks to `done` when no `prUrl` was provided. This happened with tasks 891ac897 and 6f2afb77.

## Solution

Only the work loop should move tasks to `done`:
- Review phase: when PR is already merged
- Cleanup phase: when detecting merged PRs on non-done tasks  
- Loop outcome handler: after auto-merging approved PRs

The API endpoint now always transitions to `in_review`, ensuring all work goes through proper review.

## Changes

- `app/api/tasks/[id]/complete/route.ts`: Always set status to `in_review`

## Verification

- `pnpm typecheck` ✓
- `pnpm lint` ✓  
- `pnpm test` ✓ (97 tests pass)