### PR TITLE
fix: delivery indicators not appearing on queued messages

### DIFF
--- a/app/api/chats/[id]/all-sent-messages/route.ts
+++ b/app/api/chats/[id]/all-sent-messages/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from "next/server"
+import { getConvexClient } from "@/lib/convex/server"
+import { api } from "@/convex/_generated/api"
+
+type RouteParams = { params: Promise<{ id: string }> }
+
+// GET /api/chats/[id]/all-sent-messages — Get ALL messages with "sent" status (for batch delivery marking)
+export async function GET(request: NextRequest, { params }: RouteParams) {
+  const { id } = await params
+
+  try {
+    const convex = getConvexClient()
+
+    // Verify chat exists
+    const chat = await convex.query(api.chats.getById, { id })
+    if (!chat) {
+      return NextResponse.json(
+        { error: "Chat not found" },
+        { status: 404 }
+      )
+    }
+
+    // Get ALL messages with "sent" status
+    const messages = await convex.query(api.chats.getAllSentMessages, {
+      chat_id: id,
+    })
+
+    return NextResponse.json({
+      messages: messages,
+      chat_id: id
+    })
+  } catch (error) {
+    console.error("[All Sent Messages API] Error fetching messages:", error)
+    return NextResponse.json(
+      { error: "Failed to fetch sent messages" },
+      { status: 500 }
+    )
+  }
+}


### PR DESCRIPTION
Ticket: a9fe3df0-0ae2-446e-9677-c231f40ac7ce

## Problem
When sending multiple messages in quick succession, only the first message was getting delivery indicators (sent → delivered → processing → responded). Subsequent messages stayed stuck with no indicator.

## Root Cause
The FIFO delivery status system processed one message at a time through lifecycle hooks. Each hook fired once per gateway event, advancing only one message. Messages behind in the queue never got their 'delivered' tick until the preceding message completed its full lifecycle.

## Fix
In the  hook, after receiving a message, we now fetch ALL messages with 'sent' status and mark them all as 'delivered' (since the gateway has received them all). The  and  hooks remain single-message since the agent processes one at a time.

## Changes
- Added  query to 
- Added  endpoint
- Updated  hook in  to batch-mark all sent messages as delivered

## Acceptance Criteria
- [x] When sending 3 messages quickly, all 3 show sent → delivered indicators
- [x] Only the message being actively processed shows 
- [x] After agent responds, the processed message shows , next queued message advances to 
- [x] pnpm typecheck && pnpm lint pass