### PR TITLE
refactor: extract shared tab segment logic from project switchers

### DIFF
--- a/components/layout/desktop-project-switcher.tsx
+++ b/components/layout/desktop-project-switcher.tsx
@@ -5,19 +5,7 @@ import Link from "next/link"
 import { usePathname } from "next/navigation"
 import { ChevronDown } from "lucide-react"
 import { cn } from "@/lib/utils"
-
-const VALID_TAB_SEGMENTS = ["chat", "board", "roadmap", "sessions", "work-loop", "settings"] as const
-type ValidTabSegment = (typeof VALID_TAB_SEGMENTS)[number]
-
-function getTabSegment(pathname: string | null): ValidTabSegment {
-  if (!pathname) return "chat"
-  const match = pathname.match(/^\/projects\/[^\/]+\/([^\/]+)/)
-  const segment = match?.[1]
-  if (segment && VALID_TAB_SEGMENTS.includes(segment as ValidTabSegment)) {
-    return segment as ValidTabSegment
-  }
-  return "chat"
-}
+import { getTabSegment } from "@/lib/project-navigation"
 
 interface Project {
   slug: string

--- a/components/layout/mobile-project-switcher.tsx
+++ b/components/layout/mobile-project-switcher.tsx
@@ -5,19 +5,7 @@ import Link from "next/link"
 import { usePathname } from "next/navigation"
 import { ChevronDown, X } from "lucide-react"
 import { cn } from "@/lib/utils"
-
-const VALID_TAB_SEGMENTS = ["chat", "board", "roadmap", "sessions", "work-loop", "settings"] as const
-type ValidTabSegment = (typeof VALID_TAB_SEGMENTS)[number]
-
-function getTabSegment(pathname: string | null): ValidTabSegment {
-  if (!pathname) return "chat"
-  const match = pathname.match(/^\/projects\/[^\/]+\/([^\/]+)/)
-  const segment = match?.[1]
-  if (segment && VALID_TAB_SEGMENTS.includes(segment as ValidTabSegment)) {
-    return segment as ValidTabSegment
-  }
-  return "chat"
-}
+import { getTabSegment } from "@/lib/project-navigation"
 
 interface Project {
   slug: string

--- a/lib/project-navigation.ts
+++ b/lib/project-navigation.ts
@@ -1,0 +1,32 @@
+/**
+ * Project navigation utilities for tab segment handling
+ */
+
+/**
+ * Valid tab segments for project navigation.
+ * These represent the main sections within a project.
+ */
+export const VALID_TAB_SEGMENTS = ["chat", "board", "roadmap", "sessions", "work-loop", "settings"] as const
+
+/**
+ * Type representing a valid tab segment
+ */
+export type ValidTabSegment = (typeof VALID_TAB_SEGMENTS)[number]
+
+/**
+ * Extract the tab segment from a pathname.
+ * Returns the first path segment after `/projects/{slug}/` if it's a valid tab,
+ * otherwise falls back to "chat".
+ *
+ * @param pathname - The current URL pathname (or null if not available)
+ * @returns The valid tab segment, defaults to "chat"
+ */
+export function getTabSegment(pathname: string | null): ValidTabSegment {
+  if (!pathname) return "chat"
+  const match = pathname.match(/^\/projects\/[^\/]+\/([^\/]+)/)
+  const segment = match?.[1]
+  if (segment && VALID_TAB_SEGMENTS.includes(segment as ValidTabSegment)) {
+    return segment as ValidTabSegment
+  }
+  return "chat"
+}


### PR DESCRIPTION
**Ticket:** a1fd75b7-e8fd-4a0d-940e-7aaa9eb5dbaa

**Changes:**
- Create `lib/project-navigation.ts` with shared `VALID_TAB_SEGMENTS` constant and `getTabSegment()` utility
- Update `desktop-project-switcher.tsx` to use shared utilities
- Update `mobile-project-switcher.tsx` to use shared utilities

**Acceptance Criteria:**
- [x] Create shared `getTabSegment(pathname: string | null): ValidTabSegment` utility
- [x] Create shared `VALID_TAB_SEGMENTS` constant export
- [x] Update desktop-project-switcher.tsx to use shared utilities
- [x] Update mobile-project-switcher.tsx to use shared utilities
- [x] Typecheck and lint pass