### PR TITLE
fix: preserve line breaks in task descriptions

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -186,6 +186,11 @@
     word-break: break-all;
     white-space: pre-wrap;
   }
+
+  /* Preserve line breaks in markdown paragraphs */
+  .markdown-content p {
+    white-space: pre-line;
+  }
   
   /* Handle long URLs and text that might not break naturally */
   .markdown-content a {


### PR DESCRIPTION
Ticket: 5dc6bef9-916a-43de-aaf1-845213ff9493

## Summary
Add white-space: pre-line to markdown content paragraphs to ensure line breaks in task descriptions are properly displayed.

## Changes
- Added CSS rule to globals.css for markdown content paragraphs

## Context
The remark-breaks plugin converts newlines to br tags, but the CSS needs to properly handle whitespace for line breaks to be visible. This fix ensures that task descriptions preserve line breaks when rendered.