### PR TITLE
Fix race condition in delivery status tracking (FIFO queue)

### DIFF
--- a/app/api/chats/[id]/oldest-delivered-message/route.ts
+++ b/app/api/chats/[id]/oldest-delivered-message/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from "next/server"
+import { getConvexClient } from "@/lib/convex/server"
+import { api } from "@/convex/_generated/api"
+
+type RouteParams = { params: Promise<{ id: string }> }
+
+// GET /api/chats/[id]/oldest-delivered-message — Get the oldest message with "delivered" status (FIFO)
+export async function GET(request: NextRequest, { params }: RouteParams) {
+  const { id } = await params
+  
+  try {
+    const convex = getConvexClient()
+
+    // Verify chat exists
+    const chat = await convex.query(api.chats.getById, { id })
+    if (!chat) {
+      return NextResponse.json(
+        { error: "Chat not found" },
+        { status: 404 }
+      )
+    }
+
+    // Get the oldest message with "delivered" status
+    const message = await convex.query(api.chats.getOldestDeliveredMessage, {
+      chat_id: id,
+    })
+
+    return NextResponse.json({ 
+      message: message,
+      chat_id: id 
+    })
+  } catch (error) {
+    console.error("[Oldest Delivered Message API] Error fetching message:", error)
+    return NextResponse.json(
+      { error: "Failed to fetch oldest delivered message" },
+      { status: 500 }
+    )
+  }
+}

--- a/app/api/chats/[id]/oldest-processing-message/route.ts
+++ b/app/api/chats/[id]/oldest-processing-message/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from "next/server"
+import { getConvexClient } from "@/lib/convex/server"
+import { api } from "@/convex/_generated/api"
+
+type RouteParams = { params: Promise<{ id: string }> }
+
+// GET /api/chats/[id]/oldest-processing-message — Get the oldest message with "processing" status (FIFO)
+export async function GET(request: NextRequest, { params }: RouteParams) {
+  const { id } = await params
+  
+  try {
+    const convex = getConvexClient()
+
+    // Verify chat exists
+    const chat = await convex.query(api.chats.getById, { id })
+    if (!chat) {
+      return NextResponse.json(
+        { error: "Chat not found" },
+        { status: 404 }
+      )
+    }
+
+    // Get the oldest message with "processing" status
+    const message = await convex.query(api.chats.getOldestProcessingMessage, {
+      chat_id: id,
+    })
+
+    return NextResponse.json({ 
+      message: message,
+      chat_id: id 
+    })
+  } catch (error) {
+    console.error("[Oldest Processing Message API] Error fetching message:", error)
+    return NextResponse.json(
+      { error: "Failed to fetch oldest processing message" },
+      { status: 500 }
+    )
+  }
+}

--- a/app/api/chats/[id]/oldest-sent-message/route.ts
+++ b/app/api/chats/[id]/oldest-sent-message/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from "next/server"
+import { getConvexClient } from "@/lib/convex/server"
+import { api } from "@/convex/_generated/api"
+
+type RouteParams = { params: Promise<{ id: string }> }
+
+// GET /api/chats/[id]/oldest-sent-message — Get the oldest message with "sent" status (FIFO)
+export async function GET(request: NextRequest, { params }: RouteParams) {
+  const { id } = await params
+  
+  try {
+    const convex = getConvexClient()
+
+    // Verify chat exists
+    const chat = await convex.query(api.chats.getById, { id })
+    if (!chat) {
+      return NextResponse.json(
+        { error: "Chat not found" },
+        { status: 404 }
+      )
+    }
+
+    // Get the oldest message with "sent" status
+    const message = await convex.query(api.chats.getOldestSentMessage, {
+      chat_id: id,
+    })
+
+    return NextResponse.json({ 
+      message: message,
+      chat_id: id 
+    })
+  } catch (error) {
+    console.error("[Oldest Sent Message API] Error fetching message:", error)
+    return NextResponse.json(
+      { error: "Failed to fetch oldest sent message" },
+      { status: 500 }
+    )
+  }
+}

--- a/convex/chats.ts
+++ b/convex/chats.ts
@@ -1063,3 +1063,168 @@ export const getLatestHumanMessage = query({
     }
   },
 })
+
+// Get the oldest human message with "sent" status (FIFO for delivery tracking)
+export const getOldestSentMessage = query({
+  args: {
+    chat_id: v.string(),
+  },
+  returns: v.union(
+    v.object({
+      id: v.string(),
+      chat_id: v.string(),
+      author: v.string(),
+      content: v.string(),
+      run_id: v.optional(v.string()),
+      session_key: v.optional(v.string()),
+      is_automated: v.optional(v.number()),
+      delivery_status: v.optional(v.union(
+        v.literal("sent"),
+        v.literal("delivered"),
+        v.literal("processing"),
+        v.literal("responded"),
+        v.literal("failed"),
+      )),
+      created_at: v.number(),
+    }),
+    v.null()
+  ),
+  handler: async (ctx, args) => {
+    // Find the oldest message where author is not "ada" and delivery_status is "sent"
+    const message = await ctx.db
+      .query('chatMessages')
+      .withIndex('by_chat', (q) => q.eq('chat_id', args.chat_id))
+      .filter((q) => 
+        q.and(
+          q.neq(q.field('author'), 'ada'),
+          q.eq(q.field('delivery_status'), 'sent')
+        )
+      )
+      .order('asc') // oldest first
+      .first()
+
+    if (!message) return null
+
+    return {
+      id: message.id,
+      chat_id: message.chat_id,
+      author: message.author,
+      content: message.content,
+      run_id: message.run_id,
+      session_key: message.session_key,
+      is_automated: message.is_automated ? 1 : 0,
+      delivery_status: message.delivery_status,
+      created_at: message.created_at,
+    }
+  },
+})
+
+// Get the oldest human message with "delivered" status (FIFO for processing)
+export const getOldestDeliveredMessage = query({
+  args: {
+    chat_id: v.string(),
+  },
+  returns: v.union(
+    v.object({
+      id: v.string(),
+      chat_id: v.string(),
+      author: v.string(),
+      content: v.string(),
+      run_id: v.optional(v.string()),
+      session_key: v.optional(v.string()),
+      is_automated: v.optional(v.number()),
+      delivery_status: v.optional(v.union(
+        v.literal("sent"),
+        v.literal("delivered"),
+        v.literal("processing"),
+        v.literal("responded"),
+        v.literal("failed"),
+      )),
+      created_at: v.number(),
+    }),
+    v.null()
+  ),
+  handler: async (ctx, args) => {
+    // Find the oldest message where author is not "ada" and delivery_status is "delivered"
+    const message = await ctx.db
+      .query('chatMessages')
+      .withIndex('by_chat', (q) => q.eq('chat_id', args.chat_id))
+      .filter((q) => 
+        q.and(
+          q.neq(q.field('author'), 'ada'),
+          q.eq(q.field('delivery_status'), 'delivered')
+        )
+      )
+      .order('asc') // oldest first
+      .first()
+
+    if (!message) return null
+
+    return {
+      id: message.id,
+      chat_id: message.chat_id,
+      author: message.author,
+      content: message.content,
+      run_id: message.run_id,
+      session_key: message.session_key,
+      is_automated: message.is_automated ? 1 : 0,
+      delivery_status: message.delivery_status,
+      created_at: message.created_at,
+    }
+  },
+})
+
+// Get the oldest human message in "processing" status (for agent_end)
+export const getOldestProcessingMessage = query({
+  args: {
+    chat_id: v.string(),
+  },
+  returns: v.union(
+    v.object({
+      id: v.string(),
+      chat_id: v.string(),
+      author: v.string(),
+      content: v.string(),
+      run_id: v.optional(v.string()),
+      session_key: v.optional(v.string()),
+      is_automated: v.optional(v.number()),
+      delivery_status: v.optional(v.union(
+        v.literal("sent"),
+        v.literal("delivered"),
+        v.literal("processing"),
+        v.literal("responded"),
+        v.literal("failed"),
+      )),
+      created_at: v.number(),
+    }),
+    v.null()
+  ),
+  handler: async (ctx, args) => {
+    // Find the oldest message where author is not "ada" and delivery_status is "processing"
+    const message = await ctx.db
+      .query('chatMessages')
+      .withIndex('by_chat', (q) => q.eq('chat_id', args.chat_id))
+      .filter((q) => 
+        q.and(
+          q.neq(q.field('author'), 'ada'),
+          q.eq(q.field('delivery_status'), 'processing')
+        )
+      )
+      .order('asc') // oldest first
+      .first()
+
+    if (!message) return null
+
+    return {
+      id: message.id,
+      chat_id: message.chat_id,
+      author: message.author,
+      content: message.content,
+      run_id: message.run_id,
+      session_key: message.session_key,
+      is_automated: message.is_automated ? 1 : 0,
+      delivery_status: message.delivery_status,
+      created_at: message.created_at,
+    }
+  },
+})


### PR DESCRIPTION
Fixes race condition where multiple quick messages would interfere with each other's delivery status tracking.

## Problem
The clutch-channel plugin used getLatestHumanMessage() to determine which message to update delivery status on. This created a race condition when users sent multiple messages quickly:

1. User sends message A (status: sent)
2. User sends message B (status: sent)  
3. message_received fires for message A → queries latest → finds message B → marks B as delivered
4. Message A stays stuck in sent forever

## Solution
Replaced the latest message heuristic with a FIFO (first-in-first-out) queue approach:

- message_received: Mark oldest sent message as delivered
- agent_start: Mark oldest delivered message as processing  
- agent_end: Mark oldest processing message as responded/failed

## Changes
- Added 3 new Convex queries: getOldestSentMessage, getOldestDeliveredMessage, getOldestProcessingMessage
- Added corresponding API routes for each query
- Updated clutch-channel plugin to use FIFO functions instead of latest message
- Removed unused getLatestHumanMessage function from plugin

## Testing
- ✅ TypeScript compilation passes (pnpm typecheck)
- ✅ Lint passes (pnpm lint) with only pre-existing warnings
- ✅ Pre-commit hooks pass

## Acceptance Criteria Met
- ✅ Each message independently tracks its status (sent → delivered → processing → responded)
- ✅ No messages get stuck in sent when newer messages exist  
- ✅ FIFO processing ensures correct order

Ticket: 2155d3f6-b4be-409d-b95c-b4145301cbe1