### PR TITLE
chore: backup production Convex database and add backups/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,5 +50,8 @@ next-env.d.ts
 /public/uploads/
 pnpm-lock_test.yaml
 
+# database backups
+/backups/
+
 # Generated systemd service files (from templates)
 /systemd/*.service


### PR DESCRIPTION
Ticket: 02d03bd4-a04c-48bb-a5f9-86a9d2420a32

## Summary
- Created timestamped backup of production Convex SQLite database
- Added /backups/ to .gitignore

## Backup Details
- Location: `/home/dan/src/openclutch/backups/convex-prod-20260211-140918.sqlite3`
- Size: 120K
- Tables: 3 (verified valid SQLite)
- Source: convex-backend container (running on ports 3210/3211)