### PR TITLE
feat: preserve active tab when switching projects via header dropdown

### DIFF
--- a/components/layout/desktop-project-switcher.tsx
+++ b/components/layout/desktop-project-switcher.tsx
@@ -2,8 +2,22 @@
 
 import { useState, useRef, useEffect } from "react"
 import Link from "next/link"
+import { usePathname } from "next/navigation"
 import { ChevronDown } from "lucide-react"
 import { cn } from "@/lib/utils"
+
+const VALID_TAB_SEGMENTS = ["chat", "board", "roadmap", "sessions", "work-loop", "settings"] as const
+type ValidTabSegment = (typeof VALID_TAB_SEGMENTS)[number]
+
+function getTabSegment(pathname: string | null): ValidTabSegment {
+  if (!pathname) return "chat"
+  const match = pathname.match(/^\/projects\/[^\/]+\/([^\/]+)/)
+  const segment = match?.[1]
+  if (segment && VALID_TAB_SEGMENTS.includes(segment as ValidTabSegment)) {
+    return segment as ValidTabSegment
+  }
+  return "chat"
+}
 
 interface Project {
   slug: string
@@ -19,6 +33,8 @@ interface DesktopProjectSwitcherProps {
 export function DesktopProjectSwitcher({ currentProject, projects = [] }: DesktopProjectSwitcherProps) {
   const [isOpen, setIsOpen] = useState(false)
   const dropdownRef = useRef<HTMLDivElement>(null)
+  const pathname = usePathname()
+  const currentTab = getTabSegment(pathname)
 
   const toggleOpen = () => setIsOpen(!isOpen)
   const handleClose = () => setIsOpen(false)
@@ -81,7 +97,7 @@ export function DesktopProjectSwitcher({ currentProject, projects = [] }: Deskto
                 {projects.map((project) => (
                   <Link
                     key={project.slug}
-                    href={`/projects/${project.slug}/chat`}
+                    href={`/projects/${project.slug}/${currentTab}`}
                     prefetch={false}
                     onClick={handleClose}
                     className={cn(

--- a/components/layout/mobile-project-switcher.tsx
+++ b/components/layout/mobile-project-switcher.tsx
@@ -2,8 +2,22 @@
 
 import { useState } from "react"
 import Link from "next/link"
+import { usePathname } from "next/navigation"
 import { ChevronDown, X } from "lucide-react"
 import { cn } from "@/lib/utils"
+
+const VALID_TAB_SEGMENTS = ["chat", "board", "roadmap", "sessions", "work-loop", "settings"] as const
+type ValidTabSegment = (typeof VALID_TAB_SEGMENTS)[number]
+
+function getTabSegment(pathname: string | null): ValidTabSegment {
+  if (!pathname) return "chat"
+  const match = pathname.match(/^\/projects\/[^\/]+\/([^\/]+)/)
+  const segment = match?.[1]
+  if (segment && VALID_TAB_SEGMENTS.includes(segment as ValidTabSegment)) {
+    return segment as ValidTabSegment
+  }
+  return "chat"
+}
 
 interface Project {
   slug: string
@@ -18,6 +32,8 @@ interface MobileProjectSwitcherProps {
 
 export function MobileProjectSwitcher({ currentProject, projects = [] }: MobileProjectSwitcherProps) {
   const [isOpen, setIsOpen] = useState(false)
+  const pathname = usePathname()
+  const currentTab = getTabSegment(pathname)
 
   const toggleOpen = () => setIsOpen(!isOpen)
   const handleClose = () => setIsOpen(false)
@@ -83,7 +99,7 @@ export function MobileProjectSwitcher({ currentProject, projects = [] }: MobileP
                   {projects.map((project) => (
                     <Link
                       key={project.slug}
-                      href={`/projects/${project.slug}`}
+                      href={`/projects/${project.slug}/${currentTab}`}
                       prefetch={false}
                       onClick={handleClose}
                       className={cn(


### PR DESCRIPTION
Ticket: 8bf89a36-b3d4-4072-8be0-c4c9eadd7693

## Summary
When switching projects from the header dropdown, the active tab is now preserved instead of always navigating to /chat.

## Changes
- Added usePathname() hook to both DesktopProjectSwitcher and MobileProjectSwitcher
- Added getTabSegment() helper to extract the current tab from the pathname
- Valid tabs: chat, board, roadmap, sessions, work-loop, settings
- Falls back to /chat for unrecognized paths or project root

## Files Modified
- components/layout/desktop-project-switcher.tsx
- components/layout/mobile-project-switcher.tsx

## Testing
- TypeScript compiles (pnpm typecheck)
- Lint passes (pnpm lint)
- UI changes require browser QA