### PR TITLE
feat: render inline images in chat messages from agent responses

### DIFF
--- a/test/image-processor.test.ts
+++ b/test/image-processor.test.ts
@@ -1,0 +1,246 @@
+/**
+ * Tests for image-processor.ts
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest"
+import { promises as fs } from "fs"
+import path from "path"
+import { processMessageContent } from "../worker/image-processor"
+
+// Test data - small 1x1 PNG in base64
+const TEST_PNG_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+const TEST_PNG_DATA_URL = `data:image/png;base64,${TEST_PNG_BASE64}`
+
+const UPLOAD_DIR = path.join(process.cwd(), "public", "uploads", "images")
+
+describe("processMessageContent", () => {
+  // Clean up any test files after each test
+  afterEach(async () => {
+    try {
+      const files = await fs.readdir(UPLOAD_DIR)
+      for (const file of files) {
+        if (file.includes("test") || file.match(/^\d+-[a-f0-9]+\.(png|jpg|gif|webp)$/)) {
+          await fs.unlink(path.join(UPLOAD_DIR, file))
+        }
+      }
+    } catch {
+      // Directory might not exist
+    }
+  })
+
+  describe("string content", () => {
+    it("should return string content as-is", async () => {
+      const content = "Hello, world!"
+      const result = await processMessageContent(content)
+      expect(result).toBe(content)
+    })
+  })
+
+  describe("text blocks", () => {
+    it("should extract text from text blocks", async () => {
+      const content = [
+        { type: "text", text: "Hello" },
+        { type: "text", text: "World" },
+      ]
+      const result = await processMessageContent(content)
+      expect(result).toBe("Hello\n\nWorld")
+    })
+
+    it("should handle empty text blocks", async () => {
+      const content = [
+        { type: "text", text: "Hello" },
+        { type: "text" },
+        { type: "text", text: "World" },
+      ]
+      const result = await processMessageContent(content)
+      expect(result).toBe("Hello\n\nWorld")
+    })
+  })
+
+  describe("image_url blocks", () => {
+    it("should convert data URL images to markdown", async () => {
+      const content = [
+        {
+          type: "image_url",
+          image_url: { url: TEST_PNG_DATA_URL },
+        },
+      ]
+      const result = await processMessageContent(content)
+      expect(result).toMatch(/!\[image\]\(\/uploads\/images\/\d+-[a-f0-9]+\.png\)/)
+    })
+
+    it("should pass through external HTTP URLs", async () => {
+      const content = [
+        {
+          type: "image_url",
+          image_url: { url: "https://example.com/image.png" },
+        },
+      ]
+      const result = await processMessageContent(content)
+      expect(result).toBe("![image](https://example.com/image.png)")
+    })
+
+    it("should pass through local paths", async () => {
+      const content = [
+        {
+          type: "image_url",
+          image_url: { url: "/uploads/images/existing.png" },
+        },
+      ]
+      const result = await processMessageContent(content)
+      expect(result).toBe("![image](/uploads/images/existing.png)")
+    })
+  })
+
+  describe("image blocks with source (Anthropic format)", () => {
+    it("should process base64 image with source", async () => {
+      const content = [
+        {
+          type: "image",
+          source: {
+            type: "base64",
+            media_type: "image/png",
+            data: TEST_PNG_BASE64,
+          },
+        },
+      ]
+      const result = await processMessageContent(content)
+      expect(result).toMatch(/!\[image\]\(\/uploads\/images\/\d+-[a-f0-9]+\.png\)/)
+    })
+
+    it("should detect MIME type from base64 header if not provided", async () => {
+      const content = [
+        {
+          type: "image",
+          source: {
+            type: "base64",
+            data: TEST_PNG_BASE64,
+          },
+        },
+      ]
+      const result = await processMessageContent(content)
+      expect(result).toMatch(/!\[image\]\(\/uploads\/images\/\d+-[a-f0-9]+\.png\)/)
+    })
+  })
+
+  describe("image blocks with url", () => {
+    it("should process image with data URL", async () => {
+      const content = [
+        {
+          type: "image",
+          url: TEST_PNG_DATA_URL,
+        },
+      ]
+      const result = await processMessageContent(content)
+      expect(result).toMatch(/!\[image\]\(\/uploads\/images\/\d+-[a-f0-9]+\.png\)/)
+    })
+
+    it("should pass through HTTP URLs", async () => {
+      const content = [
+        {
+          type: "image",
+          url: "https://example.com/image.jpg",
+        },
+      ]
+      const result = await processMessageContent(content)
+      expect(result).toBe("![image](https://example.com/image.jpg)")
+    })
+  })
+
+  describe("generic blocks with url or data", () => {
+    it("should process block with data property", async () => {
+      const content = [
+        {
+          type: "image",
+          data: TEST_PNG_BASE64,
+          mimeType: "image/png",
+        },
+      ]
+      const result = await processMessageContent(content)
+      expect(result).toMatch(/!\[image\]\(\/uploads\/images\/\d+-[a-f0-9]+\.png\)/)
+    })
+
+    it("should process block with url property", async () => {
+      const content = [
+        {
+          type: "attachment",
+          url: "/uploads/images/file.png",
+        },
+      ]
+      const result = await processMessageContent(content)
+      expect(result).toBe("![image](/uploads/images/file.png)")
+    })
+  })
+
+  describe("mixed content", () => {
+    it("should handle mixed text and image blocks", async () => {
+      const content = [
+        { type: "text", text: "Here is an image:" },
+        {
+          type: "image_url",
+          image_url: { url: TEST_PNG_DATA_URL },
+        },
+        { type: "text", text: "Isn't it nice?" },
+      ]
+      const result = await processMessageContent(content)
+      expect(result).toContain("Here is an image:")
+      expect(result).toContain("Isn't it nice?")
+      expect(result).toMatch(/!\[image\]\(\/uploads\/images\/\d+-[a-f0-9]+\.png\)/)
+    })
+
+    it("should ignore unknown block types", async () => {
+      const content = [
+        { type: "text", text: "Hello" },
+        { type: "tool_use", name: "read", input: {} },
+        { type: "text", text: "World" },
+      ]
+      const result = await processMessageContent(content)
+      expect(result).toBe("Hello\n\nWorld")
+    })
+  })
+
+  describe("edge cases", () => {
+    it("should handle empty content array", async () => {
+      const content: Array<{ type: string }> = []
+      const result = await processMessageContent(content)
+      expect(result).toBe("")
+    })
+
+    it("should handle null/undefined blocks gracefully", async () => {
+      const content = [
+        { type: "text", text: "Hello" },
+        null,
+        undefined,
+        { type: "text", text: "World" },
+      ] as unknown[]
+      const result = await processMessageContent(content as Parameters<typeof processMessageContent>[0])
+      expect(result).toBe("Hello\n\nWorld")
+    })
+
+    it("should skip unsupported image types", async () => {
+      const content = [
+        {
+          type: "image_url",
+          image_url: { url: "data:image/bmp;base64,Qk08" },
+        },
+      ]
+      const result = await processMessageContent(content)
+      // Should return empty since BMP is not supported
+      expect(result).toBe("")
+    })
+
+    it("should handle malformed data URLs gracefully", async () => {
+      const content = [
+        {
+          type: "image_url",
+          image_url: { url: "data:invalid" },
+        },
+      ]
+      // Should not throw
+      const result = await processMessageContent(content)
+      // May or may not produce output depending on how it's handled
+      expect(typeof result).toBe("string")
+    })
+  })
+})

--- a/worker/chat-bridge.ts
+++ b/worker/chat-bridge.ts
@@ -11,6 +11,7 @@
 import { ConvexHttpClient } from "convex/browser"
 import { api } from "../convex/_generated/api"
 import { initializeOpenClawClient } from "../lib/openclaw/client"
+import { processMessageContent } from "./image-processor"
 
 const convexUrl = process.env.CONVEX_URL ?? "http://127.0.0.1:3210"
 
@@ -49,17 +50,8 @@ async function main() {
       switch (event.type) {
         case "chat.message":
           if (event.message) {
-            // Extract text content
-            const content =
-              typeof event.message.content === "string"
-                ? event.message.content
-                : event.message.content
-                    .filter(
-                      (b: { type: string; text?: string }) =>
-                        b.type === "text" && b.text,
-                    )
-                    .map((b: { text?: string }) => b.text!)
-                    .join("\n")
+            // Process message content (extract text and convert images to markdown)
+            const content = await processMessageContent(event.message.content)
 
             // Check for duplicate via run_id
             if (event.runId) {

--- a/worker/image-processor.ts
+++ b/worker/image-processor.ts
@@ -1,0 +1,290 @@
+/**
+ * Image attachment processor for chat messages
+ *
+ * Handles extracting image data from message content blocks,
+ * saving them to disk, and converting them to markdown image tags.
+ */
+
+import { promises as fs } from "fs"
+import path from "path"
+import crypto from "crypto"
+
+const UPLOAD_DIR = path.join(process.cwd(), "public", "uploads", "images")
+
+// Supported image MIME types
+const ALLOWED_IMAGE_TYPES = [
+  "image/png",
+  "image/jpeg",
+  "image/jpg",
+  "image/gif",
+  "image/webp",
+]
+
+// File extensions for MIME types
+const MIME_TO_EXT: Record<string, string> = {
+  "image/png": ".png",
+  "image/jpeg": ".jpg",
+  "image/jpg": ".jpg",
+  "image/gif": ".gif",
+  "image/webp": ".webp",
+}
+
+// Maximum image size (10MB)
+const MAX_IMAGE_SIZE = 10 * 1024 * 1024
+
+/**
+ * Generic image block interface
+ */
+interface ImageBlock {
+  type?: string
+  url?: string
+  data?: string
+  mimeType?: string
+  media_type?: string
+  image_url?: { url: string }
+  source?: {
+    type: string
+    media_type?: string
+    data?: string
+  }
+}
+
+/**
+ * Content block from OpenClaw message
+ */
+interface ContentBlock {
+  type: string
+  text?: string
+  url?: string
+  data?: string
+  mimeType?: string
+  media_type?: string
+  image_url?: { url: string }
+  source?: {
+    type: string
+    media_type?: string
+    data?: string
+  }
+  [key: string]: unknown
+}
+
+/**
+ * Ensure the upload directory exists
+ */
+async function ensureUploadDir(): Promise<void> {
+  try {
+    await fs.access(UPLOAD_DIR)
+  } catch {
+    await fs.mkdir(UPLOAD_DIR, { recursive: true })
+  }
+}
+
+/**
+ * Generate a unique filename for an image
+ */
+function generateImageFilename(mimeType: string): string {
+  const timestamp = Date.now()
+  const random = crypto.randomBytes(4).toString("hex")
+  const ext = MIME_TO_EXT[mimeType] || ".png"
+  return `${timestamp}-${random}${ext}`
+}
+
+/**
+ * Detect MIME type from base64 data or data URL
+ */
+function detectMimeType(data: string): string | null {
+  // Check if it's a data URL
+  const dataUrlMatch = data.match(/^data:([a-zA-Z0-9/+]+);base64,/)
+  if (dataUrlMatch) {
+    return dataUrlMatch[1]
+  }
+
+  // Try to detect from base64 header bytes
+  // PNG: iVBORw0KGgo
+  // JPEG: /9j/4
+  // GIF: R0lGOD
+  // WebP: UklGR
+  const header = data.slice(0, 20)
+  if (header.startsWith("iVBORw0KGgo")) return "image/png"
+  if (header.startsWith("/9j/4")) return "image/jpeg"
+  if (header.startsWith("R0lGOD")) return "image/gif"
+  if (header.startsWith("UklGR")) return "image/webp"
+
+  return null
+}
+
+/**
+ * Extract base64 data from a data URL or return as-is if already base64
+ */
+function extractBase64Data(data: string): string {
+  const dataUrlMatch = data.match(/^data:[a-zA-Z0-9/+]+;base64,(.+)$/)
+  if (dataUrlMatch) {
+    return dataUrlMatch[1]
+  }
+  return data
+}
+
+/**
+ * Save a base64-encoded image to disk
+ */
+async function saveBase64Image(
+  base64Data: string,
+  mimeType: string,
+): Promise<string | null> {
+  // Validate MIME type
+  if (!ALLOWED_IMAGE_TYPES.includes(mimeType)) {
+    console.warn(`[ImageProcessor] Unsupported image type: ${mimeType}`)
+    return null
+  }
+
+  try {
+    const cleanBase64 = extractBase64Data(base64Data)
+    const buffer = Buffer.from(cleanBase64, "base64")
+
+    // Check size
+    if (buffer.length > MAX_IMAGE_SIZE) {
+      console.warn(`[ImageProcessor] Image too large: ${buffer.length} bytes`)
+      return null
+    }
+
+    // Ensure upload directory exists
+    await ensureUploadDir()
+
+    // Generate filename and save
+    const filename = generateImageFilename(mimeType)
+    const filePath = path.join(UPLOAD_DIR, filename)
+    await fs.writeFile(filePath, buffer)
+
+    // Return public URL
+    return `/uploads/images/${filename}`
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    console.error(`[ImageProcessor] Failed to save image: ${message}`)
+    return null
+  }
+}
+
+/**
+ * Process an image block and return a markdown image tag if successful
+ */
+async function processImageBlock(block: ImageBlock): Promise<string | null> {
+  try {
+    let imageUrl: string | null = null
+
+    // Handle image_url type (OpenAI format)
+    if (block.type === "image_url" && block.image_url?.url) {
+      const url = block.image_url.url
+      // If it's a data URL, save it
+      if (url.startsWith("data:")) {
+        const mimeType = detectMimeType(url) || "image/png"
+        const base64Data = extractBase64Data(url)
+        imageUrl = await saveBase64Image(base64Data, mimeType)
+      } else if (url.startsWith("http")) {
+        // External URL - use as-is
+        imageUrl = url
+      } else if (url.startsWith("/")) {
+        // Already a local path
+        imageUrl = url
+      }
+    }
+    // Handle image type with source (Anthropic format)
+    else if (block.type === "image" && block.source) {
+      if (block.source.type === "base64" && block.source.data) {
+        const mimeType =
+          block.source.media_type ||
+          detectMimeType(block.source.data) ||
+          "image/png"
+        imageUrl = await saveBase64Image(block.source.data, mimeType)
+      }
+    }
+    // Handle image type with url
+    else if (block.type === "image" && block.url) {
+      if (block.url.startsWith("data:")) {
+        const mimeType = detectMimeType(block.url) || "image/png"
+        const base64Data = extractBase64Data(block.url)
+        imageUrl = await saveBase64Image(base64Data, mimeType)
+      } else {
+        imageUrl = block.url
+      }
+    }
+    // Handle generic block with url or data
+    else if (block.url || block.data) {
+      if (block.data) {
+        const mimeType =
+          block.mimeType || block.media_type || detectMimeType(block.data) || "image/png"
+        imageUrl = await saveBase64Image(block.data, mimeType)
+      } else if (block.url) {
+        if (block.url.startsWith("data:")) {
+          const mimeType = detectMimeType(block.url) || "image/png"
+          const base64Data = extractBase64Data(block.url)
+          imageUrl = await saveBase64Image(base64Data, mimeType)
+        } else if (block.url.startsWith("http") || block.url.startsWith("/")) {
+          imageUrl = block.url
+        }
+      }
+    }
+
+    if (imageUrl) {
+      return `![image](${imageUrl})`
+    }
+
+    return null
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    console.error(`[ImageProcessor] Error processing image block: ${message}`)
+    return null
+  }
+}
+
+/**
+ * Check if a content block is an image
+ */
+function isImageBlock(block: ContentBlock): boolean {
+  if (!block || typeof block !== "object") return false
+
+  const blockType = block.type
+  return (
+    blockType === "image" ||
+    blockType === "image_url" ||
+    !!block.url ||
+    !!block.data
+  )
+}
+
+/**
+ * Process message content and extract images
+ * Returns the processed content with image markdown tags
+ */
+export async function processMessageContent(
+  content: string | ContentBlock[],
+): Promise<string> {
+  // If content is a simple string, return as-is
+  if (typeof content === "string") {
+    return content
+  }
+
+  // Process array of content blocks
+  const parts: string[] = []
+
+  for (const block of content) {
+    if (!block || typeof block !== "object") {
+      continue
+    }
+
+    const blockType = block.type
+
+    if (blockType === "text" && block.text) {
+      // Text block - add to content
+      parts.push(String(block.text))
+    } else if (isImageBlock(block)) {
+      // Image block - process and convert to markdown
+      const imageMarkdown = await processImageBlock(block)
+      if (imageMarkdown) {
+        parts.push(imageMarkdown)
+      }
+    }
+    // Ignore other block types (tool_use, tool_result, etc.)
+  }
+
+  return parts.join("\n\n")
+}


### PR DESCRIPTION
## Summary

Implements inline image rendering for agent chat messages. When Ada (or any agent) includes an image in a chat response, it now renders correctly in the Clutch chat UI.

## Changes

### Bridge/ingestion side (worker/chat-bridge.ts)
- Integrated processMessageContent() from new image-processor.ts module
- Now processes message content arrays to extract both text and image blocks

### New image processor (worker/image-processor.ts)
- Detects image attachments in various formats:
  - image_url blocks (OpenAI format)
  - image blocks with source (Anthropic format)
  - Generic blocks with url or data properties
- Saves base64-encoded images to public/uploads/images/
- Converts image blocks to markdown ![image](url) tags
- Supports PNG, JPEG, GIF, WebP formats
- Handles external URLs and local paths without modification

### Test coverage (test/image-processor.test.ts)
- 18 comprehensive tests covering:
  - String content passthrough
  - Text block extraction
  - Various image formats (image_url, image with source, generic blocks)
  - Data URL processing
  - External URL handling
  - Mixed content (text + images)
  - Edge cases (empty content, null blocks, unsupported types)

## How it works

1. When OpenClaw sends a message with image attachments, the chat bridge receives the message content as an array of blocks
2. processMessageContent() iterates through blocks:
   - Text blocks -> extracted as-is
   - Image blocks -> processed and converted to markdown image tags
   - Base64 image data -> saved to disk with unique filename, referenced via local URL
   - External URLs -> used as-is
3. The resulting markdown (with ![image](url) tags) is saved to Convex
4. The existing MarkdownContent component renders the images with lightbox support

## Acceptance Criteria

- [x] When an agent reads/generates an image, it appears inline in the Clutch chat
- [x] Images are clickable to expand (existing lightbox in MarkdownContent)
- [x] Works for common formats: PNG, JPG, GIF, WebP
- [x] No broken images or missing attachments
- [x] Typecheck and lint pass

Ticket: 552cbdfb-e42d-4ad2-99ef-56fca416b9cf

## QA Notes

This change affects how the chat bridge processes incoming messages from OpenClaw. To verify:
1. Start a chat with Ada
2. Ask Ada to read an image file (e.g., "read /path/to/screenshot.png")
3. The image should appear inline in the chat
4. Click the image to verify the lightbox opens

Note: The chat bridge process must be restarted to pick up these changes.