### PR TITLE
fix: handle undefined cost in cost-breakdown-chart legend

### DIFF
--- a/components/observatory/analytics/cost-breakdown-chart.tsx
+++ b/components/observatory/analytics/cost-breakdown-chart.tsx
@@ -94,7 +94,7 @@ function CustomLegend({
             style={{ backgroundColor: entry.color }}
           />
           <span className="text-muted-foreground">{entry.value}:</span>
-          <span className="font-medium">${entry.payload.cost.toFixed(2)}</span>
+          <span className="font-medium">${(entry.payload.cost ?? 0).toFixed(2)}</span>
           <span className="text-muted-foreground text-xs">({entry.payload.percentage.toFixed(1)}%)</span>
         </div>
       ))}


### PR DESCRIPTION
Fixes TypeError when entry.payload.cost is undefined in the cost breakdown chart legend.

**Changes:**
- Added nullish coalescing operator (entry.payload.cost ?? 0) before calling .toFixed(2)
- Chart legend now displays 0.00 gracefully when cost data is missing

**Testing:**
- [x] Lint passes (72 pre-existing warnings, 0 errors)
- [x] TypeScript compiles without errors
- [x] Fix handles undefined cost values without crashing

Ticket: a289cafb-d833-450d-9b6b-7a60f9d5cdd8