### PR TITLE
fix: observatory active agents showing unknown model and timing

### DIFF
--- a/components/observatory/live/active-agents.tsx
+++ b/components/observatory/live/active-agents.tsx
@@ -28,7 +28,7 @@ export function ActiveAgents({ projectId, projectSlug, projectName }: ActiveAgen
       role: item.task.role ?? "dev",
       // Session data (now from sessions table via Convex)
       sessionKey: item.task.agent_session_key,
-      model: item.session?.model ?? "unknown",
+      model: item.session?.model ?? null,
       provider: item.session?.provider ?? null,
       status: item.session?.status ?? "idle",
       tokensInput: item.session?.tokens_input ?? 0,
@@ -38,7 +38,8 @@ export function ActiveAgents({ projectId, projectSlug, projectName }: ActiveAgen
       lastActiveAt: item.session?.last_active_at ?? null,
       outputPreview: item.session?.output_preview ?? null,
       stopReason: item.session?.stop_reason ?? null,
-      sessionCreatedAt: item.session?.created_at ?? null,
+      // Use agent_spawned_at from task as fallback for timing (session created_at may not be set yet)
+      sessionCreatedAt: item.session?.created_at ?? item.task.agent_spawned_at ?? null,
       sessionUpdatedAt: item.session?.updated_at ?? 0,
       projectName: projectName,
     }))
@@ -107,7 +108,7 @@ interface AgentCardProps {
     taskTitle: string
     role: string
     sessionKey: string | null
-    model: string
+    model: string | null
     provider: string | null
     status: string
     tokensInput: number
@@ -146,7 +147,7 @@ function AgentCard({ agent, projectSlug }: AgentCardProps) {
 
   // Format model name for display
   const displayModel = useMemo(() => {
-    if (agent.model === "unknown") return "unknown"
+    if (!agent.model) return "starting..."
     // Extract short name from full model path (e.g., "anthropic/claude-sonnet-4" -> "claude-sonnet")
     const parts = agent.model.split('/')
     const shortName = parts[parts.length - 1]
@@ -160,7 +161,7 @@ function AgentCard({ agent, projectSlug }: AgentCardProps) {
 
   // Calculate duration from session start time
   const duration = useMemo(() => {
-    if (!agent.sessionCreatedAt) return "Unknown"
+    if (!agent.sessionCreatedAt) return "just started"
     return formatDuration(agent.sessionCreatedAt)
   }, [agent.sessionCreatedAt])
 


### PR DESCRIPTION
Ticket: dcd26717-d765-40a4-bfce-f8ee17bb66d1

## Changes
- Use \+agent_spawned_at\+ from task as fallback when session \+created_at\+ is not yet available
- Show 'starting...' instead of 'unknown' when model is not yet available  
- Show 'just started' instead of 'Unknown' when timing is not yet available
- Update type definition to allow null model

## Problem
When agents are first spawned, the session data hasn't been synced from the JSONL file yet, causing the observatory to display 'unknown' for model and 'Unknown' for timing until the session watcher processes the file.

## Solution
Use the task's \+agent_spawned_at\+ field (which is set immediately when spawning) as a fallback for timing, and show 'starting...' as a more accurate status when the model isn't available yet.