### PR TITLE
fix: convert relative image URLs to absolute for agent viewing

### DIFF
--- a/app/projects/[slug]/chat/page.tsx
+++ b/app/projects/[slug]/chat/page.tsx
@@ -22,6 +22,39 @@ type PageProps = {
   params: Promise<{ slug: string }>
 }
 
+/**
+ * Convert relative image URLs to absolute URLs for agent consumption.
+ * Agents running in OpenClaw can't access relative URLs like /uploads/images/xxx.jpg
+ * because they run in a different context. This ensures images are viewable.
+ */
+function makeImageUrlsAbsolute(content: string): string {
+  // Match markdown image syntax: ![alt](url)
+  const imageRegex = /!\[([^\]]*)\]\(([^)]+)\)/g
+
+  return content.replace(imageRegex, (match, alt, url) => {
+    // If already absolute, leave as-is
+    if (url.startsWith('http://') || url.startsWith('https://') || url.startsWith('data:')) {
+      return match
+    }
+
+    // Convert relative URL to absolute
+    let baseUrl: string
+    if (typeof window !== 'undefined') {
+      // Client-side: use current location
+      baseUrl = `${window.location.protocol}//${window.location.host}`
+    } else {
+      // Server-side: use environment variable or fallback
+      baseUrl = process.env.NEXT_PUBLIC_CLUTCH_URL || 'http://localhost:3002'
+    }
+
+    // Ensure the relative URL starts with /
+    const normalizedUrl = url.startsWith('/') ? url : `/${url}`
+    const absoluteUrl = `${baseUrl}${normalizedUrl}`
+
+    return `![${alt}](${absoluteUrl})`
+  })
+}
+
 interface ProjectInfo {
   id: string
   slug: string
@@ -282,9 +315,11 @@ export default function ChatPage({ params }: PageProps) {
     })
 
     // Build message for OpenClaw (include project context on first message)
-    let openClawMessage = messageContent
+    // Convert relative image URLs to absolute so agents can view them
+    const openClawMessageContent = makeImageUrlsAbsolute(messageContent)
+    let openClawMessage = openClawMessageContent
     if (isFirstMessage && projectContext) {
-      openClawMessage = `[Project Context]\n\n${projectContext}\n\n---\n\n[User Message]\n\n${messageContent}`
+      openClawMessage = `[Project Context]\n\n${projectContext}\n\n---\n\n[User Message]\n\n${openClawMessageContent}`
     }
 
     // Send to OpenClaw via HTTP POST


### PR DESCRIPTION
**Problem:**
When users upload images via Clutch chat, the images were included as markdown with relative URLs like `/uploads/images/xxx.jpg`. Agents running in OpenClaw couldn't view these images because they run in a different context and can't resolve relative URLs.

**Solution:**
Added a `makeImageUrlsAbsolute()` helper function that converts relative image URLs to absolute URLs before sending messages to OpenClaw.

**Changes:**
- Added `makeImageUrlsAbsolute()` function that detects markdown image syntax `![alt](url)`
- Converts relative URLs to absolute using `window.location` (client-side) or `NEXT_PUBLIC_CLUTCH_URL` env var (server-side)
- Leaves already-absolute URLs (http/https/data:) unchanged
- Applied conversion when building the OpenClaw message in `handleSendMessage`

**Testing:**
- TypeScript compiles without errors
- Lint passes (warnings are pre-existing)
- Image processor tests pass

Ticket: 99d6f60b-24c6-42fa-8302-b9729c263800